### PR TITLE
fix(bridge): preserve Windows NSIS paths

### DIFF
--- a/app/bridgeInstallerBuild.test.ts
+++ b/app/bridgeInstallerBuild.test.ts
@@ -5,6 +5,7 @@ import {
   createNsiPath,
   createVisBridgeInstallerAssetName,
   createVisBridgeInstallerPaths,
+  createWindowsInstallerScript,
 } from '../scripts/package-vis-bridge-installer.mjs';
 
 describe('vis_bridge installer packaging', () => {
@@ -52,5 +53,18 @@ describe('vis_bridge installer packaging', () => {
   it('preserves native Windows separators in NSIS compile-time paths', () => {
     const binaryPath = String.raw`D:\a\vis\dist-bridge\vis_bridge.exe`;
     expect(createNsiPath(binaryPath)).toBe(binaryPath);
+  });
+
+  it('initializes the NSIS plug-in directory before embedding the PATH helper', () => {
+    const paths = createVisBridgeInstallerPaths('/workspace', {
+      version: 'v1.2.3',
+      platform: 'win32',
+      arch: 'x64',
+    });
+    const script = createWindowsInstallerScript(paths);
+    expect(script.indexOf('  InitPluginsDir')).toBeGreaterThanOrEqual(0);
+    expect(script.indexOf('  InitPluginsDir')).toBeLessThan(
+      script.indexOf('  SetOutPath "$PLUGINSDIR"'),
+    );
   });
 });

--- a/app/bridgeInstallerBuild.test.ts
+++ b/app/bridgeInstallerBuild.test.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  createNsiPath,
   createVisBridgeInstallerAssetName,
   createVisBridgeInstallerPaths,
 } from '../scripts/package-vis-bridge-installer.mjs';
@@ -46,5 +47,10 @@ describe('vis_bridge installer packaging', () => {
         arch: 'ia32',
       });
     }).toThrow('Unsupported vis_bridge installer architecture: ia32');
+  });
+
+  it('preserves native Windows separators in NSIS compile-time paths', () => {
+    const binaryPath = String.raw`D:\a\vis\dist-bridge\vis_bridge.exe`;
+    expect(createNsiPath(binaryPath)).toBe(binaryPath);
   });
 });

--- a/scripts/package-vis-bridge-installer.d.mts
+++ b/scripts/package-vis-bridge-installer.d.mts
@@ -14,6 +14,7 @@ export type VisBridgeInstallerPaths = {
 export class VisBridgeInstallerTargetError extends Error {}
 
 export function createNsiPath(filePath: string): string;
+export function createWindowsInstallerScript(paths: VisBridgeInstallerPaths): string;
 export function createVisBridgeInstallerAssetName(target: VisBridgeInstallerTarget): string;
 export function createVisBridgeInstallerPaths(
   rootDirectory: string,

--- a/scripts/package-vis-bridge-installer.d.mts
+++ b/scripts/package-vis-bridge-installer.d.mts
@@ -13,6 +13,7 @@ export type VisBridgeInstallerPaths = {
 
 export class VisBridgeInstallerTargetError extends Error {}
 
+export function createNsiPath(filePath: string): string;
 export function createVisBridgeInstallerAssetName(target: VisBridgeInstallerTarget): string;
 export function createVisBridgeInstallerPaths(
   rootDirectory: string,

--- a/scripts/package-vis-bridge-installer.mjs
+++ b/scripts/package-vis-bridge-installer.mjs
@@ -143,6 +143,48 @@ export function createNsiPath(filePath) {
   return filePath.replaceAll('$', '$$').replaceAll('"', '$\\"');
 }
 
+export function createWindowsInstallerScript(paths) {
+  const addPathScript = path.join(paths.workspacePath, 'add-path.ps1');
+  const removePathScript = path.join(paths.workspacePath, 'remove-path.ps1');
+  return [
+    '!include "MUI2.nsh"',
+    '!include "WinMessages.nsh"',
+    'Unicode True',
+    'Name "Vis Bridge"',
+    `OutFile "${createNsiPath(paths.installerPath)}"`,
+    'InstallDir "$LOCALAPPDATA\\Programs\\vis_bridge"',
+    'RequestExecutionLevel user',
+    '!insertmacro MUI_PAGE_DIRECTORY',
+    '!insertmacro MUI_PAGE_INSTFILES',
+    '!insertmacro MUI_UNPAGE_CONFIRM',
+    '!insertmacro MUI_UNPAGE_INSTFILES',
+    '!insertmacro MUI_LANGUAGE "English"',
+    'Section "Install"',
+    '  SetOutPath "$INSTDIR"',
+    `  File /oname=vis_bridge.exe "${createNsiPath(paths.binaryPath)}"`,
+    `  File /oname=remove-path.ps1 "${createNsiPath(removePathScript)}"`,
+    '  WriteUninstaller "$INSTDIR\\Uninstall.exe"',
+    '  InitPluginsDir',
+    '  SetOutPath "$PLUGINSDIR"',
+    `  File /oname=add-path.ps1 "${createNsiPath(addPathScript)}"`,
+    '  nsExec::ExecToLog \'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\\add-path.ps1" "$INSTDIR"\'',
+    '  Pop $0',
+    '  StrCmp $0 "0" +2',
+    '  Abort',
+    '  System::Call \'USER32::SendMessageTimeout(p 0xffff, i ${WM_SETTINGCHANGE}, p 0, t "Environment", i 0x2, i 5000, *p .r0)\'',
+    'SectionEnd',
+    'Section "Uninstall"',
+    '  nsExec::ExecToLog \'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$INSTDIR\\remove-path.ps1" "$INSTDIR"\'',
+    '  Delete "$INSTDIR\\vis_bridge.exe"',
+    '  Delete "$INSTDIR\\remove-path.ps1"',
+    '  Delete "$INSTDIR\\Uninstall.exe"',
+    '  RMDir "$INSTDIR"',
+    '  System::Call \'USER32::SendMessageTimeout(p 0xffff, i ${WM_SETTINGCHANGE}, p 0, t "Environment", i 0x2, i 5000, *p .r0)\'',
+    'SectionEnd',
+    '',
+  ].join('\r\n');
+}
+
 async function packageWindowsInstaller(paths) {
   const addPathScript = path.join(paths.workspacePath, 'add-path.ps1');
   const removePathScript = path.join(paths.workspacePath, 'remove-path.ps1');
@@ -150,46 +192,7 @@ async function packageWindowsInstaller(paths) {
   await mkdir(paths.workspacePath, { recursive: true });
   await writeFile(addPathScript, windowsPathScript('add'), 'utf8');
   await writeFile(removePathScript, windowsPathScript('remove'), 'utf8');
-  await writeFile(
-    nsiScript,
-    [
-      '!include "MUI2.nsh"',
-      '!include "WinMessages.nsh"',
-      'Unicode True',
-      'Name "Vis Bridge"',
-      `OutFile "${createNsiPath(paths.installerPath)}"`,
-      'InstallDir "$LOCALAPPDATA\\Programs\\vis_bridge"',
-      'RequestExecutionLevel user',
-      '!insertmacro MUI_PAGE_DIRECTORY',
-      '!insertmacro MUI_PAGE_INSTFILES',
-      '!insertmacro MUI_UNPAGE_CONFIRM',
-      '!insertmacro MUI_UNPAGE_INSTFILES',
-      '!insertmacro MUI_LANGUAGE "English"',
-      'Section "Install"',
-      '  SetOutPath "$INSTDIR"',
-      `  File /oname=vis_bridge.exe "${createNsiPath(paths.binaryPath)}"`,
-      `  File /oname=remove-path.ps1 "${createNsiPath(removePathScript)}"`,
-      '  WriteUninstaller "$INSTDIR\\Uninstall.exe"',
-      '  SetOutPath "$PLUGINSDIR"',
-      `  File /oname=add-path.ps1 "${createNsiPath(addPathScript)}"`,
-      '  nsExec::ExecToLog \'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\\add-path.ps1" "$INSTDIR"\'',
-      '  Pop $0',
-      '  StrCmp $0 "0" +2',
-      '  Abort',
-      '  System::Call \'USER32::SendMessageTimeout(p 0xffff, i ${WM_SETTINGCHANGE}, p 0, t "Environment", i 0x2, i 5000, *p .r0)\'',
-      'SectionEnd',
-      'Section "Uninstall"',
-      '  nsExec::ExecToLog \'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$INSTDIR\\remove-path.ps1" "$INSTDIR"\'',
-      '  Delete "$INSTDIR\\vis_bridge.exe"',
-      '  Delete "$INSTDIR\\remove-path.ps1"',
-      '  Delete "$INSTDIR\\Uninstall.exe"',
-      '  RMDir "$INSTDIR"',
-      '  System::Call \'USER32::SendMessageTimeout(p 0xffff, i ${WM_SETTINGCHANGE}, p 0, t "Environment", i 0x2, i 5000, *p .r0)\'',
-      'SectionEnd',
-      '',
-    ].join('\r\n'),
-    'utf8',
-  );
+  await writeFile(nsiScript, createWindowsInstallerScript(paths), 'utf8');
   await execFileAsync('makensis', [nsiScript]);
 }
 

--- a/scripts/package-vis-bridge-installer.mjs
+++ b/scripts/package-vis-bridge-installer.mjs
@@ -139,8 +139,8 @@ function windowsPathScript(operation) {
   ].join('\r\n');
 }
 
-function nsiPath(filePath) {
-  return filePath.replaceAll('\\', '/').replaceAll('$', '$$').replaceAll('"', '$\\"');
+export function createNsiPath(filePath) {
+  return filePath.replaceAll('$', '$$').replaceAll('"', '$\\"');
 }
 
 async function packageWindowsInstaller(paths) {
@@ -157,7 +157,7 @@ async function packageWindowsInstaller(paths) {
       '!include "WinMessages.nsh"',
       'Unicode True',
       'Name "Vis Bridge"',
-      `OutFile "${nsiPath(paths.installerPath)}"`,
+      `OutFile "${createNsiPath(paths.installerPath)}"`,
       'InstallDir "$LOCALAPPDATA\\Programs\\vis_bridge"',
       'RequestExecutionLevel user',
       '!insertmacro MUI_PAGE_DIRECTORY',
@@ -167,11 +167,11 @@ async function packageWindowsInstaller(paths) {
       '!insertmacro MUI_LANGUAGE "English"',
       'Section "Install"',
       '  SetOutPath "$INSTDIR"',
-      `  File /oname=vis_bridge.exe "${nsiPath(paths.binaryPath)}"`,
-      `  File /oname=remove-path.ps1 "${nsiPath(removePathScript)}"`,
+      `  File /oname=vis_bridge.exe "${createNsiPath(paths.binaryPath)}"`,
+      `  File /oname=remove-path.ps1 "${createNsiPath(removePathScript)}"`,
       '  WriteUninstaller "$INSTDIR\\Uninstall.exe"',
       '  SetOutPath "$PLUGINSDIR"',
-      `  File /oname=add-path.ps1 "${nsiPath(addPathScript)}"`,
+      `  File /oname=add-path.ps1 "${createNsiPath(addPathScript)}"`,
       '  nsExec::ExecToLog \'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\\add-path.ps1" "$INSTDIR"\'',
       '  Pop $0',
       '  StrCmp $0 "0" +2',


### PR DESCRIPTION
## Summary
- preserve native Windows separators in NSIS compile-time paths
- add regression coverage for the exact drive-qualified path emitted on GitHub Windows runners

## Root cause
`nsiPath()` converted `D:\...` and `C:\...` to forward-slash drive paths. NSIS started successfully but its compile-time `File` command reported the existing SEA payload as `no files found` on both x64 and arm64 runners.

## Verification
- RED: regression test failed because the path conversion was not exposed/fixed
- GREEN: targeted Vitest, full Vitest (864 passed), lint/type-check, formatter
- Linux-hosted NSIS compile succeeds; required full CI matrix will exercise both real Windows runners' install/reinstall/PATH/uninstall flow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installer packaging to preserve native path separators and correctly escape paths in generated installer scripts.
  * Updated installer output and packaged file paths for more reliable installation builds.

* **Tests**
  * Added coverage verifying Windows path handling during installer packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->