### PR TITLE
fix(bridge): allow release renderers to connect

### DIFF
--- a/app/vis_bridge.releaseOrigins.test.ts
+++ b/app/vis_bridge.releaseOrigins.test.ts
@@ -1,0 +1,106 @@
+import { once } from 'node:events';
+import { request as httpRequest } from 'node:http';
+import { createConnection } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createVisBridgeServer } from '../vis_bridge';
+
+type TestServer = ReturnType<typeof createVisBridgeServer>;
+
+const RELEASE_ORIGINS = ['app://index.html', 'https://qiyuanhuakai.github.io'] as const;
+const UNTRUSTED_ORIGINS = ['null', 'app://other.html', 'https://example.com'] as const;
+const servers: TestServer[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) reject(error);
+            else resolve();
+          });
+        }),
+    ),
+  );
+});
+
+async function listen(server: TestServer): Promise<number> {
+  servers.push(server);
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Expected TCP server address.');
+  return address.port;
+}
+
+async function readHttpStatus(port: number, origin: string): Promise<number | undefined> {
+  return new Promise((resolve, reject) => {
+    const request = httpRequest(
+      {
+        host: '127.0.0.1',
+        port,
+        path: '/homedir',
+        method: 'GET',
+        headers: { Origin: origin },
+      },
+      (response) => {
+        response.resume();
+        response.on('end', () => resolve(response.statusCode));
+      },
+    );
+    request.on('error', reject);
+    request.end();
+  });
+}
+
+async function sendUpgrade(port: number, origin: string): Promise<string> {
+  const socket = createConnection({ host: '127.0.0.1', port });
+  await once(socket, 'connect');
+  socket.write(
+    [
+      'GET /codex HTTP/1.1',
+      `Host: 127.0.0.1:${port}`,
+      'Upgrade: websocket',
+      'Connection: Upgrade',
+      'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==',
+      'Sec-WebSocket-Version: 13',
+      `Origin: ${origin}`,
+      '',
+      '',
+    ].join('\r\n'),
+  );
+  const [chunk] = (await once(socket, 'data')) as [Buffer];
+  socket.destroy();
+  return chunk.toString('utf8');
+}
+
+describe('vis_bridge release renderer origins', () => {
+  it.each(RELEASE_ORIGINS)('allows HTTP requests from %s', async (origin) => {
+    const server = createVisBridgeServer({ path: '/codex', target: 'ws://127.0.0.1:1' });
+    const port = await listen(server);
+
+    await expect(readHttpStatus(port, origin)).resolves.toBe(200);
+  });
+
+  it.each(RELEASE_ORIGINS)('allows WebSocket upgrades from %s', async (origin) => {
+    const server = createVisBridgeServer({ path: '/codex', target: 'ws://127.0.0.1:1' });
+    const port = await listen(server);
+
+    await expect(sendUpgrade(port, origin)).resolves.toContain('HTTP/1.1 502 Bad Gateway');
+  });
+
+  it.each(UNTRUSTED_ORIGINS)('rejects HTTP requests from %s', async (origin) => {
+    const server = createVisBridgeServer({ path: '/codex', target: 'ws://127.0.0.1:1' });
+    const port = await listen(server);
+
+    await expect(readHttpStatus(port, origin)).resolves.toBe(403);
+  });
+
+  it.each(UNTRUSTED_ORIGINS)('rejects WebSocket upgrades from %s', async (origin) => {
+    const server = createVisBridgeServer({ path: '/codex', target: 'ws://127.0.0.1:1' });
+    const port = await listen(server);
+
+    await expect(sendUpgrade(port, origin)).resolves.toContain('HTTP/1.1 403 Forbidden');
+  });
+});

--- a/vis_bridge.js
+++ b/vis_bridge.js
@@ -143,6 +143,8 @@ function isWildcardHost(hostname) {
 }
 
 const TOKENLESS_VIS_ORIGINS = new Set([
+  'app://index.html',
+  'https://qiyuanhuakai.github.io',
   'http://127.0.0.1:5173',
   'http://localhost:5173',
   'http://[::1]:5173',
@@ -154,6 +156,7 @@ const TOKENLESS_VIS_ORIGINS = new Set([
 function isAllowedOrigin(origin, bridgeToken) {
   if (!origin) return true;
   if (bridgeToken) return true;
+  if (TOKENLESS_VIS_ORIGINS.has(origin)) return true;
   try {
     return TOKENLESS_VIS_ORIGINS.has(new URL(origin).origin);
   } catch {


### PR DESCRIPTION
## Summary

- trust only the packaged Electron origin `app://index.html` and the deployed Pages origin `https://qiyuanhuakai.github.io` in tokenless bridge mode
- exact-match the custom Electron origin before WHATWG normalization, which otherwise serializes it as `null`
- add real HTTP and WebSocket regression coverage for both trusted origins and for rejected `null`, app impostor, and foreign origins

## Verification

- `pnpm lint`
- `pnpm test` (140 files passed, 869 tests passed, 2 skipped)
- `pnpm build`
- `pnpm bridge:build`
- deployed GitHub Pages -> rebuilt SEA bridge: `/homedir` 200 and `/codex` WebSocket OPEN
- packaged Electron `app://index.html` -> rebuilt SEA bridge: `/homedir` 200 and `/codex` WebSocket OPEN
- `Origin: null` and foreign origins remain 403 for HTTP and WebSocket
- 5-lane target, QA, code-quality, security, and history review: PASS