### PR TITLE
fix(ui): clarify branch and plugin status indicators

### DIFF
--- a/app/components/StatusMonitorModal.unsupportedAcp.test.ts
+++ b/app/components/StatusMonitorModal.unsupportedAcp.test.ts
@@ -217,6 +217,25 @@ describe('plugin stat-card grid gated to codex', () => {
   });
 });
 
+describe('plugin row status redundancy', () => {
+  it.each<BackendKind>(['opencode', 'codex'])(
+    'omits the enabled label for the %s backend while retaining the success dot',
+    async (backendKind) => {
+      adapterSlot.current = pluginEntriesAdapter();
+      const { root, app } = await mountModal(backendKind);
+
+      clickTab(root, 'Plugins');
+      await nextTick();
+      const row = [...root.querySelectorAll('.status-monitor-row')].find((candidate) =>
+        candidate.textContent?.includes('Demo'),
+      );
+      expect(row?.querySelector('.status-dot-success')).not.toBeNull();
+      expect(row?.querySelector('.status-monitor-meta')).toBeNull();
+      app.unmount();
+    },
+  );
+});
+
 describe('ACP pluginUnsupported not masked by getGlobalConfig', () => {
   it('shows the ACP plugin unsupported message when only getPluginStatus rejects', async () => {
     adapterSlot.current = acpUnsupportedAdapter();

--- a/app/components/StatusMonitorModal.vue
+++ b/app/components/StatusMonitorModal.vue
@@ -963,8 +963,10 @@ function formatPercent(value: number, total: number): string {
                 <span class="status-dot" :class="plugin.enabled ? 'status-dot-success' : plugin.installed ? 'status-dot-warning' : 'status-dot-muted'" />
                 <span class="status-monitor-name">{{ plugin.name }}</span>
               </div>
-              <div class="status-monitor-meta-column">
-                <span class="status-monitor-meta">{{ plugin.enabled ? $t('codexPanel.appEnabled') : plugin.installed ? $t('codexPanel.appDisabled') : $t('codexPanel.appNotAccessible') }}</span>
+              <div v-if="!plugin.enabled" class="status-monitor-meta-column">
+                <span class="status-monitor-meta">
+                  {{ plugin.installed ? $t('codexPanel.appDisabled') : $t('codexPanel.appNotAccessible') }}
+                </span>
               </div>
             </div>
           </div>

--- a/app/components/TopPanel.branchIcon.test.ts
+++ b/app/components/TopPanel.branchIcon.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp, defineComponent, h, nextTick } from 'vue';
+import { createI18n } from 'vue-i18n';
+import en from '../locales/en';
+import TopPanel from './TopPanel.vue';
+
+vi.mock('@iconify/vue', async () => {
+  const { defineComponent, h } = await import('vue');
+  return {
+    Icon: defineComponent({
+      props: { icon: { type: String, required: true } },
+      setup(props) {
+        return () => h('span', { 'data-icon': props.icon });
+      },
+    }),
+  };
+});
+
+describe('TopPanel OpenCode branch icon', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ path: '/home/user' }), { status: 200 })),
+    );
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('renders a native OpenCode sandbox row with the branch icon', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    const app = createApp(
+      defineComponent({
+        setup() {
+          return () =>
+            h(TopPanel, {
+              treeData: [
+                {
+                  directory: '/repo',
+                  label: '/repo',
+                  name: 'repo',
+                  projectId: 'project-1',
+                  kind: 'sandbox',
+                  sandboxes: [
+                    {
+                      directory: '/repo',
+                      branch: 'main',
+                      kind: 'sandbox',
+                      sessions: [{ id: 'session-1', title: 'Session', status: 'idle' }],
+                    },
+                  ],
+                },
+              ],
+              notificationSessions: [],
+              projectDirectory: '/repo',
+              activeDirectory: '/repo',
+              selectedSessionId: 'session-1',
+              homePath: '/home/user',
+              ptySupported: true,
+            });
+        },
+      }),
+    );
+    app.provide('showConfirm', vi.fn());
+    app.use(createI18n({ legacy: false, locale: 'en', messages: { en } }));
+    app.mount(root);
+
+    const dropdownButton = root.querySelector<HTMLButtonElement>(
+      '.tree-dropdown-root .ui-dropdown-button',
+    );
+    expect(dropdownButton).not.toBeNull();
+    dropdownButton?.click();
+    await nextTick();
+
+    const icon = root.querySelector('.tree-sandbox .tree-header-icon');
+    expect(icon?.getAttribute('data-icon')).toBe('lucide:git-branch');
+    app.unmount();
+  });
+});

--- a/app/components/TopPanel.vue
+++ b/app/components/TopPanel.vue
@@ -275,9 +275,7 @@
                                 ? 'lucide:folder'
                                 : sandbox.kind === 'global'
                                   ? 'lucide:globe'
-                                  : sandbox.kind === 'branch'
-                                    ? 'lucide:git-branch'
-                                    : 'lucide:package'
+                                  : 'lucide:git-branch'
                           "
                           class="tree-header-icon"
                         />


### PR DESCRIPTION
## Summary
- render OpenCode branch-level sandbox rows with the Git branch icon instead of the package icon
- remove the redundant enabled label from OpenCode and Codex plugin rows while preserving the green status dot
- retain disabled and inaccessible plugin labels, and add regression coverage for both UI contracts

## Validation
- `pnpm lint`
- `pnpm test` (878 passed, 2 skipped)
- `pnpm build`
- targeted TopPanel and StatusMonitorModal tests
- manual UI verification on real OpenCode and Codex backends

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sandbox branch rows now display a branch icon for clearer navigation.

- **Bug Fixes**
  - Plugin status rows no longer show redundant enabled text when a plugin is active.
  - Plugin status messaging now accurately reflects whether an inactive plugin is installed.

- **Tests**
  - Added coverage for plugin status display and sandbox branch icon rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->