### PR TITLE
Thirdend：修复codex mcp识别异常

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 本文档记录本 fork 项目相对于上游 [xenodrive/vis](https://github.com/xenodrive/vis) 的所有功能改进、性能优化和修复。
 
 ---
+## [Unreleased]
+
+### Codex 后端修复
+
+- [x] 修复 Status Monitor 在 MCP 冷启动超过 3 秒时过早回退到 `config/read`、导致 `codex_apps` 等运行时 MCP 缺失的问题；状态请求现在使用 30 秒有界等待，并继续在超时后回退到已配置状态。
+
 ## [v0.7.1 released]
 
 ### CI 与发布流程

--- a/app/backends/codex/codexAdapter.test.ts
+++ b/app/backends/codex/codexAdapter.test.ts
@@ -1572,6 +1572,66 @@ describe('CodexAdapter', () => {
       }
     });
 
+    it('uses the live MCP inventory when cold startup exceeds three seconds', async () => {
+      vi.useFakeTimers();
+      try {
+        MockWebSocket.instances = [];
+        const adapter = createCodexAdapter({
+          url: 'ws://localhost:4500',
+          webSocketCtor: MockWebSocket,
+        });
+
+        const status = adapter.getMcpStatus();
+        const socket = MockWebSocket.instances[0]!;
+        socket.emitOpen();
+        await waitForSent(socket, 1);
+        socket.respond(1, {});
+        await waitForSent(socket, 3);
+        socket.respond(2, {
+          config: {
+            mcp_servers: {
+              officecli: { command: 'officecli', args: ['mcp'], enabled: true },
+            },
+          },
+        });
+        await waitForSent(socket, 4);
+
+        await vi.advanceTimersByTimeAsync(3_001);
+        const liveServers = [
+          { name: 'codegraph', authStatus: 'unsupported', tool: 'codegraph_explore' },
+          { name: 'codex_apps', authStatus: 'bearerToken', tool: 'sites.get_site' },
+          { name: 'context7', authStatus: 'notLoggedIn', tool: 'query-docs' },
+          { name: 'git_bash', authStatus: 'unsupported', tool: '' },
+          { name: 'grep_app', authStatus: 'unsupported', tool: 'searchGitHub' },
+          { name: 'lsp', authStatus: 'unsupported', tool: 'diagnostics' },
+          { name: 'officecli', authStatus: 'unsupported', tool: 'officecli' },
+        ] as const;
+        socket.respond(3, {
+          data: liveServers.map(({ name, authStatus, tool }) => ({
+            name,
+            serverInfo: tool ? { name, version: 'live' } : null,
+            tools: tool ? { [tool]: { name: tool } } : {},
+            resources: [],
+            resourceTemplates: [],
+            authStatus,
+          })),
+          nextCursor: null,
+        });
+
+        await expect(status).resolves.toEqual({
+          codegraph: { status: 'connected' },
+          codex_apps: { status: 'connected' },
+          context7: { status: 'needs_auth' },
+          git_bash: { status: 'configured' },
+          grep_app: { status: 'connected' },
+          lsp: { status: 'connected' },
+          officecli: { status: 'connected' },
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('preserves method-not-found so the UI can render MCP as unsupported', async () => {
       MockWebSocket.instances = [];
       const adapter = createCodexAdapter({

--- a/app/backends/codex/codexAdapter.ts
+++ b/app/backends/codex/codexAdapter.ts
@@ -1429,7 +1429,7 @@ export class CodexAdapter implements BackendAdapter {
     this.client = new CodexJsonRpcClient(options);
     this.clientInfo = options.clientInfo ?? defaultClientInfo();
     this.experimentalApi = options.experimentalApi ?? false;
-    this.mcpStatusTimeoutMs = options.mcpStatusTimeoutMs ?? 3_000;
+    this.mcpStatusTimeoutMs = options.mcpStatusTimeoutMs ?? 30_000;
     this.bridgeUrl = options.url;
     this.bindBackendMethods();
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Codex MCP status monitoring during cold starts by allowing up to 30 seconds for runtime status information to become available.
  - Prevented premature fallback to configured status, preserving accurate information such as connected, authentication-required, and configured MCP servers.

- **Documentation**
  - Added an unreleased changelog entry describing the MCP status monitoring fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->