### PR TITLE
fix(codex): persist panel connection across reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ## [Unreleased]
 
+### Codex Panel 与浮窗修复
+
+- [x] Codex Panel 成功连接后仅持久化自动重连意图；页面刷新时由应用启动生命周期立即重建 transport，并通过真实 `account/read` 恢复账号状态，不再等到重新打开 Panel 才连接。
+- [x] OpenCode/ACP 登录、重登录与初始化中止不再断开独立的 Codex Panel transport；Codex 主后端激活失败只清理当前 transport，保留下一次启动的重连意图，只有用户显式点击 Disconnect 才清除该意图。
+- [x] 修复线程加载期间断开连接后 loading 锁无法释放的问题；断开状态下保留线程上下文但禁用线程选择和置顶操作，避免调用已销毁的 adapter。
+- [x] 浮动窗口在创建、恢复、拖动、缩放及 viewport 变化时始终约束在可见 canvas 内；桌面尺寸窗口切换到 375px 移动视口后会立即回到屏幕内，标题栏和操作按钮保持可访问。
+
 ## [v0.7.2 released]
 
 ### Codex 后端修复

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@
 ### Codex Panel 与浮窗修复
 
 - [x] Codex Panel 成功连接后仅持久化自动重连意图；页面刷新时由应用启动生命周期立即重建 transport，并通过真实 `account/read` 恢复账号状态，不再等到重新打开 Panel 才连接。
-- [x] OpenCode/ACP 登录、重登录与初始化中止不再断开独立的 Codex Panel transport；Codex 主后端激活失败只清理当前 transport，保留下一次启动的重连意图，只有用户显式点击 Disconnect 才清除该意图。
+- [x] OpenCode/ACP 登录、重登录与初始化中止不再断开独立的 Codex Panel transport；Codex 主后端初始化中止或激活失败也只清理当前 transport，保留下一次启动的重连意图，只有用户显式点击 Disconnect 才清除该意图。
 - [x] 修复线程加载期间断开连接后 loading 锁无法释放的问题；断开状态下保留线程上下文但禁用线程选择和置顶操作，避免调用已销毁的 adapter。
-- [x] 浮动窗口在创建、恢复、拖动、缩放及 viewport 变化时始终约束在可见 canvas 内；桌面尺寸窗口切换到 375px 移动视口后会立即回到屏幕内，标题栏和操作按钮保持可访问。
+- [x] 浮动窗口在创建、恢复、实时拖动、选项更新、缩放及 viewport 变化时始终约束在可见 canvas 内；临时 `0×0` ResizeObserver extent 不再覆盖有效坐标，桌面尺寸窗口切换到 375px 移动视口后会立即回到屏幕内，标题栏和操作按钮保持可访问。
 
 ## [v0.7.2 released]
 

--- a/app/App.vue
+++ b/app/App.vue
@@ -9096,6 +9096,9 @@ onMounted(() => {
     });
   }
   credentials.load();
+  codexApi.url.value = credentials.codexBridgeUrl.value;
+  codexApi.bridgeToken.value = credentials.codexBridgeToken.value;
+  void codexApi.restoreConnection().catch(() => undefined);
   activeBackendKind.value = credentials.backendKind.value;
   loginBackendKind.value = credentials.backendKind.value;
   loginCodexBridgeUrl.value = credentials.codexBridgeUrl.value;

--- a/app/components/CodexPanel.test.ts
+++ b/app/components/CodexPanel.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createApp, type App as VueApp } from 'vue';
+import { createI18n } from 'vue-i18n';
+import { useCodexApi } from '../composables/useCodexApi';
+import CodexPanel from './CodexPanel.vue';
+
+const apps: VueApp[] = [];
+
+afterEach(() => {
+  apps.splice(0).forEach((app) => app.unmount());
+  document.body.innerHTML = '';
+});
+
+describe('CodexPanel', () => {
+  it('disables cached thread selection while disconnected', () => {
+    const api = useCodexApi();
+    api.reconnectOnMount.value = false;
+    api.threads.value = [{ id: 'thread-1', name: 'Cached thread', cwd: '/workspace' }];
+    api.activeThreadId.value = 'thread-1';
+
+    const target = document.createElement('div');
+    document.body.append(target);
+    const app = createApp(CodexPanel, { api });
+    app.use(
+      createI18n({
+        legacy: false,
+        locale: 'en',
+        missingWarn: false,
+        fallbackWarn: false,
+        messages: { en: {} },
+      }),
+    );
+    apps.push(app);
+    app.mount(target);
+
+    const threadButton = target.querySelector<HTMLButtonElement>('.codex-thread-select');
+    expect(threadButton?.disabled).toBe(true);
+  });
+});

--- a/app/components/CodexPanel.test.ts
+++ b/app/components/CodexPanel.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { createApp, type App as VueApp } from 'vue';
+import { createApp, nextTick, type App as VueApp } from 'vue';
 import { createI18n } from 'vue-i18n';
 import { useCodexApi } from '../composables/useCodexApi';
+import { StorageKeys, storageRemove } from '../utils/storageKeys';
 import CodexPanel from './CodexPanel.vue';
 
 const apps: VueApp[] = [];
@@ -9,31 +10,57 @@ const apps: VueApp[] = [];
 afterEach(() => {
   apps.splice(0).forEach((app) => app.unmount());
   document.body.innerHTML = '';
+  storageRemove(StorageKeys.state.codexActiveThread);
 });
+
+function mountPanel(api: ReturnType<typeof useCodexApi>) {
+  const target = document.createElement('div');
+  document.body.append(target);
+  const app = createApp(CodexPanel, { api });
+  app.use(
+    createI18n({
+      legacy: false,
+      locale: 'en',
+      missingWarn: false,
+      fallbackWarn: false,
+      messages: { en: {} },
+    }),
+  );
+  apps.push(app);
+  app.mount(target);
+  return target;
+}
 
 describe('CodexPanel', () => {
   it('disables cached thread selection while disconnected', () => {
+    // Given: cached thread metadata remains after the transport disconnects
     const api = useCodexApi();
     api.reconnectOnMount.value = false;
     api.threads.value = [{ id: 'thread-1', name: 'Cached thread', cwd: '/workspace' }];
     api.activeThreadId.value = 'thread-1';
 
-    const target = document.createElement('div');
-    document.body.append(target);
-    const app = createApp(CodexPanel, { api });
-    app.use(
-      createI18n({
-        legacy: false,
-        locale: 'en',
-        missingWarn: false,
-        fallbackWarn: false,
-        messages: { en: {} },
-      }),
-    );
-    apps.push(app);
-    app.mount(target);
+    // When: the disconnected panel renders that cached state
+    const target = mountPanel(api);
 
+    // Then: stale adapter actions are unavailable
     const threadButton = target.querySelector<HTMLButtonElement>('.codex-thread-select');
     expect(threadButton?.disabled).toBe(true);
+  });
+
+  it('enables cached thread selection after the transport reconnects', async () => {
+    // Given: the panel renders cached thread metadata while disconnected
+    const api = useCodexApi();
+    api.reconnectOnMount.value = false;
+    api.threads.value = [{ id: 'thread-1', name: 'Cached thread', cwd: '/workspace' }];
+    const target = mountPanel(api);
+
+    // When: the transport reconnects without an active loading operation
+    api.initialized.value = true;
+    api.status.value = 'connected';
+    await nextTick();
+
+    // Then: thread selection becomes available again
+    const threadButton = target.querySelector<HTMLButtonElement>('.codex-thread-select');
+    expect(threadButton?.disabled).toBe(false);
   });
 });

--- a/app/components/CodexPanel.vue
+++ b/app/components/CodexPanel.vue
@@ -186,7 +186,7 @@
               type="button"
               class="codex-thread-select"
               :title="thread.name || thread.preview || thread.id"
-              :disabled="api.loadingThread.value"
+              :disabled="!api.connected.value || api.loadingThread.value"
               @click="selectThread(thread.id)"
             >
               <span class="codex-thread-title-row">
@@ -784,8 +784,11 @@ async function connect() {
 }
 
 onMounted(() => {
-  if (!props.autoConnect || api.connected.value || api.status.value === 'connecting') return;
-  void connect().catch(() => undefined);
+  if (props.autoConnect) {
+    void connect().catch(() => undefined);
+    return;
+  }
+  void api.restoreConnection().catch(() => undefined);
 });
 
 async function refreshThreads() {
@@ -1773,6 +1776,54 @@ input:disabled {
   min-height: 32px;
   border-radius: 10px;
   background: rgba(30, 41, 59, 0.88);
+}
+
+@media (max-width: 640px) {
+  .codex-panel {
+    overflow-y: auto;
+  }
+
+  .codex-panel-header {
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 8px;
+  }
+
+  .codex-url-field {
+    flex-basis: 100%;
+  }
+
+  .codex-token-field {
+    flex: 1 1 160px;
+  }
+
+  .codex-panel-body {
+    display: flex;
+    flex: 0 0 auto;
+    flex-direction: column;
+    overflow: visible;
+  }
+
+  .codex-thread-list {
+    flex: 0 0 auto;
+    max-height: 220px;
+    padding: 8px;
+    border-right: 0;
+    border-bottom: 1px solid var(--theme-border-subtle, rgba(148, 163, 184, 0.18));
+  }
+
+  .codex-output {
+    flex: 0 0 auto;
+    min-height: 180px;
+    padding: 8px;
+    overflow: visible;
+  }
+
+  .codex-prompt {
+    flex: 0 0 auto;
+    gap: 8px;
+    padding: 8px;
+  }
 }
 
 .codex-rate-limit-chip {

--- a/app/components/FloatingWindow.vue
+++ b/app/components/FloatingWindow.vue
@@ -302,16 +302,6 @@ let dragX = 0;
 let dragY = 0;
 let dragTarget: HTMLElement | null = null;
 let dragPointerId = -1;
-const TITLEBAR_VISIBLE_PX = 32;
-
-function getAxisBounds(extentSize: number, windowSize: number, visibleSize: number) {
-  const keepVisible = Math.max(1, Math.min(visibleSize, windowSize, extentSize));
-  return {
-    min: keepVisible - windowSize,
-    max: extentSize - keepVisible,
-  };
-}
-
 function applyTransform(x: number, y: number) {
   const el = windowEl.value;
   if (!el) return;
@@ -328,15 +318,13 @@ function cancelSnapAnimation() {
 
 function getDragBounds() {
   const extent = props.manager.getExtent();
-  const w = props.entry.width || 600;
-  const h = props.entry.height || 400;
-  const xBounds = getAxisBounds(extent.width, w, TITLEBAR_VISIBLE_PX);
-  const keepVisibleY = Math.max(1, Math.min(TITLEBAR_VISIBLE_PX, extent.height));
+  const w = Math.min(props.entry.width || 600, extent.width);
+  const h = Math.min(props.entry.height || 400, extent.height);
   return {
-    minX: xBounds.min,
-    maxX: xBounds.max,
+    minX: 0,
+    maxX: Math.max(0, extent.width - w),
     minY: 0,
-    maxY: extent.height - keepVisibleY,
+    maxY: Math.max(0, extent.height - h),
     w,
     h,
     extent,
@@ -504,8 +492,14 @@ function onResizeStart(e: PointerEvent) {
 function onResizeMove(e: PointerEvent) {
   const dx = e.clientX - resizeStartX;
   const dy = e.clientY - resizeStartY;
-  props.entry.width = Math.max(200, windowStartWidth + dx);
-  props.entry.height = Math.max(150, windowStartHeight + dy);
+  const extent = props.manager.getExtent();
+  const maxWidth = Math.max(1, extent.width - Math.max(0, props.entry.x));
+  const maxHeight = Math.max(1, extent.height - Math.max(0, props.entry.y));
+  props.entry.width = Math.min(maxWidth, Math.max(Math.min(200, maxWidth), windowStartWidth + dx));
+  props.entry.height = Math.min(
+    maxHeight,
+    Math.max(Math.min(150, maxHeight), windowStartHeight + dy),
+  );
 }
 
 function onResizeEnd(e: PointerEvent) {
@@ -671,7 +665,9 @@ function onResizeEnd(e: PointerEvent) {
   contain: layout;
   display: flex;
   flex-direction: column;
-  max-width: 100vw;
+  box-sizing: border-box;
+  max-width: 100%;
+  max-height: 100%;
   overflow: hidden;
   background: transparent;
   border: 1px solid var(--floating-accent, #3a4150);

--- a/app/components/FloatingWindow.vue
+++ b/app/components/FloatingWindow.vue
@@ -3,7 +3,11 @@ import { ref, computed, provide, watch, onBeforeUnmount, nextTick } from 'vue';
 import { useI18n } from 'vue-i18n';
 import CodeContent from './CodeContent.vue';
 import { FLOATING_WINDOW_KEY, type FloatingWindowAPI } from '../composables/useFloatingWindow';
-import type { FloatingWindowEntry, useFloatingWindows } from '../composables/useFloatingWindows';
+import {
+  clampFloatingWindowPosition,
+  type FloatingWindowEntry,
+  type useFloatingWindows,
+} from '../composables/useFloatingWindows';
 import { useAutoScroller, type ScrollMode } from '../composables/useAutoScroller';
 import { useContentSearch } from '../composables/useContentSearch';
 import { useSettings } from '../composables/useSettings';
@@ -354,9 +358,10 @@ function onDragMove(e: PointerEvent) {
   const dy = e.clientY - lastPointerY;
   lastPointerX = e.clientX;
   lastPointerY = e.clientY;
-  const { minX, maxX, minY, maxY } = getDragBounds();
-  dragX += dx * (dragX < minX || dragX > maxX ? 0.5 : 1);
-  dragY += dy * (dragY < minY || dragY > maxY ? 0.5 : 1);
+  const { w, h, extent } = getDragBounds();
+  const next = clampFloatingWindowPosition(dragX + dx, dragY + dy, w, h, extent);
+  dragX = next.x;
+  dragY = next.y;
 
   // Direct DOM update — bypasses Vue reactivity and restyle cascade
   applyTransform(dragX, dragY);

--- a/app/composables/useBackendActivation.test.ts
+++ b/app/composables/useBackendActivation.test.ts
@@ -376,15 +376,16 @@ describe('useBackendActivation', () => {
     },
   );
 
-  it('disconnects the shared Codex API when aborting Codex backend initialization', () => {
+  it('preserves reconnect intent when aborting Codex backend initialization', () => {
     // Given: Codex is the backend being initialized
     const harness = createHarness('codex');
 
     // When: Codex initialization is aborted
     harness.activation.abortInitialization();
 
-    // Then: the shared Codex API connection is closed
-    expect(harness.codexApi.disconnect).toHaveBeenCalledOnce();
+    // Then: only the current transport is closed
+    expect(harness.codexApi.disconnectTransport).toHaveBeenCalledOnce();
+    expect(harness.codexApi.disconnect).not.toHaveBeenCalled();
   });
 
   it('preserves reconnect intent when Codex activation fails after connecting', async () => {

--- a/app/composables/useBackendActivation.test.ts
+++ b/app/composables/useBackendActivation.test.ts
@@ -29,6 +29,9 @@ function createHarness(initialBackend: BackendKind = 'opencode', overrides: Harn
     disconnect: vi.fn(() => {
       calls.push('codex.disconnect');
     }),
+    disconnectTransport: vi.fn(() => {
+      calls.push('codex.disconnectTransport');
+    }),
     selectThread: vi.fn(async () => {
       calls.push('codex.selectThread');
     }),
@@ -188,7 +191,6 @@ describe('useBackendActivation', () => {
     expect(harness.selectedModel.value).toBe('');
     expect(harness.calls).toEqual([
       'disconnectAcpBackend',
-      'codex.disconnect',
       'disconnectCodexBackend',
       'setActiveBackendKind:opencode',
       'ge.connect',
@@ -245,7 +247,6 @@ describe('useBackendActivation', () => {
     await vi.waitFor(() => expect(harness.calls).toContain('hydrateActiveWorktreeResources'));
     expect(harness.calls).toEqual([
       'ge.disconnect',
-      'codex.disconnect',
       'disconnectCodexBackend',
       'configureAcpBackend',
       'setActiveBackendKind:acp',
@@ -358,5 +359,48 @@ describe('useBackendActivation', () => {
     expect(harness.uiInitState.value).toBe('login');
     expect(harness.initErrorMessage.value).toContain('invalid ACP bridge');
     expect(harness.activation.initializationInFlight.value).toBe(false);
+  });
+
+  it.each(['opencode', 'acp'] satisfies BackendKind[])(
+    'preserves the Codex panel connection when aborting %s initialization',
+    (backendKind) => {
+      // Given: a non-Codex backend is being initialized while the panel is connected
+      const harness = createHarness(backendKind);
+
+      // When: that backend initialization is aborted
+      harness.activation.abortInitialization();
+
+      // Then: only backend-owned transports are disconnected
+      expect(harness.codexApi.disconnect).not.toHaveBeenCalled();
+      expect(harness.calls).toContain('disconnectCodexBackend');
+    },
+  );
+
+  it('disconnects the shared Codex API when aborting Codex backend initialization', () => {
+    // Given: Codex is the backend being initialized
+    const harness = createHarness('codex');
+
+    // When: Codex initialization is aborted
+    harness.activation.abortInitialization();
+
+    // Then: the shared Codex API connection is closed
+    expect(harness.codexApi.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it('preserves reconnect intent when Codex activation fails after connecting', async () => {
+    // Given: Codex transport connects before downstream workspace hydration fails
+    const harness = createHarness('codex', {
+      hydrateActiveWorktreeResources: async () => {
+        throw new Error('workspace hydration failed');
+      },
+    });
+
+    // When: Codex backend activation falls back to the login screen
+    await harness.activation.startInitialization();
+
+    // Then: transport is closed without treating the failure as an explicit disconnect
+    expect(harness.codexApi.disconnectTransport).toHaveBeenCalledOnce();
+    expect(harness.codexApi.disconnect).not.toHaveBeenCalled();
+    expect(harness.uiInitState.value).toBe('login');
   });
 });

--- a/app/composables/useBackendActivation.ts
+++ b/app/composables/useBackendActivation.ts
@@ -275,7 +275,7 @@ export function useBackendActivation(options: UseBackendActivationOptions) {
   function abortInitialization() {
     options.ge.disconnect();
     options.disconnectAcpBackend();
-    if (options.credentials.backendKind.value === 'codex') options.codexApi.disconnect();
+    if (options.credentials.backendKind.value === 'codex') options.codexApi.disconnectTransport();
     options.disconnectCodexBackend();
     initializationInFlight.value = false;
     options.connectionState.value = 'connecting';

--- a/app/composables/useBackendActivation.ts
+++ b/app/composables/useBackendActivation.ts
@@ -19,6 +19,7 @@ type CodexApiLike = {
   activeThreadId: Ref<string>;
   visibleThreads: Ref<Array<{ id: string }>>;
   connect: (bridgeUrl: string, onPhase?: (phase: string) => void) => Promise<void>;
+  disconnectTransport: () => void;
   disconnect: () => void;
   selectThread: (threadId: string) => Promise<void>;
 };
@@ -158,7 +159,7 @@ export function useBackendActivation(options: UseBackendActivationOptions) {
         await options.reloadSelectedSessionState(options.selectedSessionId.value);
       }
     } catch (error) {
-      options.codexApi.disconnect();
+      options.codexApi.disconnectTransport();
       options.disconnectCodexBackend();
       options.connectionState.value = 'error';
       options.initErrorMessage.value = options.toErrorMessage(error);
@@ -170,7 +171,6 @@ export function useBackendActivation(options: UseBackendActivationOptions) {
 
   async function activateOpenCode() {
     options.disconnectAcpBackend();
-    options.codexApi.disconnect();
     options.disconnectCodexBackend();
     options.activeBackendKind.value = 'opencode';
     options.setActiveBackendKind('opencode');
@@ -217,7 +217,6 @@ export function useBackendActivation(options: UseBackendActivationOptions) {
   async function activateAcp() {
     try {
       options.ge.disconnect();
-      options.codexApi.disconnect();
       options.disconnectCodexBackend();
       options.activeBackendKind.value = 'acp';
       options.configureAcpBackend({
@@ -276,7 +275,7 @@ export function useBackendActivation(options: UseBackendActivationOptions) {
   function abortInitialization() {
     options.ge.disconnect();
     options.disconnectAcpBackend();
-    options.codexApi.disconnect();
+    if (options.credentials.backendKind.value === 'codex') options.codexApi.disconnect();
     options.disconnectCodexBackend();
     initializationInFlight.value = false;
     options.connectionState.value = 'connecting';

--- a/app/composables/useCodexApi.test.ts
+++ b/app/composables/useCodexApi.test.ts
@@ -165,6 +165,29 @@ describe('useCodexApi', () => {
     expect(api.connected.value).toBe(true);
   });
 
+  it('releases the loading lock when disconnecting during thread selection', async () => {
+    // Given: a connected API is still waiting for the selected thread
+    const pendingThread = deferred<Awaited<ReturnType<CodexAdapter['readThread']>>>();
+    const mock = createAdapterMock();
+    mock.adapter.readThread = vi.fn().mockReturnValue(pendingThread.promise);
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    const selection = api.selectThread('thread-pending');
+    await vi.waitFor(() => expect(mock.adapter.readThread).toHaveBeenCalledOnce());
+    expect(api.loadingThread.value).toBe(true);
+
+    // When: the transport disconnects before that request settles
+    api.disconnectTransport();
+
+    // Then: reconnecting cannot inherit the obsolete loading lock
+    expect(api.loadingThread.value).toBe(false);
+    await api.connect();
+    expect(api.loadingThread.value).toBe(false);
+    pendingThread.resolve({ thread: { id: 'thread-pending', turns: [] } });
+    await selection;
+    expect(api.loadingThread.value).toBe(false);
+  });
+
   it('loads runtime inspector data through capability-tracked composable methods', async () => {
     const mock = createAdapterMock();
     mock.adapter.getThreadGoal = vi.fn().mockResolvedValue({

--- a/app/composables/useCodexApi.test.ts
+++ b/app/composables/useCodexApi.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useCodexApi } from './useCodexApi';
 import type { CodexAdapter, CodexPromptResult } from '../backends/codex/codexAdapter';
 import type { CodexJsonRpcId, CodexJsonRpcNotification } from '../backends/codex/jsonRpcClient';
-import { StorageKeys, storageGet, storageGetJSON, storageKey } from '../utils/storageKeys';
+import { StorageKeys, storageGet, storageGetJSON, storageKey, storageSet } from '../utils/storageKeys';
 
 function deferred<T>() {
   let resolve: (value: T) => void = () => undefined;
@@ -123,6 +123,46 @@ describe('useCodexApi', () => {
     expect(api.threads.value).toEqual([{ id: 'thr_existing', preview: 'Existing thread' }]);
     expect(api.activeThreadId.value).toBe('thr_existing');
     expect(phases).toEqual(['home', 'handshake', 'threads', 'workspace', 'panelData']);
+  });
+
+  it('restores successful panel connection intent until the user disconnects', async () => {
+    // Given: the Codex panel establishes a real initialized connection
+    const firstMock = createAdapterMock();
+    const firstApi = useCodexApi({ adapterFactory: () => firstMock.adapter });
+    await firstApi.connect();
+    firstApi.disconnectTransport();
+    expect(firstApi.reconnectOnMount.value).toBe(true);
+    expect(storageGet(StorageKeys.state.codexPanelConnected)).toBe('1');
+
+    // When: a fresh API instance is created after a page reload
+    const reloadedMock = createAdapterMock();
+    const reloadedApi = useCodexApi({ adapterFactory: () => reloadedMock.adapter });
+
+    // Then: it remembers that the panel should reconnect
+    expect(reloadedApi.reconnectOnMount.value).toBe(true);
+    expect(storageGet(StorageKeys.state.codexPanelConnected)).toBe('1');
+
+    // When: the user explicitly disconnects the panel
+    reloadedApi.disconnect();
+
+    // Then: later reloads no longer reconnect automatically
+    const disconnectedApi = useCodexApi({ adapterFactory: () => createAdapterMock().adapter });
+    expect(disconnectedApi.reconnectOnMount.value).toBe(false);
+    expect(storageGet(StorageKeys.state.codexPanelConnected)).toBe('0');
+  });
+
+  it('restores a remembered connection without mounting the Codex panel', async () => {
+    // Given: a prior initialized connection left startup reconnect intent behind
+    storageSet(StorageKeys.state.codexPanelConnected, '1');
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+
+    // When: the application startup lifecycle restores the API transport
+    await api.restoreConnection();
+
+    // Then: the connection is initialized before any panel component mounts
+    expect(mock.adapter.initialize).toHaveBeenCalledOnce();
+    expect(api.connected.value).toBe(true);
   });
 
   it('loads runtime inspector data through capability-tracked composable methods', async () => {

--- a/app/composables/useCodexApi.ts
+++ b/app/composables/useCodexApi.ts
@@ -462,6 +462,7 @@ export type CodexPluginWithMarketplace = CodexPlugin & {
 
 export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   const status = ref<CodexConnectionStatus>('idle');
+  const reconnectOnMount = ref(storageGet(StorageKeys.state.codexPanelConnected) === '1');
   const url = ref(initialOptions.url ?? getPersistedCodexBridgeUrl());
   const bridgeToken = ref(initialOptions.bridgeToken ?? getPersistedCodexBridgeToken());
   const errorMessage = ref('');
@@ -1682,7 +1683,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   }
 
   async function connect(nextUrl = url.value, onPhase?: (phase: CodexConnectPhase) => void) {
-    disconnect();
+    teardownConnection(true);
     url.value = nextUrl.trim();
     status.value = 'connecting';
     errorMessage.value = '';
@@ -1705,6 +1706,8 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       if (!isCurrentConnection(request)) return;
       initialized.value = true;
       status.value = 'connected';
+      reconnectOnMount.value = true;
+      storageSet(StorageKeys.state.codexPanelConnected, '1');
 
       onPhase?.('threads');
       await Promise.allSettled([refreshThreads({}, false)]);
@@ -1719,14 +1722,19 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       if (!isCurrentConnection(request)) return;
       status.value = 'error';
       errorMessage.value = error instanceof Error ? error.message : String(error);
-      disconnect(false);
+      teardownConnection(false);
       if (import.meta.env.DEV) console.timeEnd('codex-connect');
       throw error;
     }
     if (import.meta.env.DEV) console.timeEnd('codex-connect');
   }
 
-  function disconnect(resetStatus = true) {
+  async function restoreConnection() {
+    if (!reconnectOnMount.value || connected.value || status.value === 'connecting') return;
+    await connect(url.value);
+  }
+
+  function teardownConnection(resetStatus: boolean) {
     connectionGeneration += 1;
     threadSelectionGeneration += 1;
     accountRefreshGeneration += 1;
@@ -1750,6 +1758,16 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     threadGoalThreadId.value = null;
     threadGoalLoading.value = false;
     if (resetStatus) status.value = 'idle';
+  }
+
+  function disconnectTransport() {
+    teardownConnection(true);
+  }
+
+  function disconnect() {
+    disconnectTransport();
+    reconnectOnMount.value = false;
+    storageSet(StorageKeys.state.codexPanelConnected, '0');
   }
 
   async function fetchThreadList(
@@ -3296,6 +3314,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
 
     return {
      status,
+     reconnectOnMount,
      url,
      bridgeToken,
      errorMessage,
@@ -3332,7 +3351,9 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       fsSuggestions,
       fsShowSuggestions,
       connect,
-      disconnect,
+      restoreConnection,
+      disconnectTransport,
+     disconnect,
       refreshHomeDir,
       refreshThreads,
       preloadPanelData,

--- a/app/composables/useCodexApi.ts
+++ b/app/composables/useCodexApi.ts
@@ -1757,6 +1757,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     threadGoal.value = null;
     threadGoalThreadId.value = null;
     threadGoalLoading.value = false;
+    loadingThread.value = false;
     if (resetStatus) status.value = 'idle';
   }
 

--- a/app/composables/useFloatingWindows.test.ts
+++ b/app/composables/useFloatingWindows.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { createApp, defineComponent } from 'vue';
 import { createI18n } from 'vue-i18n';
-import { useFloatingWindows } from './useFloatingWindows';
+import { clampFloatingWindowPosition, useFloatingWindows } from './useFloatingWindows';
 
 function mountFloatingWindows() {
   let api: ReturnType<typeof useFloatingWindows> | undefined;
@@ -68,6 +68,103 @@ describe('useFloatingWindows responsive geometry', () => {
 
     // Then: the same window is immediately moved back into view
     expect(mounted.api.get('responsive-window')).toMatchObject({ x: 0, y: 0 });
+    mounted.unmount();
+  });
+
+  it('repositions a desktop window inside a tablet viewport', async () => {
+    // Given: a window at the right edge of a desktop canvas
+    const mounted = mountFloatingWindows();
+    mounted.api.setExtent(1280, 900);
+    await mounted.api.open('tablet-window', {
+      width: 760,
+      height: 560,
+      x: 520,
+      y: 200,
+      expiry: Infinity,
+    });
+
+    // When: the canvas narrows to a 768px tablet viewport
+    mounted.api.setExtent(768, 900);
+
+    // Then: the complete window remains inside the available width
+    expect(mounted.api.get('tablet-window')).toMatchObject({ x: 8, y: 200 });
+    mounted.unmount();
+  });
+
+  it('clamps live drag coordinates to the visible extent', () => {
+    // Given: a desktop-sized window in a mobile extent
+    const extent = { width: 375, height: 500 };
+
+    // When: pointer movement requests coordinates outside every edge
+    const position = clampFloatingWindowPosition(900, -40, 760, 560, extent);
+
+    // Then: the rendered origin cannot leave the extent
+    expect(position).toEqual({ x: 0, y: 0 });
+  });
+
+  it('clamps size and position updates before rebuilding entries', async () => {
+    // Given: a visible mobile window
+    const mounted = mountFloatingWindows();
+    mounted.api.setExtent(375, 500);
+    await mounted.api.open('updated-window', {
+      width: 300,
+      height: 300,
+      x: 50,
+      y: 100,
+      expiry: Infinity,
+    });
+
+    // When: an option update supplies stale desktop geometry
+    mounted.api.updateOptions('updated-window', { width: 760, height: 560, x: 900, y: 700 });
+
+    // Then: the updated window remains visible
+    expect(mounted.api.get('updated-window')).toMatchObject({ x: 0, y: 0 });
+    mounted.unmount();
+  });
+
+  it('clamps stale geometry when restoring a minimized window', async () => {
+    // Given: a minimized window whose stored geometry is outside the current extent
+    const mounted = mountFloatingWindows();
+    mounted.api.setExtent(375, 500);
+    await mounted.api.open('restored-window', {
+      width: 300,
+      height: 400,
+      x: 50,
+      y: 100,
+      expiry: Infinity,
+    });
+    mounted.api.minimize('restored-window');
+    const entry = mounted.api.get('restored-window');
+    if (!entry) throw new Error('Expected restored-window entry.');
+    entry.x = 900;
+    entry.y = 700;
+
+    // When: the window is restored
+    mounted.api.restore('restored-window');
+
+    // Then: its full rendered bounds are reachable again
+    expect(mounted.api.get('restored-window')).toMatchObject({ x: 75, y: 100, minimized: false });
+    mounted.unmount();
+  });
+
+  it('preserves window position through a transient zero-sized extent', async () => {
+    // Given: a desktop window with a valid remembered position
+    const mounted = mountFloatingWindows();
+    mounted.api.setExtent(1280, 720);
+    await mounted.api.open('observer-window', {
+      width: 760,
+      height: 560,
+      x: 500,
+      y: 100,
+      expiry: Infinity,
+    });
+
+    // When: a ResizeObserver briefly reports zero before layout returns
+    mounted.api.setExtent(0, 0);
+    mounted.api.setExtent(1280, 720);
+
+    // Then: the valid position is not permanently overwritten
+    expect(mounted.api.get('observer-window')).toMatchObject({ x: 500, y: 100 });
     mounted.unmount();
   });
 });

--- a/app/composables/useFloatingWindows.test.ts
+++ b/app/composables/useFloatingWindows.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createApp, defineComponent } from 'vue';
+import { createI18n } from 'vue-i18n';
+import { useFloatingWindows } from './useFloatingWindows';
+
+function mountFloatingWindows() {
+  let api: ReturnType<typeof useFloatingWindows> | undefined;
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  const app = createApp(
+    defineComponent({
+      setup() {
+        api = useFloatingWindows();
+        return () => null;
+      },
+    }),
+  );
+  app.use(createI18n({ legacy: false, locale: 'en', messages: { en: {} } }));
+  app.mount(root);
+  if (!api) throw new Error('Floating window composable did not mount.');
+  return {
+    api,
+    unmount() {
+      app.unmount();
+      root.remove();
+    },
+  };
+}
+
+describe('useFloatingWindows responsive geometry', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('keeps an oversized window inside a narrow viewport when opening', async () => {
+    // Given: a mobile-sized floating canvas
+    const mounted = mountFloatingWindows();
+    mounted.api.setExtent(375, 500);
+
+    // When: a desktop-sized window opens with stale desktop coordinates
+    await mounted.api.open('mobile-window', {
+      width: 760,
+      height: 560,
+      x: 900,
+      y: 700,
+      expiry: Infinity,
+    });
+
+    // Then: the rendered window origin stays inside the mobile canvas
+    expect(mounted.api.get('mobile-window')).toMatchObject({ x: 0, y: 0 });
+    mounted.unmount();
+  });
+
+  it('repositions an existing window when the viewport narrows', async () => {
+    // Given: a visible window positioned near the right edge of a desktop canvas
+    const mounted = mountFloatingWindows();
+    mounted.api.setExtent(1280, 720);
+    await mounted.api.open('responsive-window', {
+      width: 760,
+      height: 560,
+      x: 500,
+      y: 100,
+      expiry: Infinity,
+    });
+
+    // When: the floating canvas shrinks to a mobile viewport
+    mounted.api.setExtent(375, 500);
+
+    // Then: the same window is immediately moved back into view
+    expect(mounted.api.get('responsive-window')).toMatchObject({ x: 0, y: 0 });
+    mounted.unmount();
+  });
+});

--- a/app/composables/useFloatingWindows.ts
+++ b/app/composables/useFloatingWindows.ts
@@ -80,11 +80,28 @@ function nextZIndex(manualTier: boolean): number {
   return ++zIndexCounter + (manualTier ? MANUAL_ZINDEX_OFFSET : 0);
 }
 
+export function clampFloatingWindowPosition(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  extent: Extent,
+): { x: number; y: number } {
+  const renderedWidth = Math.min(width, Math.max(0, extent.width));
+  const renderedHeight = Math.min(height, Math.max(0, extent.height));
+  return {
+    x: Math.max(0, Math.min(x, Math.max(0, extent.width - renderedWidth))),
+    y: Math.max(0, Math.min(y, Math.max(0, extent.height - renderedHeight))),
+  };
+}
+
 function clampEntryToExtent(entry: FloatingWindowEntry, extent: Extent): void {
   const renderedWidth = Math.min(entry.width ?? 600, Math.max(0, extent.width));
   const renderedHeight = Math.min(entry.height ?? 400, Math.max(0, extent.height));
-  entry.x = Math.max(0, Math.min(entry.x, Math.max(0, extent.width - renderedWidth)));
-  entry.y = Math.max(0, Math.min(entry.y, Math.max(0, extent.height - renderedHeight)));
+  Object.assign(
+    entry,
+    clampFloatingWindowPosition(entry.x, entry.y, renderedWidth, renderedHeight, extent),
+  );
 }
 
 function variantToGutterMode(variant?: string): 'none' | 'single' | 'double' {
@@ -149,7 +166,7 @@ export function useFloatingWindows() {
 
   function setExtent(w: number, h: number) {
     extent = { width: Math.max(0, w), height: Math.max(0, h) };
-    if (entriesMap.size === 0) return;
+    if (entriesMap.size === 0 || extent.width === 0 || extent.height === 0) return;
     for (const entry of entriesMap.values()) clampEntryToExtent(entry, extent);
     rebuildEntries();
   }
@@ -328,6 +345,7 @@ export function useFloatingWindows() {
        }
      }
 
+     clampEntryToExtent(merged, extent);
      entriesMap.set(key, sanitizeEntry(merged));
      rebuildEntries();
 
@@ -422,6 +440,7 @@ export function useFloatingWindows() {
   function restore(key: string): void {
     const entry = entriesMap.get(key);
     if (!entry) return;
+    clampEntryToExtent(entry, extent);
     entry.minimized = false;
     bringToFront(key);
   }

--- a/app/composables/useFloatingWindows.ts
+++ b/app/composables/useFloatingWindows.ts
@@ -42,7 +42,6 @@ export type Extent = { width: number; height: number };
 
 const TOOL_RUNNING_TTL_MS = 1000 * 60 * 10;
 const TOOL_COMPLETED_TTL_MS = 2000;
-const TITLEBAR_VISIBLE_PX = 32;
 
 const DEFAULT_OPTS: Partial<FloatingWindowEntry> = {
   closable: false,
@@ -81,12 +80,11 @@ function nextZIndex(manualTier: boolean): number {
   return ++zIndexCounter + (manualTier ? MANUAL_ZINDEX_OFFSET : 0);
 }
 
-function getAxisBounds(extentSize: number, windowSize: number, visibleSize: number) {
-  const keepVisible = Math.max(1, Math.min(visibleSize, windowSize, extentSize));
-  return {
-    min: keepVisible - windowSize,
-    max: extentSize - keepVisible,
-  };
+function clampEntryToExtent(entry: FloatingWindowEntry, extent: Extent): void {
+  const renderedWidth = Math.min(entry.width ?? 600, Math.max(0, extent.width));
+  const renderedHeight = Math.min(entry.height ?? 400, Math.max(0, extent.height));
+  entry.x = Math.max(0, Math.min(entry.x, Math.max(0, extent.width - renderedWidth)));
+  entry.y = Math.max(0, Math.min(entry.y, Math.max(0, extent.height - renderedHeight)));
 }
 
 function variantToGutterMode(variant?: string): 'none' | 'single' | 'double' {
@@ -150,7 +148,10 @@ export function useFloatingWindows() {
   };
 
   function setExtent(w: number, h: number) {
-    extent = { width: w, height: h };
+    extent = { width: Math.max(0, w), height: Math.max(0, h) };
+    if (entriesMap.size === 0) return;
+    for (const entry of entriesMap.values()) clampEntryToExtent(entry, extent);
+    rebuildEntries();
   }
 
   function getExtent(): Extent {
@@ -231,12 +232,7 @@ export function useFloatingWindows() {
       merged.y = pos.y;
     }
 
-    // Clamp position to visible bounds
-    const windowWidth = merged.width ?? 600;
-    const xBounds = getAxisBounds(extent.width, windowWidth, TITLEBAR_VISIBLE_PX);
-    const keepVisibleY = Math.max(1, Math.min(TITLEBAR_VISIBLE_PX, extent.height));
-    merged.x = Math.max(xBounds.min, Math.min(merged.x, xBounds.max));
-    merged.y = Math.max(0, Math.min(merged.y, extent.height - keepVisibleY));
+    clampEntryToExtent(merged, extent);
 
     // Execute beforeOpen hook
     if (merged.beforeOpen) {

--- a/app/utils/storageKeys.ts
+++ b/app/utils/storageKeys.ts
@@ -76,6 +76,7 @@ export const StorageKeys = {
     lastAuthError: 'state.lastAuthError.v1',
     deletedSandboxes: 'state.deletedSandboxes.v1',
     codexActiveThread: 'state.codexActiveThread.v1',
+    codexPanelConnected: 'state.codexPanelConnected.v1',
     codexAuxiliaryHistory: 'state.codexAuxiliaryHistory.v1',
     forgePtyId: 'state.forgePtyId.v1',
     acpArchivedSessions: 'state.acpArchivedSessions.v1',


### PR DESCRIPTION
## Summary

- persist only successful Codex panel reconnect intent and restore the live transport during app startup, without requiring the panel to open
- keep the independent Codex panel connected across OpenCode/ACP logout and backend activation while preserving explicit Disconnect semantics
- release stale thread-loading state on teardown and guard disconnected cached controls
- clamp floating windows during open, restore, resize, viewport changes, option updates, and live pointer movement
- add a responsive single-column Codex panel layout for narrow viewports and document all fixes in CHANGELOG.md

## Verification

- `pnpm lint`
- `pnpm test` (905 passed, 2 skipped)
- `pnpm build`
- `pnpm bridge:build`
- real Chromium QA: startup reconnect with panel unmounted, explicit disconnect, ACP/OpenCode relogin, 1280/768/375 viewports, and pointer-capture drag bounds
- 5-lane implementation review plus dual visual/CJK review passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex Panel connections now restore automatically after reopening the app.
  * Connection state is preserved across sessions, while explicit disconnections remain cleared.
  * The panel layout adapts for smaller screens with a scrollable, stacked design.

* **Bug Fixes**
  * Prevented thread selection while disconnected or loading.
  * Improved backend switching and reconnection behavior.
  * Floating windows now remain within available bounds when moved, resized, or restored.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->