### PR TITLE
feat(ui): improve plugin compatibility status

### DIFF
--- a/RoadMap.md
+++ b/RoadMap.md
@@ -11,11 +11,11 @@
     - [ ] 分支名不再过度压缩搜索框
     - [ ] 搜索命中的文件夹完全展开 
 
-- [ ] 改善插件兼容性
-	- [ ] omo：尝试识别Sisyphus Junior的类别（category）
-	- [ ] omo：特殊处理工具lsp-*
-    - [ ] magic context：特殊处理子代理magic-context-*
-    - [ ] magic context：特殊处理工具ctx-*
+- [x] 改善插件兼容性
+	- [x] omo：尝试识别Sisyphus Junior的类别（category）
+	- [x] omo：特殊处理工具lsp-*、codegraph-*
+    - [x] magic context：特殊处理子代理magic-context-*
+    - [x] magic context：特殊处理工具ctx-*
 
 - [ ] 修复已知问题
     - [?] codex：edit工具悬浮窗在首次弹出时不显示内容

--- a/app/App.vue
+++ b/app/App.vue
@@ -451,6 +451,7 @@
       :session-id="selectedSessionId"
       :codex-api="codexApi"
       :active-backend-kind="activeBackendKind"
+      :magic-context-workers="magicContextWorkers"
       @close="isStatusMonitorOpen = false"
     />
     <ProjectSettingsDialog
@@ -670,6 +671,10 @@ import {
 import { retryReferencedSessionIds } from './utils/retryReferencedSessions';
 import { resumeOutputFollowing } from './utils/resumeOutputFollowing';
 import { normalizeToolName } from './utils/toolNames';
+import {
+  collectMagicContextWorkers,
+  isPluginToolName,
+} from './utils/pluginCompatibility';
 import {
   extractFileRead as extractToolFileRead,
   extractPatch as extractToolPatch,
@@ -1750,6 +1755,10 @@ const sessionHistoryMetaById = computed(() => {
     });
   return meta;
 });
+
+const magicContextWorkers = computed(() =>
+  collectMagicContextWorkers(sessionHistoryMetaById.value),
+);
 
 const sessions = computed<SessionInfo[]>(() => {
   const projectId = selectedProjectId.value.trim();
@@ -7930,6 +7939,7 @@ const TOOL_WINDOW_SUPPORTED = new Set([
 ]);
 
 function shouldRenderToolWindow(tool: string) {
+  if (isPluginToolName(tool)) return true;
   const normalizedTool = normalizeToolName(tool);
   return !TOOL_WINDOW_HIDDEN.has(normalizedTool) && TOOL_WINDOW_SUPPORTED.has(normalizedTool);
 }

--- a/app/App.vue
+++ b/app/App.vue
@@ -1757,7 +1757,7 @@ const sessionHistoryMetaById = computed(() => {
 });
 
 const magicContextWorkers = computed(() =>
-  collectMagicContextWorkers(sessionHistoryMetaById.value),
+  collectMagicContextWorkers(sessionHistoryMetaById.value, selectedSessionId.value),
 );
 
 const sessions = computed<SessionInfo[]>(() => {

--- a/app/App.vue
+++ b/app/App.vue
@@ -1743,21 +1743,26 @@ function collectAllSessionsByProject() {
 const sessionsByProject = computed(() => collectAllSessionsByProject());
 
 const sessionHistoryMetaById = computed(() => {
-  const meta: Record<string, SessionHistoryMeta> = {};
-  Object.values(sessionsByProject.value)
-    .flat()
-    .forEach((session) => {
+  const meta: Record<string, SessionHistoryMeta & { projectId: string }> = {};
+  Object.entries(sessionsByProject.value).forEach(([projectId, projectSessions]) => {
+    projectSessions.forEach((session) => {
       meta[session.id] = {
+        projectId,
         parentID: session.parentID,
         label: sessionLabel(session),
         status: session.status,
       };
     });
+  });
   return meta;
 });
 
 const magicContextWorkers = computed(() =>
-  collectMagicContextWorkers(sessionHistoryMetaById.value, selectedSessionId.value),
+  collectMagicContextWorkers(
+    sessionHistoryMetaById.value,
+    selectedSessionId.value,
+    selectedProjectId.value,
+  ),
 );
 
 const sessions = computed<SessionInfo[]>(() => {

--- a/app/components/StatusMonitorModal.codexStatus.test.ts
+++ b/app/components/StatusMonitorModal.codexStatus.test.ts
@@ -127,7 +127,7 @@ describe('StatusMonitorModal Codex status isolation', () => {
     await nextTick();
 
     const tabs = [...root.querySelectorAll<HTMLButtonElement>('[role="tab"]')];
-    expect(tabs).toHaveLength(7);
+    expect(tabs).toHaveLength(8);
     expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
     tabs[0]?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
     await nextTick();

--- a/app/components/StatusMonitorModal.magicContext.test.ts
+++ b/app/components/StatusMonitorModal.magicContext.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createApp, defineComponent, h, nextTick } from 'vue';
+import { createI18n } from 'vue-i18n';
+
+vi.mock('@iconify/vue', () => ({ Icon: () => null }));
+vi.mock('../backends/registry', () => ({
+  getPersistedCodexBridgeUrl: () => 'ws://localhost:23004/codex',
+  getPersistedCodexBridgeToken: () => '',
+  getActiveBackendAdapter: () => ({
+    getGlobalHealth: async () => ({ healthy: true, version: 'test' }),
+    getMcpStatus: async () => ({}),
+    getLspStatus: async () => [],
+    getSkillStatus: async () => [],
+    getGlobalConfig: async () => ({}),
+  }),
+}));
+vi.mock('../composables/useMessages', () => ({
+  useMessages: () => ({
+    roots: { value: [] },
+    getThread: () => [],
+    getUsage: () => undefined,
+    loadHistory: () => undefined,
+  }),
+}));
+vi.mock('../composables/useSettings', () => ({
+  useSettings: () => ({ showCodexInStatusMonitor: { value: false, __v_isRef: true } }),
+}));
+vi.mock('../composables/useAcpBridge', () => ({
+  useAcpBridge: () => ({
+    services: { value: [] },
+    agents: { value: [] },
+    loading: { value: false },
+    bridgeAvailable: { value: true },
+    error: { value: '' },
+    refresh: async () => undefined,
+    updateAgent: async () => undefined,
+    createAgent: async () => undefined,
+    removeAgent: async () => undefined,
+  }),
+}));
+
+import StatusMonitorModal from './StatusMonitorModal.vue';
+import en from '../locales/en';
+import { useCodexApi } from '../composables/useCodexApi';
+
+describe('StatusMonitorModal Magic Context status', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('lists magic-context workers only on the MC tab with their live session status', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    const app = createApp(
+      defineComponent({
+        setup() {
+          return () =>
+            h(StatusMonitorModal, {
+              open: true,
+              preload: false,
+              activeBackendKind: 'opencode',
+              sessionId: 'ses-parent',
+              codexApi: useCodexApi(),
+              magicContextWorkers: [
+                { sessionId: 'mc-1', name: 'magic-context-reviewer', status: 'busy' },
+                { sessionId: 'mc-2', name: 'magic-context-historian', status: 'idle' },
+                { sessionId: 'mc-3', name: 'magic-context-recomp', status: 'retry' },
+              ],
+            });
+        },
+      }),
+    );
+    app.use(createI18n({ legacy: false, locale: 'en', messages: { en } }));
+    app.mount(root);
+    await nextTick();
+
+    expect(root.textContent).not.toContain('magic-context-reviewer');
+    const mcTab = [...root.querySelectorAll<HTMLButtonElement>('[role="tab"]')].find(
+      (button) => button.textContent?.trim() === 'MC',
+    );
+    expect(mcTab).toBeDefined();
+    mcTab?.click();
+    await nextTick();
+
+    expect(root.textContent).toContain('magic-context-reviewer');
+    expect(root.textContent).toContain('Running');
+    expect(root.textContent).toContain('Idle');
+    expect(root.textContent).toContain('Retrying');
+    app.unmount();
+  });
+});

--- a/app/components/StatusMonitorModal.vue
+++ b/app/components/StatusMonitorModal.vue
@@ -13,6 +13,7 @@ import { useSettings } from '../composables/useSettings';
 import type { useCodexApi } from '../composables/useCodexApi';
 import type { MessageUsage } from '../types/message';
 import type { MessageInfo } from '../types/sse';
+import type { MagicContextWorker } from '../utils/pluginCompatibility';
 import AcpManagerPanel from './AcpManagerPanel.vue';
 
 type CodexApi = ReturnType<typeof useCodexApi>;
@@ -23,6 +24,7 @@ const props = defineProps<{
   codexApi: CodexApi;
   preload: boolean;
   activeBackendKind: BackendKind;
+  magicContextWorkers?: readonly MagicContextWorker[];
 }>();
 const emit = defineEmits<{ close: [] }>();
 
@@ -41,7 +43,7 @@ function requireBackendMethod<T extends (...args: never[]) => unknown>(method: T
   return method;
 }
 
-type TabId = 'server' | 'mcp' | 'lsp' | 'plugins' | 'skills' | 'token' | 'acp' | 'codex';
+type TabId = 'server' | 'mcp' | 'lsp' | 'plugins' | 'skills' | 'token' | 'mc' | 'acp' | 'codex';
 const activeTab = ref<TabId>('server');
 const acpManagerRef = ref<{ refresh: () => Promise<void> } | null>(null);
 
@@ -666,6 +668,16 @@ function lspStatusClass(status: string) {
   return status === 'connected' ? 'status-dot-success' : 'status-dot-error';
 }
 
+function magicContextStatusClass(status: MagicContextWorker['status']) {
+  if (status === 'busy') return 'status-dot-success';
+  if (status === 'retry') return 'status-dot-warning';
+  return 'status-dot-muted';
+}
+
+function magicContextStatusText(status: MagicContextWorker['status']) {
+  return t(`statusMonitor.mc.states.${status}`);
+}
+
 const tabs = computed<{ id: TabId; labelKey: string }[]>(() => {
   const base: { id: TabId; labelKey: string }[] = [
     { id: 'server', labelKey: 'statusMonitor.tabs.server' },
@@ -674,6 +686,7 @@ const tabs = computed<{ id: TabId; labelKey: string }[]>(() => {
     { id: 'plugins', labelKey: 'statusMonitor.tabs.plugins' },
     { id: 'skills', labelKey: 'statusMonitor.tabs.skills' },
     { id: 'token', labelKey: 'statusMonitor.tabs.token' },
+    { id: 'mc', labelKey: 'statusMonitor.tabs.mc' },
     { id: 'acp', labelKey: 'statusMonitor.tabs.acp' },
   ];
   if (showCodexInStatusMonitor.value) {
@@ -728,6 +741,10 @@ const currentTotalInfo = computed(() => {
     case 'token':
       return tokenUsage.value
         ? { label: t('statusMonitor.token.totalTokens'), count: tokenUsage.value.tokens.total ?? (tokenUsage.value.tokens.input + tokenUsage.value.tokens.output + tokenUsage.value.tokens.reasoning) }
+        : null;
+    case 'mc':
+      return props.magicContextWorkers?.length
+        ? { label: t('statusMonitor.common.totalLabel'), count: props.magicContextWorkers.length }
         : null;
     case 'acp':
       return null;
@@ -1085,6 +1102,28 @@ function formatPercent(value: number, total: number): string {
           <AcpManagerPanel ref="acpManagerRef" />
         </div>
 
+        <!-- Magic Context Tab -->
+        <div v-if="activeTab === 'mc'" class="status-monitor-content">
+          <div v-if="!magicContextWorkers?.length" class="status-monitor-empty">
+            {{ $t('statusMonitor.mc.noData') }}
+          </div>
+          <div v-else class="status-monitor-list">
+            <div
+              v-for="worker in magicContextWorkers"
+              :key="worker.sessionId"
+              class="status-monitor-row"
+            >
+              <div class="status-monitor-row-main">
+                <span class="status-dot" :class="magicContextStatusClass(worker.status)" />
+                <span class="status-monitor-name">{{ worker.name }}</span>
+              </div>
+              <span class="status-monitor-meta">
+                {{ magicContextStatusText(worker.status) }}
+              </span>
+            </div>
+          </div>
+        </div>
+
         <!-- Codex Tab -->
         <div v-if="activeTab === 'codex'" class="status-monitor-content">
           <div v-if="codexApi.status.value !== 'connected'" class="status-monitor-empty">
@@ -1256,9 +1295,10 @@ function formatPercent(value: number, total: number): string {
 }
 
 .status-monitor-tabs {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   padding: 4px;
   margin: 12px 16px 0;
   background: var(--theme-card-bg, var(--theme-modal-control-bg, rgba(30, 41, 59, 0.55)));
@@ -1267,29 +1307,12 @@ function formatPercent(value: number, total: number): string {
   width: calc(100% - 32px);
   box-sizing: border-box;
   min-width: 0;
-  overflow-x: auto;
-  overflow-y: hidden;
-  scrollbar-width: thin;
-  scrollbar-color: var(--theme-modal-border, rgba(148, 163, 184, 0.3)) transparent;
   flex-shrink: 0;
 }
 
-.status-monitor-tabs::-webkit-scrollbar {
-  height: 4px;
-}
-
-.status-monitor-tabs::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.status-monitor-tabs::-webkit-scrollbar-thumb {
-  background: var(--theme-modal-border, rgba(148, 163, 184, 0.3));
-  border-radius: 999px;
-}
-
 .status-monitor-tab {
-  flex: 0 0 auto;
-  padding: 6px 10px;
+  min-width: 0;
+  padding: 6px 4px;
   font-size: 12px;
   font-weight: 500;
   color: var(--theme-tab-text, var(--theme-modal-text-muted, #94a3b8));

--- a/app/components/StatusMonitorModal.vue
+++ b/app/components/StatusMonitorModal.vue
@@ -1295,10 +1295,9 @@ function formatPercent(value: number, total: number): string {
 }
 
 .status-monitor-tabs {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   padding: 4px;
   margin: 12px 16px 0;
   background: var(--theme-card-bg, var(--theme-modal-control-bg, rgba(30, 41, 59, 0.55)));
@@ -1307,12 +1306,29 @@ function formatPercent(value: number, total: number): string {
   width: calc(100% - 32px);
   box-sizing: border-box;
   min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: var(--theme-modal-border, rgba(148, 163, 184, 0.3)) transparent;
   flex-shrink: 0;
 }
 
+.status-monitor-tabs::-webkit-scrollbar {
+  height: 4px;
+}
+
+.status-monitor-tabs::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.status-monitor-tabs::-webkit-scrollbar-thumb {
+  background: var(--theme-modal-border, rgba(148, 163, 184, 0.3));
+  border-radius: 999px;
+}
+
 .status-monitor-tab {
-  min-width: 0;
-  padding: 6px 4px;
+  flex: 0 0 auto;
+  padding: 6px 10px;
   font-size: 12px;
   font-weight: 500;
   color: var(--theme-tab-text, var(--theme-modal-text-muted, #94a3b8));

--- a/app/i18n/types.ts
+++ b/app/i18n/types.ts
@@ -281,6 +281,7 @@ export interface LocaleMessages {
       plugins: string;
       skills: string;
       token: string;
+      mc: string;
       acp: string;
       codex: string;
     };
@@ -351,6 +352,14 @@ export interface LocaleMessages {
       totalCost: string;
       createdTime: string;
       lastActivity: string;
+    };
+    mc: {
+      noData: string;
+      states: {
+        busy: string;
+        idle: string;
+        retry: string;
+      };
     };
     acp: {
       unavailable: string;

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -285,6 +285,7 @@ const messages: LocaleMessages = {
       plugins: 'Plugins',
       skills: 'Skills',
       token: 'Token',
+      mc: 'MC',
       acp: 'ACP',
       codex: 'Codex',
     },
@@ -355,6 +356,14 @@ const messages: LocaleMessages = {
       totalCost: 'Total cost',
       createdTime: 'Created',
       lastActivity: 'Last activity',
+    },
+    mc: {
+      noData: 'No Magic Context workers are active.',
+      states: {
+        busy: 'Running',
+        idle: 'Idle',
+        retry: 'Retrying',
+      },
     },
     acp: {
       unavailable: 'The VIS bridge is unavailable.',

--- a/app/locales/eo.ts
+++ b/app/locales/eo.ts
@@ -285,6 +285,7 @@ const messages: LocaleMessages = {
       plugins: 'Kromaĵoj',
       skills: 'Kapablecoj',
       token: 'Token',
+      mc: 'MC',
       acp: 'ACP',
       codex: 'Codex',
     },
@@ -355,6 +356,14 @@ const messages: LocaleMessages = {
       totalCost: 'Entuta kosto',
       createdTime: 'Kreita',
       lastActivity: 'Lasta aktiveco',
+    },
+    mc: {
+      noData: 'Neniu Magic Context-subagento disponeblas.',
+      states: {
+        busy: 'Rulas',
+        idle: 'Senokupa',
+        retry: 'Reprovas',
+      },
     },
     acp: {
       unavailable: 'VIS bridge ne estas disponebla.',

--- a/app/locales/ja.ts
+++ b/app/locales/ja.ts
@@ -287,6 +287,7 @@ const messages: LocaleMessages = {
       plugins: 'プラグイン',
       skills: 'スキル',
       token: 'Token',
+      mc: 'MC',
       acp: 'ACP',
       codex: 'Codex',
     },
@@ -357,6 +358,14 @@ const messages: LocaleMessages = {
       totalCost: '総コスト',
       createdTime: '作成日時',
       lastActivity: '最終活動',
+    },
+    mc: {
+      noData: 'Magic Context サブエージェントはありません。',
+      states: {
+        busy: '実行中',
+        idle: '待機中',
+        retry: '再試行中',
+      },
     },
     acp: {
       unavailable: 'VIS bridge を利用できません。',

--- a/app/locales/zh-CN.ts
+++ b/app/locales/zh-CN.ts
@@ -283,6 +283,7 @@ const messages: LocaleMessages = {
       plugins: '插件',
       skills: '技能',
       token: 'Token',
+      mc: 'MC',
       acp: 'ACP',
       codex: 'Codex',
     },
@@ -353,6 +354,14 @@ const messages: LocaleMessages = {
       totalCost: '总成本',
       createdTime: '创建时间',
       lastActivity: '最后活动',
+    },
+    mc: {
+      noData: '当前没有 Magic Context 子代理。',
+      states: {
+        busy: '运行中',
+        idle: '空闲',
+        retry: '重试中',
+      },
     },
     acp: {
       unavailable: 'VIS bridge 当前不可用。',

--- a/app/locales/zh-TW.ts
+++ b/app/locales/zh-TW.ts
@@ -283,6 +283,7 @@ const messages: LocaleMessages = {
       plugins: '外掛',
       skills: '技能',
       token: 'Token',
+      mc: 'MC',
       acp: 'ACP',
       codex: 'Codex',
     },
@@ -353,6 +354,14 @@ const messages: LocaleMessages = {
       totalCost: '總成本',
       createdTime: '建立時間',
       lastActivity: '最後活動',
+    },
+    mc: {
+      noData: '目前沒有 Magic Context 子代理。',
+      states: {
+        busy: '執行中',
+        idle: '閒置',
+        retry: '重試中',
+      },
     },
     acp: {
       unavailable: 'VIS bridge 目前無法使用。',

--- a/app/utils/pluginCompatibility.test.ts
+++ b/app/utils/pluginCompatibility.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ToolPart } from '../types/sse';
+import { extractFileRead } from './toolRenderers';
+import { resolveChildOwners, resolveThreadSubagentSessions } from './threadSubagents';
+import { isHistoryToolName } from './toolNames';
+import { collectMagicContextWorkers } from './pluginCompatibility';
+
+const PARENT_SESSION_ID = 'ses-parent';
+
+function makeTaskPart(
+  input: Record<string, unknown>,
+  metadata: Record<string, unknown>,
+): ToolPart {
+  return {
+    id: 'part-task',
+    messageID: 'msg-assistant',
+    sessionID: PARENT_SESSION_ID,
+    type: 'tool',
+    callID: 'call-task',
+    tool: 'task',
+    state: {
+      status: 'running',
+      input,
+      metadata,
+      time: { start: 1 },
+    },
+  };
+}
+
+const rendererHelpers = {
+  FILE_READ_EVENT_TYPES: new Set<string>(),
+  FILE_WRITE_EVENT_TYPES: new Set<string>(),
+  MESSAGE_EVENT_TYPES: new Set(['message.part.updated']),
+  parsePatchTextBlocks: () => [],
+  guessLanguage: () => 'text',
+  shouldRenderToolWindow: () => true,
+  extractToolOutputText: (value: unknown) => (typeof value === 'string' ? value : undefined),
+  formatToolValue: (value: unknown) => String(value ?? ''),
+  renderWorkerHtml: async () => '<pre>rendered</pre>',
+  renderReadHtmlFromApi: async () => '<pre>read</pre>',
+  resolveReadWritePath: () => '',
+  guessLanguageFromPath: () => 'text',
+  resolveReadRange: () => ({}),
+  renderEditDiffHtml: ({ diff }: { diff: string }) => diff,
+  formatGlobToolTitle: () => '',
+  formatListToolTitle: () => '',
+  formatWebfetchToolTitle: () => '',
+  formatQueryToolTitle: () => '',
+  formatTaskToolOutput: (value: string) => value,
+  GrepContent: {},
+  GlobContent: {},
+  WebContent: {},
+};
+
+describe('plugin subagent compatibility', () => {
+  it('labels category-routed workers as Sisyphus-Junior(category)', () => {
+    const task = makeTaskPart(
+      { category: 'visual-engineering' },
+      { sessionId: 'ses-category-worker' },
+    );
+
+    expect(
+      resolveThreadSubagentSessions([task], PARENT_SESSION_ID, {
+        'ses-category-worker': { parentID: PARENT_SESSION_ID, label: 'Sisyphus-Junior' },
+      }),
+    ).toEqual([
+      { sessionId: 'ses-category-worker', label: 'Sisyphus-Junior(visual-engineering)' },
+    ]);
+  });
+
+  it('excludes magic-context workers from exact and fallback thread cards', () => {
+    const exactTask = makeTaskPart({}, { sessionId: 'ses-mc-exact' });
+    const meta = {
+      'ses-mc-exact': { parentID: PARENT_SESSION_ID, label: 'magic-context-reviewer' },
+      'ses-mc-fallback': { parentID: PARENT_SESSION_ID, label: 'magic-context-historian' },
+    };
+
+    expect(resolveThreadSubagentSessions([exactTask], PARENT_SESSION_ID, meta)).toEqual([]);
+    expect(
+      resolveChildOwners(
+        [{ rootId: 'root', parts: [makeTaskPart({ description: 'other' }, {})] }],
+        PARENT_SESSION_ID,
+        meta,
+      ),
+    ).toEqual({});
+  });
+
+  it('collects canonical session states for the MC monitor', () => {
+    expect(
+      collectMagicContextWorkers({
+        regular: { label: 'Sisyphus-Junior', status: 'busy' },
+        idle: { label: 'magic-context-historian', status: 'idle' },
+        retry: { label: 'magic-context-recomp', status: 'retry' },
+        busy: { label: 'magic-context-reviewer', status: 'busy' },
+      }),
+    ).toEqual([
+      { sessionId: 'busy', name: 'magic-context-reviewer', status: 'busy' },
+      { sessionId: 'retry', name: 'magic-context-recomp', status: 'retry' },
+      { sessionId: 'idle', name: 'magic-context-historian', status: 'idle' },
+    ]);
+  });
+});
+
+describe.each([
+  'lsp_diagnostics',
+  'codegraph_codegraph_explore',
+  'ctx_search',
+])('plugin tool compatibility: %s', (tool) => {
+  it('keeps the tool available from thread history', () => {
+    expect(isHistoryToolName(tool)).toBe(true);
+  });
+
+  it('renders completed output in a generic floating window', async () => {
+    const result = extractFileRead(
+      {
+        payload: {
+          properties: {
+            part: {
+              type: 'tool',
+              callID: `call-${tool}`,
+              tool,
+              state: {
+                status: 'completed',
+                input: { query: 'status' },
+                output: 'plugin output',
+                metadata: {},
+              },
+            },
+          },
+        },
+      },
+      'message.part.updated',
+      rendererHelpers,
+      (key: string) => key,
+    );
+
+    expect(Array.isArray(result)).toBe(false);
+    if (!result || Array.isArray(result)) throw new Error('Expected plugin tool window');
+    expect(result).toMatchObject({ toolName: tool, toolStatus: 'completed', variant: 'plain' });
+    expect(result.title).toContain(tool);
+    expect(typeof result.content).toBe('function');
+    if (typeof result.content !== 'function') throw new Error('Expected rendered content');
+    await expect(result.content()).resolves.toBe('<pre>rendered</pre>');
+  });
+});

--- a/app/utils/pluginCompatibility.test.ts
+++ b/app/utils/pluginCompatibility.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ToolPart } from '../types/sse';
 import { extractFileRead } from './toolRenderers';
@@ -37,7 +37,7 @@ const rendererHelpers = {
   shouldRenderToolWindow: () => true,
   extractToolOutputText: (value: unknown) => (typeof value === 'string' ? value : undefined),
   formatToolValue: (value: unknown) => String(value ?? ''),
-  renderWorkerHtml: async () => '<pre>rendered</pre>',
+  renderWorkerHtml: vi.fn(async () => '<pre>rendered</pre>'),
   renderReadHtmlFromApi: async () => '<pre>read</pre>',
   resolveReadWritePath: () => '',
   guessLanguageFromPath: () => 'text',
@@ -54,18 +54,24 @@ const rendererHelpers = {
 };
 
 describe('plugin subagent compatibility', () => {
-  it('labels category-routed workers as Sisyphus-Junior(category)', () => {
+  it('preserves the task title while adding the category to Sisyphus-Junior', () => {
     const task = makeTaskPart(
-      { category: 'visual-engineering' },
+      { category: 'quick', description: 'Browser QA category worker' },
       { sessionId: 'ses-category-worker' },
     );
 
     expect(
       resolveThreadSubagentSessions([task], PARENT_SESSION_ID, {
-        'ses-category-worker': { parentID: PARENT_SESSION_ID, label: 'Sisyphus-Junior' },
+        'ses-category-worker': {
+          parentID: PARENT_SESSION_ID,
+          label: 'Browser QA category worker (@Sisyphus-Junior subagent)',
+        },
       }),
     ).toEqual([
-      { sessionId: 'ses-category-worker', label: 'Sisyphus-Junior(visual-engineering)' },
+      {
+        sessionId: 'ses-category-worker',
+        label: 'Browser QA category worker (@Sisyphus-Junior(quick) subagent)',
+      },
     ]);
   });
 
@@ -107,6 +113,10 @@ describe.each([
   'codegraph_codegraph_explore',
   'ctx_search',
 ])('plugin tool compatibility: %s', (tool) => {
+  beforeEach(() => {
+    vi.mocked(rendererHelpers.renderWorkerHtml).mockClear();
+  });
+
   it('keeps the tool available from thread history', () => {
     expect(isHistoryToolName(tool)).toBe(true);
   });
@@ -142,5 +152,8 @@ describe.each([
     expect(typeof result.content).toBe('function');
     if (typeof result.content !== 'function') throw new Error('Expected rendered content');
     await expect(result.content()).resolves.toBe('<pre>rendered</pre>');
+    expect(rendererHelpers.renderWorkerHtml).toHaveBeenCalledWith(
+      expect.objectContaining({ copyButtons: false }),
+    );
   });
 });

--- a/app/utils/pluginCompatibility.test.ts
+++ b/app/utils/pluginCompatibility.test.ts
@@ -75,6 +75,27 @@ describe('plugin subagent compatibility', () => {
     ]);
   });
 
+  it('updates only the final subagent marker when the title also mentions Sisyphus-Junior', () => {
+    const task = makeTaskPart(
+      { category: 'quick', description: 'Investigate Sisyphus-Junior failures' },
+      { sessionId: 'ses-category-worker' },
+    );
+
+    expect(
+      resolveThreadSubagentSessions([task], PARENT_SESSION_ID, {
+        'ses-category-worker': {
+          parentID: PARENT_SESSION_ID,
+          label: 'Investigate Sisyphus-Junior failures (@Sisyphus-Junior(old) subagent)',
+        },
+      }),
+    ).toEqual([
+      {
+        sessionId: 'ses-category-worker',
+        label: 'Investigate Sisyphus-Junior failures (@Sisyphus-Junior(quick) subagent)',
+      },
+    ]);
+  });
+
   it('excludes magic-context workers from exact and fallback thread cards', () => {
     const exactTask = makeTaskPart({}, { sessionId: 'ses-mc-exact' });
     const meta = {
@@ -92,14 +113,32 @@ describe('plugin subagent compatibility', () => {
     ).toEqual({});
   });
 
-  it('collects canonical session states for the MC monitor', () => {
+  it('collects known canonical states only from the selected root session', () => {
+    const meta = {
+      root: { label: 'Root session', status: 'idle' as const },
+      nestedParent: {
+        parentID: 'root',
+        label: 'Sisyphus-Junior',
+        status: 'idle' as const,
+      },
+      unknown: { parentID: 'root', label: 'magic-context-unknown' },
+      idle: { parentID: 'root', label: 'magic-context-historian', status: 'idle' as const },
+      retry: {
+        parentID: 'nestedParent',
+        label: 'magic-context-recomp',
+        status: 'retry' as const,
+      },
+      busy: { parentID: 'root', label: 'magic-context-reviewer', status: 'busy' as const },
+      otherRoot: { label: 'Other root', status: 'idle' as const },
+      unrelated: {
+        parentID: 'otherRoot',
+        label: 'magic-context-unrelated',
+        status: 'busy' as const,
+      },
+    };
+
     expect(
-      collectMagicContextWorkers({
-        regular: { label: 'Sisyphus-Junior', status: 'busy' },
-        idle: { label: 'magic-context-historian', status: 'idle' },
-        retry: { label: 'magic-context-recomp', status: 'retry' },
-        busy: { label: 'magic-context-reviewer', status: 'busy' },
-      }),
+      collectMagicContextWorkers(meta, 'root'),
     ).toEqual([
       { sessionId: 'busy', name: 'magic-context-reviewer', status: 'busy' },
       { sessionId: 'retry', name: 'magic-context-recomp', status: 'retry' },

--- a/app/utils/pluginCompatibility.test.ts
+++ b/app/utils/pluginCompatibility.test.ts
@@ -115,22 +115,49 @@ describe('plugin subagent compatibility', () => {
 
   it('collects known canonical states only from the selected root session', () => {
     const meta = {
-      root: { label: 'Root session', status: 'idle' as const },
+      root: { projectId: 'project-a', label: 'Root session', status: 'idle' as const },
       nestedParent: {
+        projectId: 'project-a',
         parentID: 'root',
         label: 'Sisyphus-Junior',
         status: 'idle' as const,
       },
-      unknown: { parentID: 'root', label: 'magic-context-unknown' },
-      idle: { parentID: 'root', label: 'magic-context-historian', status: 'idle' as const },
+      unknown: {
+        projectId: 'project-a',
+        parentID: 'root',
+        label: 'magic-context-unknown',
+      },
+      idle: {
+        projectId: 'project-a',
+        parentID: 'root',
+        label: 'magic-context-historian',
+        status: 'idle' as const,
+      },
       retry: {
+        projectId: 'project-a',
         parentID: 'nestedParent',
         label: 'magic-context-recomp',
         status: 'retry' as const,
       },
-      busy: { parentID: 'root', label: 'magic-context-reviewer', status: 'busy' as const },
-      otherRoot: { label: 'Other root', status: 'idle' as const },
+      busy: {
+        projectId: 'project-a',
+        parentID: 'root',
+        label: 'magic-context-reviewer',
+        status: 'busy' as const,
+      },
+      forgedCrossProject: {
+        projectId: 'project-b',
+        parentID: 'root',
+        label: 'magic-context-forged',
+        status: 'busy' as const,
+      },
+      otherRoot: {
+        projectId: 'project-b',
+        label: 'Other root',
+        status: 'idle' as const,
+      },
       unrelated: {
+        projectId: 'project-b',
         parentID: 'otherRoot',
         label: 'magic-context-unrelated',
         status: 'busy' as const,
@@ -138,7 +165,7 @@ describe('plugin subagent compatibility', () => {
     };
 
     expect(
-      collectMagicContextWorkers(meta, 'root'),
+      collectMagicContextWorkers(meta, 'root', 'project-a'),
     ).toEqual([
       { sessionId: 'busy', name: 'magic-context-reviewer', status: 'busy' },
       { sessionId: 'retry', name: 'magic-context-recomp', status: 'retry' },

--- a/app/utils/pluginCompatibility.ts
+++ b/app/utils/pluginCompatibility.ts
@@ -1,0 +1,59 @@
+import type { ToolPart } from '../types/sse';
+import type { SessionState } from '../types/worker-state';
+
+const PLUGIN_TOOL_PREFIXES = [
+  'lsp_',
+  'lsp-',
+  'codegraph_',
+  'codegraph-',
+  'ctx_',
+  'ctx-',
+] as const;
+
+const MAGIC_CONTEXT_PREFIX = 'magic-context-';
+
+export type MagicContextWorker = {
+  readonly sessionId: string;
+  readonly name: string;
+  readonly status: NonNullable<SessionState['status']>;
+};
+
+export function isPluginToolName(tool: string): boolean {
+  const normalized = tool.trim().toLocaleLowerCase();
+  return PLUGIN_TOOL_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+export function isMagicContextWorkerName(name: string): boolean {
+  return name.trim().toLocaleLowerCase().startsWith(MAGIC_CONTEXT_PREFIX);
+}
+
+export function resolveTaskWorkerLabel(part: ToolPart, fallback: string): string {
+  const category = part.state.input?.category;
+  return typeof category === 'string' && category.trim()
+    ? `Sisyphus-Junior(${category.trim()})`
+    : fallback;
+}
+
+export function collectMagicContextWorkers(
+  metaById: Record<
+    string,
+    { readonly label: string; readonly status?: SessionState['status'] }
+  >,
+): MagicContextWorker[] {
+  const priority: Record<MagicContextWorker['status'], number> = {
+    busy: 0,
+    retry: 1,
+    idle: 2,
+  };
+  return Object.entries(metaById)
+    .filter(([, meta]) => isMagicContextWorkerName(meta.label))
+    .map(([sessionId, meta]) => ({
+      sessionId,
+      name: meta.label,
+      status: meta.status ?? 'idle',
+    }))
+    .sort(
+      (left, right) =>
+        priority[left.status] - priority[right.status] || left.name.localeCompare(right.name),
+    );
+}

--- a/app/utils/pluginCompatibility.ts
+++ b/app/utils/pluginCompatibility.ts
@@ -31,8 +31,11 @@ export function resolveTaskWorkerLabel(part: ToolPart, fallback: string): string
   const category = part.state.input?.category;
   if (typeof category !== 'string' || !category.trim()) return fallback;
   const workerLabel = `Sisyphus-Junior(${category.trim()})`;
-  const existingWorkerLabel = /Sisyphus-Junior/i.exec(fallback)?.[0];
-  if (existingWorkerLabel) return fallback.replace(existingWorkerLabel, workerLabel);
+  const subagentMarker = /(@)Sisyphus-Junior(?:\([^)]*\))?(?=\s+subagent\)\s*$)/i;
+  if (subagentMarker.test(fallback)) {
+    return fallback.replace(subagentMarker, `$1${workerLabel}`);
+  }
+  if (/^Sisyphus-Junior(?:\([^)]*\))?$/i.test(fallback.trim())) return workerLabel;
   const childSessionId = 'metadata' in part.state ? part.state.metadata?.sessionId : undefined;
   if (typeof childSessionId === 'string' && fallback.trim() === childSessionId.trim()) {
     return workerLabel;
@@ -43,21 +46,33 @@ export function resolveTaskWorkerLabel(part: ToolPart, fallback: string): string
 export function collectMagicContextWorkers(
   metaById: Record<
     string,
-    { readonly label: string; readonly status?: SessionState['status'] }
+    {
+      readonly parentID?: string;
+      readonly label: string;
+      readonly status?: SessionState['status'];
+    }
   >,
+  rootSessionId: string,
 ): MagicContextWorker[] {
+  const rootId = rootSessionId.trim();
+  if (!rootId) return [];
   const priority: Record<MagicContextWorker['status'], number> = {
     busy: 0,
     retry: 1,
     idle: 2,
   };
   return Object.entries(metaById)
-    .filter(([, meta]) => isMagicContextWorkerName(meta.label))
-    .map(([sessionId, meta]) => ({
-      sessionId,
-      name: meta.label,
-      status: meta.status ?? 'idle',
-    }))
+    .flatMap(([sessionId, meta]) => {
+      if (!isMagicContextWorkerName(meta.label) || !meta.status) return [];
+      const visited = new Set([sessionId]);
+      let ancestorId = meta.parentID;
+      while (ancestorId && ancestorId !== rootId && !visited.has(ancestorId)) {
+        visited.add(ancestorId);
+        ancestorId = metaById[ancestorId]?.parentID;
+      }
+      if (sessionId !== rootId && ancestorId !== rootId) return [];
+      return [{ sessionId, name: meta.label, status: meta.status }];
+    })
     .sort(
       (left, right) =>
         priority[left.status] - priority[right.status] || left.name.localeCompare(right.name),

--- a/app/utils/pluginCompatibility.ts
+++ b/app/utils/pluginCompatibility.ts
@@ -47,15 +47,24 @@ export function collectMagicContextWorkers(
   metaById: Record<
     string,
     {
+      readonly projectId?: string;
       readonly parentID?: string;
       readonly label: string;
       readonly status?: SessionState['status'];
     }
   >,
   rootSessionId: string,
+  projectId: string,
 ): MagicContextWorker[] {
   const rootId = rootSessionId.trim();
-  if (!rootId) return [];
+  const selectedProjectId = projectId.trim();
+  if (
+    !rootId ||
+    !selectedProjectId ||
+    metaById[rootId]?.projectId !== selectedProjectId
+  ) {
+    return [];
+  }
   const priority: Record<MagicContextWorker['status'], number> = {
     busy: 0,
     retry: 1,
@@ -63,12 +72,20 @@ export function collectMagicContextWorkers(
   };
   return Object.entries(metaById)
     .flatMap(([sessionId, meta]) => {
-      if (!isMagicContextWorkerName(meta.label) || !meta.status) return [];
+      if (
+        meta.projectId !== selectedProjectId ||
+        !isMagicContextWorkerName(meta.label) ||
+        !meta.status
+      ) {
+        return [];
+      }
       const visited = new Set([sessionId]);
       let ancestorId = meta.parentID;
       while (ancestorId && ancestorId !== rootId && !visited.has(ancestorId)) {
         visited.add(ancestorId);
-        ancestorId = metaById[ancestorId]?.parentID;
+        const ancestor = metaById[ancestorId];
+        if (ancestor?.projectId !== selectedProjectId) return [];
+        ancestorId = ancestor.parentID;
       }
       if (sessionId !== rootId && ancestorId !== rootId) return [];
       return [{ sessionId, name: meta.label, status: meta.status }];

--- a/app/utils/pluginCompatibility.ts
+++ b/app/utils/pluginCompatibility.ts
@@ -29,9 +29,15 @@ export function isMagicContextWorkerName(name: string): boolean {
 
 export function resolveTaskWorkerLabel(part: ToolPart, fallback: string): string {
   const category = part.state.input?.category;
-  return typeof category === 'string' && category.trim()
-    ? `Sisyphus-Junior(${category.trim()})`
-    : fallback;
+  if (typeof category !== 'string' || !category.trim()) return fallback;
+  const workerLabel = `Sisyphus-Junior(${category.trim()})`;
+  const existingWorkerLabel = /Sisyphus-Junior/i.exec(fallback)?.[0];
+  if (existingWorkerLabel) return fallback.replace(existingWorkerLabel, workerLabel);
+  const childSessionId = 'metadata' in part.state ? part.state.metadata?.sessionId : undefined;
+  if (typeof childSessionId === 'string' && fallback.trim() === childSessionId.trim()) {
+    return workerLabel;
+  }
+  return fallback.trim() ? `${fallback.trim()} (${workerLabel})` : workerLabel;
 }
 
 export function collectMagicContextWorkers(

--- a/app/utils/threadSubagents.ts
+++ b/app/utils/threadSubagents.ts
@@ -1,5 +1,9 @@
 import type { MessagePart } from '../types/sse';
 import type { SessionState } from '../types/worker-state';
+import {
+  isMagicContextWorkerName,
+  resolveTaskWorkerLabel,
+} from './pluginCompatibility';
 
 export type ThreadSubagentSession = { sessionId: string; label: string };
 export type ThreadParts = { rootId: string; parts: MessagePart[] };
@@ -33,7 +37,9 @@ export function resolveThreadSubagentSessions(
     if (!childId) continue;
     const meta = metaById?.[childId];
     if (meta && meta.parentID !== sessionId) continue;
-    if (!seen.has(childId)) seen.set(childId, meta?.label || childId);
+    const fallbackLabel = meta?.label || childId;
+    if (isMagicContextWorkerName(fallbackLabel)) continue;
+    if (!seen.has(childId)) seen.set(childId, resolveTaskWorkerLabel(part, fallbackLabel));
   }
   return Array.from(seen.entries()).map(([sessionId, label]) => ({ sessionId, label }));
 }
@@ -71,7 +77,11 @@ export function resolveChildOwners(
   const byRoot: Record<string, string[]> = {};
   const assignedIds = new Set<string>();
   Object.entries(metaById).forEach(([sessionId, meta]) => {
-    if (meta.parentID !== currentSessionId || exactIds.has(sessionId)) return;
+    if (
+      meta.parentID !== currentSessionId
+      || exactIds.has(sessionId)
+      || isMagicContextWorkerName(meta.label)
+    ) return;
     const owners = ownersByDescription.get(meta.label.trim().toLocaleLowerCase());
     if (owners?.size !== 1) return;
     const ownerRootId = [...owners][0];
@@ -84,7 +94,8 @@ export function resolveChildOwners(
       if (
         meta.parentID !== currentSessionId ||
         exactIds.has(sessionId) ||
-        assignedIds.has(sessionId)
+        assignedIds.has(sessionId) ||
+        isMagicContextWorkerName(meta.label)
       ) {
         return;
       }

--- a/app/utils/toolNames.ts
+++ b/app/utils/toolNames.ts
@@ -1,3 +1,5 @@
+import { isPluginToolName } from './pluginCompatibility';
+
 const WEBSEARCH_TOOL_ALIASES = new Set(['websearch', 'websearch_web_search_exa']);
 
 const HISTORY_TOOL_NAMES = new Set([
@@ -19,5 +21,5 @@ export function normalizeToolName(tool: string): string {
 }
 
 export function isHistoryToolName(tool: string): boolean {
-  return HISTORY_TOOL_NAMES.has(normalizeToolName(tool));
+  return isPluginToolName(tool) || HISTORY_TOOL_NAMES.has(normalizeToolName(tool));
 }

--- a/app/utils/toolRenderers.test.ts
+++ b/app/utils/toolRenderers.test.ts
@@ -430,6 +430,65 @@ describe('extractFileRead for edit/multiedit', () => {
     });
   });
 
+  it('uses distinct render request IDs for concurrent plugin tool updates', async () => {
+    const requests: Record<string, unknown>[] = [];
+    const resolvers: Array<(html: string) => void> = [];
+    const helpersWithDeferredRender = {
+      ...helpers,
+      renderWorkerHtml: (args: Record<string, unknown>) => {
+        requests.push(args);
+        return new Promise<string>((resolve) => resolvers.push(resolve));
+      },
+    };
+    const payload = (status: 'running' | 'completed', output: string) => ({
+      payload: {
+        properties: {
+          part: {
+            type: 'tool',
+            id: 'ctx-update-1',
+            callID: 'ctx-update-1',
+            tool: 'ctx_search',
+            state: {
+              status,
+              input: { query: 'plugin compatibility' },
+              output,
+              metadata: {},
+            },
+          },
+        },
+      },
+    });
+
+    const running = extractFileRead(
+      payload('running', 'partial'),
+      'message.part.updated',
+      helpersWithDeferredRender,
+      (key: string) => key,
+    );
+    const completed = extractFileRead(
+      payload('completed', 'final'),
+      'message.part.updated',
+      helpersWithDeferredRender,
+      (key: string) => key,
+    );
+    if (!running || Array.isArray(running) || typeof running.content !== 'function') {
+      throw new Error('Expected running plugin renderer');
+    }
+    if (!completed || Array.isArray(completed) || typeof completed.content !== 'function') {
+      throw new Error('Expected completed plugin renderer');
+    }
+
+    const runningHtml = running.content();
+    const completedHtml = completed.content();
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.id).not.toBe(requests[1]?.id);
+
+    resolvers[0]?.('<p>partial</p>');
+    resolvers[1]?.('<p>final</p>');
+    await expect(runningHtml).resolves.toBe('<p>partial</p>');
+    await expect(completedHtml).resolves.toBe('<p>final</p>');
+  });
+
   it('renders webfetch markdown without copy-button chrome labels in the payload', async () => {
     let receivedArgs: Record<string, unknown> | null = null;
     const helpersWithCapture = {

--- a/app/utils/toolRenderers.ts
+++ b/app/utils/toolRenderers.ts
@@ -81,6 +81,13 @@ function toolEmoji(tool: string): string {
 
 type TranslateFunction = (key: string) => string;
 
+let pluginRenderRequestSequence = 0;
+
+function nextPluginRenderRequestId(callId?: string): string {
+  pluginRenderRequestSequence += 1;
+  return `plugin-${callId ?? 'tool'}-${pluginRenderRequestSequence.toString(36)}`;
+}
+
 function toolPrefix(tool: string, labelKey: string, t: TranslateFunction, detail?: string): string {
   const icon = toolEmoji(tool);
   const label = t(labelKey);
@@ -295,7 +302,7 @@ export function extractFileRead(
       return {
         content: () =>
           helpers.renderWorkerHtml({
-            id: `plugin-${callId ?? Date.now().toString(36)}`,
+            id: nextPluginRenderRequestId(callId),
             code: pluginCode,
             lang: 'markdown',
             theme: 'github-dark',

--- a/app/utils/toolRenderers.ts
+++ b/app/utils/toolRenderers.ts
@@ -1,4 +1,5 @@
 import { normalizeToolName } from './toolNames';
+import { isPluginToolName } from './pluginCompatibility';
 
 export function extractXmlTagContent(text: string, tag: string): string | null {
   const open = `<${tag}>`;
@@ -287,6 +288,25 @@ export function extractFileRead(
         : stateError !== undefined
           ? helpers.formatToolValue(stateError)
           : undefined;
+
+    if (isPluginToolName(rawTool)) {
+      const pluginCode = outputText ?? errorText ?? '';
+      return {
+        content: () =>
+          helpers.renderWorkerHtml({
+            id: `plugin-${callId ?? Date.now().toString(36)}`,
+            code: pluginCode,
+            lang: 'markdown',
+            theme: 'github-dark',
+            gutterMode: 'none',
+          }),
+        variant: 'plain' as const,
+        callId,
+        toolName: rawTool,
+        toolStatus: status,
+        title: toolPrefix(rawTool, 'floatingWindow.tool', t, rawTool),
+      };
+    }
 
     switch (tool) {
       case 'bash': {

--- a/app/utils/toolRenderers.ts
+++ b/app/utils/toolRenderers.ts
@@ -34,6 +34,7 @@ export type ToolRenderersHelpers = {
     copiedLabel?: string;
     copyCodeAriaLabel?: string;
     copyMarkdownAriaLabel?: string;
+    copyButtons?: boolean;
   }) => Promise<string>;
   renderReadHtmlFromApi: (args: {
     callId?: string;
@@ -299,6 +300,7 @@ export function extractFileRead(
             lang: 'markdown',
             theme: 'github-dark',
             gutterMode: 'none',
+            copyButtons: false,
           }),
         variant: 'plain' as const,
         callId,

--- a/app/utils/workerRenderer.test.ts
+++ b/app/utils/workerRenderer.test.ts
@@ -191,6 +191,43 @@ describe('single-shot regression', () => {
     expect(poolWorker.posted).toHaveLength(1);
   });
 
+  it('separates cached Markdown renders with and without copy controls', async () => {
+    const mod = await import('../utils/workerRenderer');
+    const request = {
+      id: 'copy-controls-on',
+      code: '# Result',
+      lang: 'markdown',
+      theme: 'github-dark',
+    };
+
+    const withControls = mod.renderWorkerHtml(request);
+    const poolWorker = workerState.FakeWorker.instances[0];
+    if (!poolWorker) throw new Error('no pool worker');
+    poolWorker.emit({ id: request.id, ok: true, html: '<button>COPY</button>' });
+    await expect(withControls).resolves.toBe('<button>COPY</button>');
+
+    const withoutControls = mod.renderWorkerHtml({
+      ...request,
+      id: 'copy-controls-off',
+      copyButtons: false,
+    });
+    const posted = workerState.FakeWorker.instances.flatMap((worker) => worker.posted);
+    expect(posted).toHaveLength(2);
+    expect(posted[1]).toMatchObject({ copyButtons: false });
+    const secondWorker = workerState.FakeWorker.instances.find((worker) =>
+      worker.posted.some(
+        (message) =>
+          typeof message === 'object' &&
+          message !== null &&
+          'id' in message &&
+          message.id === 'copy-controls-off',
+      ),
+    );
+    if (!secondWorker) throw new Error('copy-controls-off request was not posted');
+    secondWorker.emit({ id: 'copy-controls-off', ok: true, html: '<h1>Result</h1>' });
+    await expect(withoutControls).resolves.toBe('<h1>Result</h1>');
+  });
+
   it('renderWorkerHtml rejects when the pool worker reports an error', async () => {
     // Given: a single-shot request in flight
     const mod = await import('../utils/workerRenderer');

--- a/app/utils/workerRenderer.ts
+++ b/app/utils/workerRenderer.ts
@@ -30,6 +30,7 @@ export type RenderRequest = {
   copiedLabel?: string;
   copyCodeAriaLabel?: string;
   copyMarkdownAriaLabel?: string;
+  copyButtons?: boolean;
   errorLabel?: string;
 };
 
@@ -83,6 +84,7 @@ function getCacheKey(payload: RenderRequest) {
     payload.copiedLabel ?? '',
     payload.copyCodeAriaLabel ?? '',
     payload.copyMarkdownAriaLabel ?? '',
+    String(payload.copyButtons ?? true),
   ].join('\u0000');
 }
 

--- a/app/workers/render-worker.test.ts
+++ b/app/workers/render-worker.test.ts
@@ -15,6 +15,7 @@ type RenderPayload = {
   lang: string;
   theme: string;
   gutterMode: 'none';
+  copyButtons?: boolean;
 };
 
 type WorkerHarness = {
@@ -34,7 +35,9 @@ function request(id: string, theme: string): RenderPayload {
   };
 }
 
-async function startWorker(moduleSuffix: 'dark-baseline' | 'light-baseline' | 'overlap') {
+async function startWorker(
+  moduleSuffix: 'dark-baseline' | 'light-baseline' | 'overlap' | 'copy-controls',
+) {
   const messages: WorkerResponse['data'][] = [];
   const waiters = new Map<string, (message: WorkerResponse['data']) => void>();
   const worker: WorkerHarness = {
@@ -85,5 +88,20 @@ describe('render worker theme isolation', () => {
     // Then: each response has the colors selected by its request's theme
     expect(darkHtml).toBe(darkAlone);
     expect(lightHtml).toBe(lightAlone);
+  });
+
+  it('omits markdown copy controls when the caller disables them', async () => {
+    const { render } = await startWorker('copy-controls');
+    const html = await render({
+      ...request('without-copy-controls', 'github-dark'),
+      code: '# Result\n\n```text\noutput\n```',
+      lang: 'markdown',
+      copyButtons: false,
+    });
+
+    expect(html).toContain('Result');
+    expect(html).not.toContain('md-copy-btn');
+    expect(html).not.toContain('COPY');
+    expect(html).not.toContain('Copied');
   });
 });

--- a/app/workers/render-worker.ts
+++ b/app/workers/render-worker.ts
@@ -35,6 +35,7 @@ type RenderRequest = {
   copiedLabel?: string;
   copyCodeAriaLabel?: string;
   copyMarkdownAriaLabel?: string;
+  copyButtons?: boolean;
 };
 
 type RenderResponse =
@@ -925,6 +926,10 @@ async function renderMarkdownHtml(request: RenderRequest): Promise<string> {
   const env: MarkdownRenderEnv = {};
   if (request.files?.length) env.fileSet = new Set(request.files);
   const rendered = md.render(request.code, env);
+
+  if (request.copyButtons === false) {
+    return `<div class="markdown-host">${rendered}</div>`;
+  }
 
   // Use localized strings or defaults
   const copyButtonLabel = request.copyButtonLabel ?? 'COPY';


### PR DESCRIPTION
## Summary
- preserve full subagent task titles while displaying `Sisyphus-Junior(category)`
- add floating/history Markdown windows for `lsp-*`, `codegraph-*`, and `ctx-*` tools without injected copy controls
- move `magic-context-*` workers from thread cards into Status Monitor → MC, scoped to the selected project/root and canonical known status
- retain the original single-row horizontal Status Monitor scrollbar
- isolate concurrent plugin render requests so running/completed updates cannot cross-deliver stale output

## Verification
- `pnpm lint`
- `pnpm test -- --run` (1212 passed, 2 skipped)
- `pnpm build`
- real Chromium QA against the live OpenCode backend: complete titles, all three tool families, zero Markdown copy controls, MC scoping/empty state, and single-row tab scrolling
- five-lane final review: goal contract, browser QA, code quality, security, repository context — all PASS at `9306ffe66`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Magic Context worker status tab and plugin tool compatibility to Status Monitor
> - Adds an "MC" tab to [StatusMonitorModal.vue](https://github.com/qiyuanhuakai/opencode-visualizer-cn/pull/104/files#diff-d98dee0c30c538c1fc154283c71aff127ed5e1a258299f18ab3b3189e901fe50) displaying Magic Context workers scoped to the selected session/project, with localized Running/Idle/Retrying status indicators.
> - Introduces `collectMagicContextWorkers` and `isMagicContextWorkerName` in [pluginCompatibility.ts](https://github.com/qiyuanhuakai/opencode-visualizer-cn/pull/104/files#diff-5e4c0ec53c9c1be61bab6a3aaf8193e78f0e203357895a7b0cd07a441510be3b) to collect, filter, and sort Magic Context workers; excludes them from thread subagent detection in [threadSubagents.ts](https://github.com/qiyuanhuakai/opencode-visualizer-cn/pull/104/files#diff-77442951f7d6fb7f3797c7bbd790fa4f27d3052c2094d3de91076dbeb4faa0c6).
> - Plugin-prefixed tools (`lsp_*`, `codegraph_*`, `ctx_*`) now always render a floating tool window with markdown output and no copy controls, using unique render request IDs to prevent cache collisions.
> - Extends `isHistoryToolName` in [toolNames.ts](https://github.com/qiyuanhuakai/opencode-visualizer-cn/pull/104/files#diff-b4bd308b52a19cd8e8ce3cb6184b1901757e983e348ec0c3de421b4a70b7e581) to treat plugin tools as history-visible.
> - Behavioral Change: `RenderRequest` cache key now includes the `copyButtons` flag; cached renders with and without copy controls are stored separately.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9306ffe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->