### PR TITLE
feat(settings): add sidebar font sizing

### DIFF
--- a/app/App.vue
+++ b/app/App.vue
@@ -767,6 +767,7 @@ const {
   terminalFontSizePx,
   appFontSizePx,
   messageFontSizePx,
+  sidebarFontSizePx,
   uiFontSizePx,
   localApplicationPath,
 } = useSettings();
@@ -4128,6 +4129,7 @@ function syncAppMonospaceMetrics() {
     app.style.setProperty('--app-monospace-font-family', appMonospaceFontFamily.value);
     app.style.setProperty('--app-monospace-font-size', `${appFontSizePx.value}px`);
     app.style.setProperty('--message-font-size', `${messageFontSizePx.value}px`);
+    app.style.setProperty('--sidebar-font-size', `${sidebarFontSizePx.value}px`);
     app.style.setProperty('--ui-font-size', `${uiFontSizePx.value}px`);
   }
   if (typeof document !== 'undefined') {
@@ -4142,6 +4144,10 @@ function syncAppMonospaceMetrics() {
     document.documentElement.style.setProperty(
       '--message-font-size',
       `${messageFontSizePx.value}px`,
+    );
+    document.documentElement.style.setProperty(
+      '--sidebar-font-size',
+      `${sidebarFontSizePx.value}px`,
     );
     document.documentElement.style.setProperty('--ui-font-size', `${uiFontSizePx.value}px`);
   }
@@ -7149,6 +7155,14 @@ watch(
 
 watch(
   messageFontSizePx,
+  () => {
+    syncAppMonospaceMetrics();
+  },
+  { immediate: true },
+);
+
+watch(
+  sidebarFontSizePx,
   () => {
     syncAppMonospaceMetrics();
   },

--- a/app/components/SessionTree.vue
+++ b/app/components/SessionTree.vue
@@ -327,7 +327,7 @@ function sessionStatusIcon(status: 'busy' | 'idle' | 'retry' | 'unknown'): strin
 .session-tree-label {
   flex: 1;
   min-width: 0;
-  font-size: 12px;
+  font-size: var(--sidebar-font-size, 12px);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/app/components/SettingsModal.vue
+++ b/app/components/SettingsModal.vue
@@ -557,6 +557,23 @@
                 <div class="setting-description" style="margin-top: 2px;">{{ $t('settings.messageFontSizePx.description') }}</div>
               </div>
               <div class="font-setting-section">
+                <label :for="sidebarSizeInputId" class="font-setting-section-label">{{ $t('settings.sidebarFontSizePx.label') }}</label>
+                <div class="number-setting-group">
+                  <input
+                    :id="sidebarSizeInputId"
+                    v-model.number="sidebarFontSizePx"
+                    type="number"
+                    class="number-input"
+                    :min="minSidebarFontSizePx"
+                    :max="maxSidebarFontSizePx"
+                    step="1"
+                    @blur="clampSidebarFontSize"
+                    @keydown.enter="clampSidebarFontSize"
+                  />
+                </div>
+                <div class="setting-description" style="margin-top: 2px;">{{ $t('settings.sidebarFontSizePx.description') }}</div>
+              </div>
+              <div class="font-setting-section">
                 <label :for="uiSizeInputId" class="font-setting-section-label">{{ $t('settings.uiFontSizePx.label') }}</label>
                 <div class="number-setting-group">
                   <input
@@ -772,6 +789,7 @@ const appInputLabelId = 'settings-app-font-input-label';
 const appTextareaId = 'settings-app-font-input';
 const appSizeInputId = 'settings-app-font-size';
 const messageSizeInputId = 'settings-message-font-size';
+const sidebarSizeInputId = 'settings-sidebar-font-size';
 const uiSizeInputId = 'settings-ui-font-size';
 const supportsLocalFontsApi = supportsLocalFontAccess();
 const isLoadingLocalFonts = ref(false);
@@ -796,6 +814,7 @@ const {
   terminalFontSizePx,
   appFontSizePx,
   messageFontSizePx,
+  sidebarFontSizePx,
   uiFontSizePx,
   themeStorage,
   externalThemes,
@@ -807,6 +826,8 @@ const {
   maxAppFontSizePx,
   minMessageFontSizePx,
   maxMessageFontSizePx,
+  minSidebarFontSizePx,
+  maxSidebarFontSizePx,
   minUiFontSizePx,
   maxUiFontSizePx,
   showOpenInEditorButton,
@@ -1097,6 +1118,13 @@ function clampMessageFontSize() {
   messageFontSizePx.value = Math.max(
     minMessageFontSizePx,
     Math.min(maxMessageFontSizePx, messageFontSizePx.value),
+  );
+}
+
+function clampSidebarFontSize() {
+  sidebarFontSizePx.value = Math.max(
+    minSidebarFontSizePx,
+    Math.min(maxSidebarFontSizePx, sidebarFontSizePx.value),
   );
 }
 

--- a/app/components/SidePanel.vue
+++ b/app/components/SidePanel.vue
@@ -255,7 +255,7 @@ const {
   border-radius: 6px;
   background: var(--theme-tab-bg, var(--theme-side-bg, rgba(15, 23, 42, 0.7)));
   color: var(--theme-tab-text, var(--theme-side-text, #94a3b8));
-  font-size: 11px;
+  font-size: var(--sidebar-font-size, 12px);
   font-weight: 600;
   letter-spacing: 0.08em;
   padding: 5px 0;
@@ -289,7 +289,7 @@ const {
 }
 
 .session-title {
-  font-size: var(--ui-font-size, 12px);
+  font-size: var(--sidebar-font-size, 12px);
   font-weight: 700;
   letter-spacing: 0.08em;
   color: var(--theme-side-text, #e2e8f0);

--- a/app/components/TodoList.vue
+++ b/app/components/TodoList.vue
@@ -96,7 +96,7 @@ function priorityLabel(priority: string): string {
 }
 
 .todo-title {
-  font-size: 12px;
+  font-size: var(--sidebar-font-size, 12px);
   font-weight: 700;
   letter-spacing: 0.08em;
   color: var(--theme-side-text, #e2e8f0);
@@ -209,6 +209,7 @@ function priorityLabel(priority: string): string {
 .todo-text {
   flex: 1;
   min-width: 0;
+  font-size: var(--sidebar-font-size, 12px);
   overflow-wrap: anywhere;
 }
 

--- a/app/components/TreeView.vue
+++ b/app/components/TreeView.vue
@@ -1196,6 +1196,7 @@ function onRowDoubleClick(row: VirtualRow) {
 
 <style scoped>
 .tree-view {
+  --tree-icon-size: clamp(18px, calc(var(--sidebar-font-size, 12px) + 6px), 20px);
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -1651,21 +1652,21 @@ function onRowDoubleClick(row: VirtualRow) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  flex: 0 0 16px;
-  width: 16px;
-  height: 16px;
+  flex: 0 0 var(--tree-icon-size);
+  width: var(--tree-icon-size);
+  height: var(--tree-icon-size);
 }
 
 .tree-icon :deep(svg) {
   display: block;
-  width: 16px;
-  height: 16px;
+  width: var(--tree-icon-size);
+  height: var(--tree-icon-size);
 }
 
 .tree-name {
   flex: 1;
   min-width: 0;
-  font-size: 12px;
+  font-size: var(--sidebar-font-size, 12px);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/app/composables/useSettings.test.ts
+++ b/app/composables/useSettings.test.ts
@@ -53,6 +53,7 @@ describe('useSettings', () => {
     expect(settings.appMonospaceFontFamily.value).toBe(settings.defaultAppMonospaceFontFamily);
     expect(settings.terminalFontSizePx.value).toBe(13);
     expect(settings.appFontSizePx.value).toBe(13);
+    expect(settings.sidebarFontSizePx.value).toBe(12);
     expect(settings.editorFontSizePx.value).toBeNull();
     expect(settings.editorTabSize.value).toBe(2);
     expect(settings.editorShortcuts.value.indent).toBe('Tab');
@@ -319,6 +320,25 @@ describe('useSettings', () => {
     expect(settings.appFontSizePx.value).toBe(12);
   });
 
+  it('persists and synchronizes sidebar font size independently from general UI text', async () => {
+    storage.setItem('opencode.settings.sidebarFontSizePx.v1', '14');
+    const settings = await importFresh();
+
+    expect(settings.sidebarFontSizePx.value).toBe(14);
+    expect(settings.uiFontSizePx.value).toBe(12);
+
+    settings.sidebarFontSizePx.value = 16;
+    expect(storage.getItem('opencode.settings.sidebarFontSizePx.v1')).toBe('16');
+
+    const event = {
+      key: 'opencode.settings.sidebarFontSizePx.v1',
+      newValue: '99',
+    } as unknown as StorageEvent;
+    for (const listener of storageListeners) listener(event);
+
+    expect(settings.sidebarFontSizePx.value).toBe(20);
+    expect(settings.uiFontSizePx.value).toBe(12);
+  });
 
   it('uses default font sizes when storage event clears the keys', async () => {
     const settings = await importFresh();
@@ -330,10 +350,16 @@ describe('useSettings', () => {
       key: 'opencode.settings.appFontSizePx.v1',
       newValue: null,
     } as unknown as StorageEvent;
+    const sidebarEvent = {
+      key: 'opencode.settings.sidebarFontSizePx.v1',
+      newValue: null,
+    } as unknown as StorageEvent;
     for (const listener of storageListeners) listener(terminalEvent);
     for (const listener of storageListeners) listener(appEvent);
+    for (const listener of storageListeners) listener(sidebarEvent);
     expect(settings.terminalFontSizePx.value).toBe(13);
     expect(settings.appFontSizePx.value).toBe(13);
+    expect(settings.sidebarFontSizePx.value).toBe(12);
   });
 
   it('persists and syncs external themes', async () => {

--- a/app/composables/useSettings.ts
+++ b/app/composables/useSettings.ts
@@ -31,6 +31,9 @@ const MAX_APP_FONT_SIZE_PX = 20;
 const DEFAULT_MESSAGE_FONT_SIZE_PX = 13;
 const MIN_MESSAGE_FONT_SIZE_PX = 10;
 const MAX_MESSAGE_FONT_SIZE_PX = 20;
+const DEFAULT_SIDEBAR_FONT_SIZE_PX = 12;
+const MIN_SIDEBAR_FONT_SIZE_PX = 10;
+const MAX_SIDEBAR_FONT_SIZE_PX = 20;
 const DEFAULT_UI_FONT_SIZE_PX = 12;
 const MIN_UI_FONT_SIZE_PX = 10;
 const MAX_UI_FONT_SIZE_PX = 16;
@@ -96,6 +99,14 @@ function normalizeMessageFontSizePx(value: unknown) {
   return rounded;
 }
 
+function normalizeSidebarFontSizePx(value: unknown) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_SIDEBAR_FONT_SIZE_PX;
+  const rounded = Math.round(value);
+  if (rounded < MIN_SIDEBAR_FONT_SIZE_PX) return MIN_SIDEBAR_FONT_SIZE_PX;
+  if (rounded > MAX_SIDEBAR_FONT_SIZE_PX) return MAX_SIDEBAR_FONT_SIZE_PX;
+  return rounded;
+}
+
 function normalizeUiFontSizePx(value: unknown) {
   if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_UI_FONT_SIZE_PX;
   const rounded = Math.round(value);
@@ -123,6 +134,12 @@ function readMessageFontSizePx() {
   if (!raw) return DEFAULT_MESSAGE_FONT_SIZE_PX;
   const parsed = Number(raw);
   return normalizeMessageFontSizePx(parsed);
+}
+
+function readSidebarFontSizePx() {
+  const raw = storageGet(StorageKeys.settings.sidebarFontSizePx);
+  if (!raw) return DEFAULT_SIDEBAR_FONT_SIZE_PX;
+  return normalizeSidebarFontSizePx(Number(raw));
 }
 
 function readUiFontSizePx() {
@@ -208,6 +225,7 @@ const appMonospaceFontFamily = ref(readAppMonospaceFontFamily());
 const terminalFontSizePx = ref(readTerminalFontSizePx());
 const appFontSizePx = ref(readAppFontSizePx());
 const messageFontSizePx = ref(readMessageFontSizePx());
+const sidebarFontSizePx = ref(readSidebarFontSizePx());
 const uiFontSizePx = ref(readUiFontSizePx());
 const showOpenInEditorButton = ref(storageGet(StorageKeys.settings.showOpenInEditorButton) !== 'false');
 const openInEditorMaxSizeMb = ref(readOpenInEditorMaxSizeMb());
@@ -287,6 +305,10 @@ watch(appFontSizePx, (value) => {
 
 watch(messageFontSizePx, (value) => {
   storageSet(StorageKeys.settings.messageFontSizePx, String(value));
+}, syncWatchOptions);
+
+watch(sidebarFontSizePx, (value) => {
+  storageSet(StorageKeys.settings.sidebarFontSizePx, String(value));
 }, syncWatchOptions);
 
 watch(uiFontSizePx, (value) => {
@@ -398,6 +420,10 @@ if (typeof window !== 'undefined') {
       const parsed = event.newValue === null ? DEFAULT_MESSAGE_FONT_SIZE_PX : Number(event.newValue);
       messageFontSizePx.value = normalizeMessageFontSizePx(parsed);
     }
+    if (event.key === storageKey(StorageKeys.settings.sidebarFontSizePx)) {
+      const parsed = event.newValue === null ? DEFAULT_SIDEBAR_FONT_SIZE_PX : Number(event.newValue);
+      sidebarFontSizePx.value = normalizeSidebarFontSizePx(parsed);
+    }
     if (event.key === storageKey(StorageKeys.settings.uiFontSizePx)) {
       const parsed = event.newValue === null ? DEFAULT_UI_FONT_SIZE_PX : Number(event.newValue);
       uiFontSizePx.value = normalizeUiFontSizePx(parsed);
@@ -481,6 +507,7 @@ export function useSettings() {
     terminalFontSizePx,
     appFontSizePx,
     messageFontSizePx,
+    sidebarFontSizePx,
     uiFontSizePx,
     defaultTerminalFontSizePx: DEFAULT_TERMINAL_FONT_SIZE_PX,
     minTerminalFontSizePx: MIN_TERMINAL_FONT_SIZE_PX,
@@ -491,6 +518,9 @@ export function useSettings() {
     defaultMessageFontSizePx: DEFAULT_MESSAGE_FONT_SIZE_PX,
     minMessageFontSizePx: MIN_MESSAGE_FONT_SIZE_PX,
     maxMessageFontSizePx: MAX_MESSAGE_FONT_SIZE_PX,
+    defaultSidebarFontSizePx: DEFAULT_SIDEBAR_FONT_SIZE_PX,
+    minSidebarFontSizePx: MIN_SIDEBAR_FONT_SIZE_PX,
+    maxSidebarFontSizePx: MAX_SIDEBAR_FONT_SIZE_PX,
     defaultUiFontSizePx: DEFAULT_UI_FONT_SIZE_PX,
     minUiFontSizePx: MIN_UI_FONT_SIZE_PX,
     maxUiFontSizePx: MAX_UI_FONT_SIZE_PX,

--- a/app/i18n/types.ts
+++ b/app/i18n/types.ts
@@ -653,6 +653,10 @@ export interface LocaleMessages {
       label: string;
       description: string;
     };
+    sidebarFontSizePx: {
+      label: string;
+      description: string;
+    };
     uiFontSizePx: {
       label: string;
       description: string;

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -732,9 +732,13 @@ const messages: LocaleMessages = {
       label: 'Message font size',
       description: 'Font size in pixels for chat messages and thread history.',
     },
+    sidebarFontSizePx: {
+      label: 'Sidebar font size',
+      description: 'Font size in pixels for file trees, session trees, and todo text.',
+    },
     uiFontSizePx: {
       label: 'UI font size',
-      description: 'Font size in pixels for sidebar, top panel, modals, and dropdowns.',
+      description: 'Font size in pixels for the top panel, modals, and dropdowns.',
     },
     fontSettings: {
       label: 'Font settings',

--- a/app/locales/eo.ts
+++ b/app/locales/eo.ts
@@ -731,10 +731,13 @@ const messages: LocaleMessages = {
       label: 'Mesaĝa tipargrandeco',
       description: 'Tipargrandeco en rastrumeroj por babilaj mesaĝoj kaj fadenhistorio.',
     },
+    sidebarFontSizePx: {
+      label: 'Tipara grandeco de la flanka breto',
+      description: 'Tipara grandeco en rastrumeroj por dosierarboj, seancaj arboj kaj farendaĵoj.',
+    },
     uiFontSizePx: {
       label: 'UI-tipargrandeco',
-      description:
-        'Tipargrandeco en rastrumeroj por flanka strio, supra panelo, modaloj, kaj falmenuoj.',
+      description: 'Tipargrandeco en rastrumeroj por supra panelo, modaloj, kaj falmenuoj.',
     },
     fontSettings: {
       label: 'Tiparaj agordoj',

--- a/app/locales/ja.ts
+++ b/app/locales/ja.ts
@@ -734,10 +734,13 @@ const messages: LocaleMessages = {
       label: 'メッセージフォントサイズ',
       description: 'チャットメッセージとスレッド履歴のフォントサイズ（ピクセル）。',
     },
+    sidebarFontSizePx: {
+      label: 'サイドバーのフォントサイズ',
+      description: 'ファイルツリー、セッションツリー、TODO テキストのフォントサイズ（ピクセル）。',
+    },
     uiFontSizePx: {
       label: 'UIフォントサイズ',
-      description:
-        'サイドバー、トップパネル、モーダル、ドロップダウンのフォントサイズ（ピクセル）。',
+      description: 'トップパネル、モーダル、ドロップダウンのフォントサイズ（ピクセル）。',
     },
     fontSettings: {
       label: 'フォント設定',

--- a/app/locales/zh-CN.ts
+++ b/app/locales/zh-CN.ts
@@ -722,9 +722,13 @@ const messages: LocaleMessages = {
       label: '消息字体大小',
       description: '聊天消息和线程历史中使用的字体大小（像素）。',
     },
+    sidebarFontSizePx: {
+      label: '侧边栏字体大小',
+      description: '文件树、会话树和待办区域文字的字体大小（像素）。',
+    },
     uiFontSizePx: {
       label: '界面字体大小',
-      description: '侧边栏、顶部面板、弹窗和下拉菜单中使用的字体大小（像素）。',
+      description: '顶部面板、弹窗和下拉菜单中使用的字体大小（像素）。',
     },
     fontSettings: {
       label: '字体设置',

--- a/app/locales/zh-TW.ts
+++ b/app/locales/zh-TW.ts
@@ -721,9 +721,13 @@ const messages: LocaleMessages = {
       label: '訊息字型大小',
       description: '聊天訊息和執行緒歷史中使用的字型大小（像素）。',
     },
+    sidebarFontSizePx: {
+      label: '側邊欄字型大小',
+      description: '檔案樹、工作階段樹和待辦區域文字的字型大小（像素）。',
+    },
     uiFontSizePx: {
       label: '介面字型大小',
-      description: '側邊欄、頂部面板、彈窗和下拉選單中使用的字型大小（像素）。',
+      description: '頂部面板、彈窗和下拉選單中使用的字型大小（像素）。',
     },
     fontSettings: {
       label: '字型設定',

--- a/app/sidebarFontSize.integration.test.ts
+++ b/app/sidebarFontSize.integration.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function source(path: string): string {
+  return readFileSync(resolve(process.cwd(), path), 'utf8');
+}
+
+function expectSidebarFontRule(path: string, selector: string): void {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  expect(source(path)).toMatch(
+    new RegExp(
+      `${escapedSelector}\\s*\\{[^}]*font-size:\\s*var\\(--sidebar-font-size,\\s*12px\\)`,
+      's',
+    ),
+  );
+}
+
+describe('sidebar font size integration', () => {
+  it('offers a dedicated sidebar size control and publishes its CSS variable', () => {
+    const settingsModal = source('app/components/SettingsModal.vue');
+    const app = source('app/App.vue');
+
+    expect(settingsModal).toContain('settings-sidebar-font-size');
+    expect(settingsModal).toContain('v-model.number="sidebarFontSizePx"');
+    expect(app).toContain("'--sidebar-font-size'");
+  });
+
+  it('applies the sidebar size only to the requested sidebar text categories', () => {
+    const sidePanel = source('app/components/SidePanel.vue');
+    expect(sidePanel).toContain("t('sidePanel.tabs.tree')");
+    expect(sidePanel).toContain("t('sidePanel.tabs.session')");
+    expect(sidePanel).toContain("t('sidePanel.tabs.todo')");
+
+    expectSidebarFontRule('app/components/SidePanel.vue', '.side-tab');
+    expectSidebarFontRule('app/components/TreeView.vue', '.tree-name');
+    expectSidebarFontRule('app/components/SessionTree.vue', '.session-tree-label');
+    expectSidebarFontRule('app/components/TodoList.vue', '.todo-title');
+    expectSidebarFontRule('app/components/TodoList.vue', '.todo-text');
+  });
+
+  it('scales file tree icons with sidebar text while preserving the virtual row height', () => {
+    const treeView = source('app/components/TreeView.vue');
+
+    expect(treeView).toContain(
+      '--tree-icon-size: clamp(18px, calc(var(--sidebar-font-size, 12px) + 6px), 20px);',
+    );
+    expect(treeView).toMatch(/\.tree-icon\s*\{[^}]*flex:\s*0 0 var\(--tree-icon-size\)/s);
+    expect(treeView).toMatch(/\.tree-icon :deep\(svg\)\s*\{[^}]*width:\s*var\(--tree-icon-size\)/s);
+  });
+});

--- a/app/utils/storageKeys.ts
+++ b/app/utils/storageKeys.ts
@@ -55,6 +55,7 @@ export const StorageKeys = {
     terminalFontSizePx: 'settings.terminalFontSizePx.v1',
     appFontSizePx: 'settings.appFontSizePx.v1',
     messageFontSizePx: 'settings.messageFontSizePx.v1',
+    sidebarFontSizePx: 'settings.sidebarFontSizePx.v1',
     uiFontSizePx: 'settings.uiFontSizePx.v1',
     showOpenInEditorButton: 'settings.showOpenInEditorButton.v1',
     openInEditorMaxSizeMb: 'settings.openInEditorMaxSizeMb.v1',


### PR DESCRIPTION
## Summary
- add a dedicated, persisted sidebar font-size setting with a 10–20px range
- apply the setting to file tree, session tree, and TODO headings and content
- scale file icons from 18px to a 20px cap alongside sidebar text
- add typed localization and regression coverage for persistence, synchronization, CSS wiring, and icon sizing

## Verification
- `pnpm lint`
- `pnpm test` (1260 passed, 2 skipped)
- `pnpm build`
- `pnpm bridge:build`
- browser QA at 10/12/16/20px, including bounds, persistence, layout, and icon scaling
- Visual QA and five-lane final review passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable sidebar font size setting
> - Adds a `sidebarFontSizePx` setting (default 12px, range 10–20px) exposed in the Settings UI and persisted to storage with its own key.
> - Publishes a `--sidebar-font-size` CSS variable via `syncAppMonospaceMetrics` in [App.vue](https://github.com/qiyuanhuakai/opencode-visualizer-cn/pull/107/files#diff-b0f1d2fd02c89170e22be5bca533bf7d5988bd1be5835047f65fdf991793a273), consumed by session tree labels, side panel tabs, todo list text, and file tree names.
> - File tree icons scale with sidebar font size using `clamp(18px, calc(var(--sidebar-font-size) + 6px), 20px)` to keep icon dimensions bounded.
> - Behavioral Change: side panel tabs and session titles now follow `--sidebar-font-size` instead of `--ui-font-size`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d2970e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->