### PR TITLE
perf: bound long-lived memory usage

### DIFF
--- a/app/App.vue
+++ b/app/App.vue
@@ -7885,6 +7885,7 @@ watch(
   ],
   () => {
     messageCacheAuthGeneration.value += 1;
+    sessionReloadRequestId.value += 1;
     msg.clearSessionCache();
     backendSessionReload.invalidateMessageCacheContext();
   },

--- a/app/App.vue
+++ b/app/App.vue
@@ -5211,8 +5211,9 @@ async function fetchHistory(
 }
 
 async function fetchRootSessionHistory(rootSessionId: string) {
-  await fetchHistory(rootSessionId);
-  return primaryHistoryRequestId;
+  const requestId = ++primaryHistoryRequestId;
+  const loaded = await fetchHistory(rootSessionId, false, requestId);
+  return { requestId, loaded };
 }
 
 function reserveRootHistoryRequestId() {
@@ -5938,7 +5939,6 @@ async function ensureShellWindow(pty: PtyInfo, options: ShellWindowOptions = {})
       void waitForTerminalFontsReady().then(() => {
         if (shellSessionsByPtyId.get(pty.id)?.terminal !== terminal) {
           terminal.dispose();
-          fw.close(key);
           return;
         }
         const host = toolWindowCanvasEl.value?.querySelector(
@@ -7431,6 +7431,7 @@ const deltaAccumulator = useDeltaAccumulator();
 deltaAccumulator.listen(ge);
 const sessionScope = ge.session(selectedSessionId, sessionParentRecord);
 const msg = useMessages();
+const messageCacheAuthGeneration = ref(0);
 msg.bindScope(sessionScope);
 reasoning.bindScope(sessionScope);
 subagentWindows.bindScope(sessionScope);
@@ -7836,7 +7837,11 @@ const backendSessionReload = useBackendSessionReload({
   activeBackendKind,
   activeDirectory,
   getMessageCacheNamespace: () =>
-    JSON.stringify([currentBackendIdentity(), activeDirectory.value]),
+    JSON.stringify([
+      currentBackendIdentity(),
+      activeDirectory.value,
+      messageCacheAuthGeneration.value,
+    ]),
   uiInitState,
   isBootstrapping,
   isLoadingHistory,
@@ -7872,6 +7877,20 @@ const backendSessionReload = useBackendSessionReload({
   fetchPendingQuestions,
   focusInput,
 });
+
+watch(
+  [
+    () => credentials.authHeader.value,
+    () => credentials.codexBridgeToken.value,
+    () => credentials.acpBridgeToken.value,
+  ],
+  () => {
+    messageCacheAuthGeneration.value += 1;
+    msg.clearSessionCache();
+    backendSessionReload.invalidateMessageCacheContext();
+  },
+  { flush: 'sync' },
+);
 
 async function reloadSelectedSessionAndAcpOptions(newId?: string, oldId?: string) {
   await backendSessionReload.reloadSelectedSessionState(newId, oldId);

--- a/app/App.vue
+++ b/app/App.vue
@@ -747,6 +747,7 @@ import {
   closeTrackedLocalFileSession,
 } from './utils/localFileSessionTracking';
 import { createKeyedTaskQueue } from './utils/keyedTaskQueue';
+import { createPendingPtyCreateRegistry, isCurrentPtySocket } from './utils/ptyLifecycle';
 
 const { t } = useI18n();
 
@@ -1534,6 +1535,7 @@ const composerDraftTabId =
     ? crypto.randomUUID()
     : `tab-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 const shellSessionsByPtyId = new Map<string, ShellSession>();
+const pendingShellWindowCreates = createPendingPtyCreateRegistry<void>();
 const pendingShellFits = new Set<string>();
 const shellExitWaiters = new Map<string, (exitCode: number) => void>();
 const shellExitCallbacks = new Map<string, (exitCode: number) => void | Promise<void>>();
@@ -5870,72 +5872,83 @@ type ShellWindowOptions = {
 
 async function ensureShellWindow(pty: PtyInfo, options: ShellWindowOptions = {}) {
   if (shellSessionsByPtyId.has(pty.id)) return;
-  if (options.onExit) shellExitCallbacks.set(pty.id, options.onExit);
-  const key = `shell:${pty.id}`;
-  if (options.minWidth !== undefined || options.minHeight !== undefined) {
-    shellWindowMinimums.set(key, {
-      width: options.minWidth ?? 0,
-      height: options.minHeight ?? 0,
+  await pendingShellWindowCreates.getOrCreate(pty.id, async (isCurrent) => {
+    if (shellSessionsByPtyId.has(pty.id)) return;
+    const key = `shell:${pty.id}`;
+
+    const { Terminal } = await import('@xterm/xterm');
+    if (!isCurrent()) return;
+
+    if (options.onExit) shellExitCallbacks.set(pty.id, options.onExit);
+    if (options.minWidth !== undefined || options.minHeight !== undefined) {
+      shellWindowMinimums.set(key, {
+        width: options.minWidth ?? 0,
+        height: options.minHeight ?? 0,
+      });
+    }
+    const { width, height } = getTerminalWindowSize();
+    const randomPosition = getRandomWindowPosition({ width, height });
+
+    fw.open(key, {
+      component: options.component ?? ShellContent,
+      props: options.props ?? { shellId: pty.id },
+      closable: true,
+      resizable: true,
+      scroll: 'none',
+      title:
+        options.title ??
+        (pty.title === 'One-shot PTY'
+          ? t('app.windowTitles.oneShotPty')
+          : pty.title || t('app.windowTitles.shell')),
+      color: options.color,
+      width,
+      height,
+      x: randomPosition.x,
+      y: randomPosition.y,
+      expiry: Infinity,
+      onResize: () => scheduleShellFit(pty.id),
     });
-  }
-  const { width, height } = getTerminalWindowSize();
-  const randomPosition = getRandomWindowPosition({ width, height });
-  fw.open(key, {
-    component: options.component ?? ShellContent,
-    props: options.props ?? { shellId: pty.id },
-    closable: true,
-    resizable: true,
-    scroll: 'none',
-    title:
-      options.title ??
-      (pty.title === 'One-shot PTY'
-        ? t('app.windowTitles.oneShotPty')
-        : pty.title || t('app.windowTitles.shell')),
-    color: options.color,
-    width,
-    height,
-    x: randomPosition.x,
-    y: randomPosition.y,
-    expiry: Infinity,
-    onResize: () => scheduleShellFit(pty.id),
-  });
 
-  // Dynamic import of Terminal for code splitting
-  const { Terminal } = await import('@xterm/xterm');
-
-  const terminal = new Terminal({
-    cols: TERM_COLUMNS,
-    rows: TERM_ROWS,
-    fontFamily: terminalFontFamily.value,
-    fontSize: TERM_FONT_SIZE_PX.value,
-    lineHeight: TERM_LINE_HEIGHT,
-    cursorBlink: true,
-    allowTransparency: true,
-    theme: {
-      background: TRANSPARENT_TERMINAL_BACKGROUND,
-      foreground: '#e2e8f0',
-      cursor: '#e2e8f0',
-      selectionBackground: 'rgba(148, 163, 184, 0.3)',
-    },
-  });
-  shellSessionsByPtyId.set(pty.id, {
-    pty,
-    terminal,
-  });
-  // Connect WebSocket immediately so the server's buffer replay arrives
-  // before a fast-exiting command deletes the session.
-  // xterm.js buffers write() calls made before open(), so data is not lost.
-  connectShellSocket(pty.id);
-  nextTick(() => {
-    void waitForTerminalFontsReady().then(() => {
-      const host = toolWindowCanvasEl.value?.querySelector(
-        `[data-shell-id="${pty.id}"]`,
-      ) as HTMLElement | null;
-      if (!host) return;
-      terminal.open(host);
-      // Wait for first paint so xterm has rendered cell dimensions
-      requestAnimationFrame(() => {
-        resizeWindowToFitTerminal(key, terminal, host);
+    const terminal = new Terminal({
+      cols: TERM_COLUMNS,
+      rows: TERM_ROWS,
+      fontFamily: terminalFontFamily.value,
+      fontSize: TERM_FONT_SIZE_PX.value,
+      lineHeight: TERM_LINE_HEIGHT,
+      cursorBlink: true,
+      allowTransparency: true,
+      theme: {
+        background: TRANSPARENT_TERMINAL_BACKGROUND,
+        foreground: '#e2e8f0',
+        cursor: '#e2e8f0',
+        selectionBackground: 'rgba(148, 163, 184, 0.3)',
+      },
+    });
+    if (!isCurrent()) {
+      terminal.dispose();
+      fw.close(key);
+      return;
+    }
+    shellSessionsByPtyId.set(pty.id, {
+      pty,
+      terminal,
+    });
+    connectShellSocket(pty.id);
+    nextTick(() => {
+      void waitForTerminalFontsReady().then(() => {
+        if (shellSessionsByPtyId.get(pty.id)?.terminal !== terminal) {
+          terminal.dispose();
+          fw.close(key);
+          return;
+        }
+        const host = toolWindowCanvasEl.value?.querySelector(
+          `[data-shell-id="${pty.id}"]`,
+        ) as HTMLElement | null;
+        if (!host) return;
+        terminal.open(host);
+        requestAnimationFrame(() => {
+          resizeWindowToFitTerminal(key, terminal, host);
+        });
       });
     });
   });
@@ -6107,8 +6120,11 @@ function connectShellSocket(ptyId: string) {
   const url = buildPtyWsUrl(`/pty/${ptyId}/connect`, directory);
   const socket = new WebSocket(url);
   session.socket = socket;
+  const isCurrentSocket = () =>
+    isCurrentPtySocket(shellSessionsByPtyId, ptyId, session, socket);
   socket.binaryType = 'arraybuffer';
   socket.addEventListener('message', (event) => {
+    if (!isCurrentSocket()) return;
     if (event.data instanceof ArrayBuffer) {
       const bytes = new Uint8Array(event.data);
       if (bytes.length > 0 && bytes[0] === 0) {
@@ -6170,6 +6186,7 @@ function connectShellSocket(ptyId: string) {
     }
   });
   socket.addEventListener('open', () => {
+    if (!isCurrentSocket()) return;
     // focus() requires the terminal to be mounted; defer if not yet attached.
     if (session.terminal.element) {
       session.terminal.focus();
@@ -6178,9 +6195,11 @@ function connectShellSocket(ptyId: string) {
     }
   });
   session.terminal.onData((data) => {
+    if (!isCurrentSocket()) return;
     if (socket.readyState === WebSocket.OPEN) socket.send(data);
   });
   socket.addEventListener('close', () => {
+    if (!isCurrentSocket()) return;
     if (session.exiting) {
       setTimeout(() => removeShellWindow(ptyId), SHELL_LINGER_MS);
       return;
@@ -6198,6 +6217,7 @@ function connectShellSocket(ptyId: string) {
 }
 
 function removeShellWindow(ptyId: string, options?: { kill?: boolean }) {
+  pendingShellWindowCreates.invalidate(ptyId);
   const session = shellSessionsByPtyId.get(ptyId);
   if (!session) return;
   pendingShellFits.delete(ptyId);
@@ -7815,6 +7835,8 @@ const backendSessionLifecycle = useBackendSessionLifecycle({
 const backendSessionReload = useBackendSessionReload({
   activeBackendKind,
   activeDirectory,
+  getMessageCacheNamespace: () =>
+    JSON.stringify([currentBackendIdentity(), activeDirectory.value]),
   uiInitState,
   isBootstrapping,
   isLoadingHistory,
@@ -9606,6 +9628,7 @@ onMounted(() => {
   );
 });
 onBeforeUnmount(() => {
+  pendingShellWindowCreates.invalidateAll();
   for (const pending of Array.from(pendingReferencedSubagentHydrations.values())) {
     pending.resolve(undefined);
   }

--- a/app/App.vue
+++ b/app/App.vue
@@ -5211,9 +5211,8 @@ async function fetchHistory(
 }
 
 async function fetchRootSessionHistory(rootSessionId: string) {
-  const requestId = ++primaryHistoryRequestId;
-  const loaded = await fetchHistory(rootSessionId, false, requestId);
-  return { requestId, loaded };
+  const loaded = await fetchHistory(rootSessionId);
+  return { requestId: primaryHistoryRequestId, loaded };
 }
 
 function reserveRootHistoryRequestId() {

--- a/app/acpTerminalManager.test.ts
+++ b/app/acpTerminalManager.test.ts
@@ -133,4 +133,42 @@ describe('acpTerminalManager', () => {
       await manager.stopAll();
     }
   });
+
+  it('keeps outputByteLimit tails valid UTF-8 when a chunk ends mid-character', async () => {
+    const child = new TestChild();
+    const manager = createAcpTerminalManager({ spawnProcess: () => child });
+    const creation = manager.create({ command: 'utf8-terminal', outputByteLimit: 3 });
+    child.emit('spawn');
+    const { terminalId } = await creation;
+
+    child.stdout.emit('data', Buffer.from('😊b'));
+
+    expect(manager.output(terminalId)).toMatchObject({ output: 'b', truncated: true });
+  });
+
+  it('waits for close before completing after exit so late output remains readable', async () => {
+    const child = new TestChild();
+    const manager = createAcpTerminalManager({ spawnProcess: () => child });
+    const creation = manager.create({ command: 'draining-terminal' });
+    child.emit('spawn');
+    const { terminalId } = await creation;
+
+    child.stdout.emit('data', Buffer.from('before'));
+    let settled = false;
+    const waiting = manager.waitForExit(terminalId).then(() => { settled = true; });
+    child.emit('exit', 0, null);
+    child.stdout.emit('data', Buffer.from('-after'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+    expect(manager.output(terminalId)).toMatchObject({ output: 'before-after' });
+
+    child.emit('close', 0, null);
+    await waiting;
+    expect(manager.output(terminalId)).toMatchObject({
+      output: 'before-after',
+      exitStatus: { exitCode: 0, signal: null },
+    });
+  });
 });

--- a/app/composables/useBackendSessionReload.test.ts
+++ b/app/composables/useBackendSessionReload.test.ts
@@ -3,6 +3,92 @@ import { ref } from 'vue';
 import { useBackendSessionReload } from './useBackendSessionReload';
 
 describe('useBackendSessionReload', () => {
+  it('keeps a completed root snapshot cacheable when child hydration fails', async () => {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+    const activeBackendKind = ref('opencode');
+    const activeDirectory = ref('/repo');
+    const sessionReloadRequestId = ref(0);
+    const deferredSessionReloadId = ref<string>();
+    const hydrateReferencedSubagents = vi
+      .fn()
+      .mockRejectedValue(new Error('child hydration failed'));
+    const fetchRootSessionHistory = vi.fn().mockResolvedValue(42);
+    const reportError = vi.fn();
+    const msg = {
+      saveSessionState: vi.fn(),
+      reset: vi.fn(),
+      tryLoadFromCache: vi.fn().mockReturnValue(false),
+    };
+
+    const { reloadSelectedSessionState } = useBackendSessionReload({
+      activeBackendKind,
+      activeDirectory,
+      getMessageCacheNamespace: () => 'opencode:primary:/repo',
+      sessionReloadRequestId,
+      isBootstrapping: ref(false),
+      deferredSessionReloadId,
+      selectedProject: ref(null),
+      persistSelectionState: vi.fn(),
+      invokeBackendSelectionAfterBootstrap: vi.fn(),
+      fwCloseAll: vi.fn(),
+      msg,
+      resetFollow: vi.fn(),
+      reasoningReset: vi.fn(),
+      subagentWindowsReset: vi.fn(),
+      clearRetryStatus: vi.fn(),
+      codexApi: {
+        loadThreadHistory: vi.fn(),
+      },
+      loadCodeReviewComments: vi.fn(),
+      reportError,
+      oc: null,
+      acp: null,
+      providerModels: ref([]),
+      selectedModel: ref(''),
+      acpSessionModels: new Map(),
+      acpSessionAgents: new Map(),
+      selectionReasoningEfforts: ref({}),
+      fetchRootSessionHistory,
+      hydratedDescendantSessionIds: new Set(),
+      waitForPendingRenders: vi.fn(),
+      hydrateReferencedSubagents,
+      scheduleDescendantSessionHistoryHydration: vi.fn(),
+      isLoadingHistory: ref(false),
+      activeSessionStarted: ref(false),
+      renderTick: ref(0),
+      anchorOutputToBottom: vi.fn(),
+      uiInitState: ref('idle'),
+      reloadTodosForAllowedSessions: vi.fn(),
+      fetchPendingPermissions: vi.fn(),
+      fetchPendingQuestions: vi.fn(),
+      focusInput: vi.fn(),
+      sessionHasStarted: vi.fn().mockReturnValue(true),
+      setActiveSessionStarted: vi.fn(),
+      windowSetTimeout: (callback: () => void) => {
+        callback();
+        return 0;
+      },
+    } as unknown as Parameters<typeof useBackendSessionReload>[0]);
+
+    try {
+      await reloadSelectedSessionState('session-1');
+      expect(hydrateReferencedSubagents).toHaveBeenCalledWith('session-1', 1);
+      expect(msg.saveSessionState).not.toHaveBeenCalled();
+
+      await reloadSelectedSessionState('session-2', 'session-1');
+
+      expect(msg.saveSessionState).toHaveBeenCalledWith({
+        namespace: 'opencode:primary:/repo',
+        sessionId: 'session-1',
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('reloads Codex session history through unified reload runtime', async () => {
     const msg = {
       saveSessionState: vi.fn(),

--- a/app/composables/useBackendSessionReload.test.ts
+++ b/app/composables/useBackendSessionReload.test.ts
@@ -15,7 +15,7 @@ describe('useBackendSessionReload', () => {
     const hydrateReferencedSubagents = vi
       .fn()
       .mockRejectedValue(new Error('child hydration failed'));
-    const fetchRootSessionHistory = vi.fn().mockResolvedValue(42);
+    const fetchRootSessionHistory = vi.fn().mockResolvedValue({ requestId: 42, loaded: true });
     const reportError = vi.fn();
     const msg = {
       saveSessionState: vi.fn(),
@@ -84,6 +84,14 @@ describe('useBackendSessionReload', () => {
         namespace: 'opencode:primary:/repo',
         sessionId: 'session-1',
       });
+
+      fetchRootSessionHistory.mockResolvedValue({ requestId: 43, loaded: false });
+      await reloadSelectedSessionState('session-failed', 'session-2');
+      msg.saveSessionState.mockClear();
+
+      await reloadSelectedSessionState('session-3', 'session-failed');
+
+      expect(msg.saveSessionState).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllGlobals();
     }

--- a/app/composables/useBackendSessionReload.test.ts
+++ b/app/composables/useBackendSessionReload.test.ts
@@ -14,6 +14,7 @@ describe('useBackendSessionReload', () => {
     const reload = useBackendSessionReload({
       activeBackendKind: ref('codex'),
       activeDirectory: ref('/repo'),
+      getMessageCacheNamespace: () => 'codex:http://127.0.0.1:4500:/repo',
       uiInitState: ref('ready'),
       isBootstrapping: ref(false),
       isLoadingHistory: ref(false),
@@ -46,7 +47,7 @@ describe('useBackendSessionReload', () => {
 
     await reload.reloadSelectedSessionState('thread-1', 'thread-old');
 
-    expect(msg.saveSessionState).toHaveBeenCalledWith('thread-old');
+    expect(msg.saveSessionState).not.toHaveBeenCalled();
     expect(selectThread).toHaveBeenCalledWith('thread-1');
     expect(msg.reset).toHaveBeenCalled();
     expect(msg.loadHistory).toHaveBeenCalledWith([{ id: 'history-1' }]);
@@ -63,6 +64,7 @@ describe('useBackendSessionReload', () => {
     const reload = useBackendSessionReload({
       activeBackendKind: ref('codex'),
       activeDirectory: ref('/repo'),
+      getMessageCacheNamespace: () => 'codex:http://127.0.0.1:4500:/repo',
       uiInitState: ref('ready'),
       isBootstrapping: ref(false),
       isLoadingHistory: ref(false),
@@ -113,6 +115,7 @@ describe('useBackendSessionReload', () => {
     const reload = useBackendSessionReload({
       activeBackendKind: ref<'opencode'>('opencode'),
       activeDirectory: ref('/repo'),
+      getMessageCacheNamespace: () => 'opencode:http://127.0.0.1:4096:/repo',
       uiInitState: ref<'ready'>('ready'),
       isBootstrapping: ref(false),
       isLoadingHistory: ref(false),
@@ -145,7 +148,10 @@ describe('useBackendSessionReload', () => {
 
     await reload.reloadSelectedSessionState('session-1');
 
-    expect(msg.tryLoadFromCache).toHaveBeenCalledWith('session-1');
+    expect(msg.tryLoadFromCache).toHaveBeenCalledWith({
+      namespace: 'opencode:http://127.0.0.1:4096:/repo',
+      sessionId: 'session-1',
+    });
     expect(fetchRootSessionHistory).not.toHaveBeenCalled();
     expect(scheduleDescendantSessionHistoryHydration).toHaveBeenCalledWith('session-1', 7, 1);
   });
@@ -163,6 +169,7 @@ describe('useBackendSessionReload', () => {
     const options = {
       activeBackendKind: ref<'opencode'>('opencode'),
       activeDirectory: ref('/repo'),
+      getMessageCacheNamespace: () => 'opencode:http://127.0.0.1:4096:/repo',
       uiInitState: ref<'ready'>('ready'),
       isBootstrapping: ref(false),
       isLoadingHistory: ref(false),
@@ -219,6 +226,7 @@ describe('useBackendSessionReload', () => {
     const options = {
       activeBackendKind: ref<'opencode'>('opencode'),
       activeDirectory: ref('/repo'),
+      getMessageCacheNamespace: () => 'opencode:http://127.0.0.1:4096:/repo',
       uiInitState: ref<'ready'>('ready'),
       isBootstrapping: ref(false),
       isLoadingHistory: ref(false),
@@ -263,5 +271,62 @@ describe('useBackendSessionReload', () => {
     await pendingReload;
 
     expect(scheduleDescendantSessionHistoryHydration).not.toHaveBeenCalled();
+  });
+
+  it('saves the old materialized view under its original backend identity', async () => {
+    const activeBackendKind = ref<'opencode' | 'acp'>('opencode');
+    const activeDirectory = ref('/repo-a');
+    let namespace = 'opencode:http://127.0.0.1:4096:/repo-a';
+    const msg = {
+      saveSessionState: vi.fn(),
+      reset: vi.fn(),
+      loadHistory: vi.fn(),
+      tryLoadFromCache: vi.fn().mockReturnValue(true),
+    };
+    const reload = useBackendSessionReload({
+      activeBackendKind,
+      activeDirectory,
+      getMessageCacheNamespace: () => namespace,
+      uiInitState: ref<'ready'>('ready'),
+      isBootstrapping: ref(false),
+      isLoadingHistory: ref(false),
+      deferredSessionReloadId: ref<string | null>(null),
+      sessionReloadRequestId: ref(0),
+      hydratedDescendantSessionIds: new Set<string>(),
+      msg,
+      fwCloseAll: vi.fn(),
+      resetFollow: vi.fn(),
+      reasoningReset: vi.fn(),
+      subagentWindowsReset: vi.fn(),
+      clearRetryStatus: vi.fn(),
+      codexApi: { activeThreadId: ref(''), selectThread: vi.fn() },
+      codexHistory: ref([]),
+      codexReapplyBackfill: vi.fn(),
+      fetchRootSessionHistory: vi.fn(),
+      waitForPendingRenders: vi.fn(),
+      reserveRootHistoryRequestId: vi.fn().mockReturnValue(1),
+      scheduleDescendantSessionHistoryHydration: vi.fn(),
+      anchorOutputToBottom: vi.fn().mockResolvedValue(undefined),
+      restoreShellSessions: vi.fn().mockResolvedValue(undefined),
+      reloadTodosForAllowedSessions: vi.fn(),
+      fetchPendingPermissions: vi.fn(),
+      fetchPendingQuestions: vi.fn(),
+      focusInput: vi.fn(),
+    });
+
+    await reload.reloadSelectedSessionState('shared-session');
+    activeBackendKind.value = 'acp';
+    activeDirectory.value = '/repo-b';
+    namespace = 'acp:agent-b:/repo-b';
+    await reload.reloadSelectedSessionState('next-session', 'shared-session');
+
+    expect(msg.saveSessionState).toHaveBeenCalledWith({
+      namespace: 'opencode:http://127.0.0.1:4096:/repo-a',
+      sessionId: 'shared-session',
+    });
+    expect(msg.tryLoadFromCache).toHaveBeenLastCalledWith({
+      namespace: 'acp:agent-b:/repo-b',
+      sessionId: 'next-session',
+    });
   });
 });

--- a/app/composables/useBackendSessionReload.ts
+++ b/app/composables/useBackendSessionReload.ts
@@ -61,6 +61,31 @@ export function useBackendSessionReload(params: {
 }) {
   let loadedMessageCacheContext: LoadedMessageCacheContext | null = null;
 
+  async function hydrateAndScheduleDescendantHistory(
+    sessionId: string,
+    rootHistoryRequestId: number,
+    reloadRequestId: number,
+  ) {
+    const referencedSessionIds = params.hydrateReferencedSubagents
+      ? await params.hydrateReferencedSubagents(sessionId, reloadRequestId)
+      : undefined;
+    if (reloadRequestId !== params.sessionReloadRequestId.value) return;
+    if (referencedSessionIds) {
+      params.scheduleDescendantSessionHistoryHydration(
+        sessionId,
+        rootHistoryRequestId,
+        reloadRequestId,
+        referencedSessionIds,
+      );
+      return;
+    }
+    params.scheduleDescendantSessionHistoryHydration(
+      sessionId,
+      rootHistoryRequestId,
+      reloadRequestId,
+    );
+  }
+
   async function reloadSelectedSessionState(newId?: string, oldId?: string) {
     const reloadRequestId = ++params.sessionReloadRequestId.value;
     const previousCacheContext = loadedMessageCacheContext;
@@ -142,30 +167,17 @@ export function useBackendSessionReload(params: {
         let rootHistoryRequestId = 0;
         try {
           rootHistoryRequestId = await params.fetchRootSessionHistory(sessionId);
+          if (reloadRequestId !== params.sessionReloadRequestId.value) return;
+          if (loadedMessageCacheContext === nextCacheContext && nextCacheContext) {
+            nextCacheContext.cacheable = true;
+          }
           await new Promise((resolve) => requestAnimationFrame(resolve));
           await params.waitForPendingRenders();
-          const referencedSessionIds = params.hydrateReferencedSubagents
-            ? await params.hydrateReferencedSubagents(sessionId, reloadRequestId)
-            : undefined;
-          if (reloadRequestId === params.sessionReloadRequestId.value) {
-            if (loadedMessageCacheContext === nextCacheContext && nextCacheContext) {
-              nextCacheContext.cacheable = true;
-            }
-            if (referencedSessionIds) {
-              params.scheduleDescendantSessionHistoryHydration(
-                sessionId,
-                rootHistoryRequestId,
-                reloadRequestId,
-                referencedSessionIds,
-              );
-            } else {
-              params.scheduleDescendantSessionHistoryHydration(
-                sessionId,
-                rootHistoryRequestId,
-                reloadRequestId,
-              );
-            }
-          }
+          await hydrateAndScheduleDescendantHistory(
+            sessionId,
+            rootHistoryRequestId,
+            reloadRequestId,
+          );
         } catch {
           // Keep partial history if hydration/rendering fails.
         } finally {
@@ -175,25 +187,11 @@ export function useBackendSessionReload(params: {
         }
       } else if (!descendantsHydrated) {
         const rootHistoryRequestId = params.reserveRootHistoryRequestId();
-        const referencedSessionIds = params.hydrateReferencedSubagents
-          ? await params.hydrateReferencedSubagents(sessionId, reloadRequestId)
-          : undefined;
-        if (reloadRequestId === params.sessionReloadRequestId.value) {
-          if (referencedSessionIds) {
-            params.scheduleDescendantSessionHistoryHydration(
-              sessionId,
-              rootHistoryRequestId,
-              reloadRequestId,
-              referencedSessionIds,
-            );
-          } else {
-            params.scheduleDescendantSessionHistoryHydration(
-              sessionId,
-              rootHistoryRequestId,
-              reloadRequestId,
-            );
-          }
-        }
+        await hydrateAndScheduleDescendantHistory(
+          sessionId,
+          rootHistoryRequestId,
+          reloadRequestId,
+        );
       }
 
       if (reloadRequestId !== params.sessionReloadRequestId.value) return;

--- a/app/composables/useBackendSessionReload.ts
+++ b/app/composables/useBackendSessionReload.ts
@@ -1,11 +1,12 @@
 import { nextTick, type Ref } from 'vue';
 import type { BackendKind } from '../backends/types';
+import type { MessageCacheIdentity } from './useMessages';
 
 type MessageStoreLike = {
-  saveSessionState: (sessionId: string) => void;
+  saveSessionState: (identity: MessageCacheIdentity) => void;
   reset: () => void;
   loadHistory: (history: unknown[]) => void;
-  tryLoadFromCache: (sessionId: string) => boolean;
+  tryLoadFromCache: (identity: MessageCacheIdentity) => boolean;
 };
 
 type CodexApiLike = {
@@ -13,9 +14,16 @@ type CodexApiLike = {
   selectThread: (sessionId: string) => Promise<unknown>;
 };
 
+type LoadedMessageCacheContext = {
+  backend: BackendKind;
+  namespace: string;
+  cacheable: boolean;
+};
+
 export function useBackendSessionReload(params: {
   activeBackendKind: Ref<BackendKind>;
   activeDirectory: Ref<string>;
+  getMessageCacheNamespace: () => string;
   uiInitState: Ref<'loading' | 'ready' | 'error' | 'login'>;
   isBootstrapping: Ref<boolean>;
   isLoadingHistory: Ref<boolean>;
@@ -51,8 +59,18 @@ export function useBackendSessionReload(params: {
   fetchPendingQuestions: (directory?: string) => Promise<void> | void;
   focusInput: () => void;
 }) {
+  let loadedMessageCacheContext: LoadedMessageCacheContext | null = null;
+
   async function reloadSelectedSessionState(newId?: string, oldId?: string) {
     const reloadRequestId = ++params.sessionReloadRequestId.value;
+    const previousCacheContext = loadedMessageCacheContext;
+    const nextCacheContext: LoadedMessageCacheContext | null = newId
+      ? {
+          backend: params.activeBackendKind.value,
+          namespace: params.getMessageCacheNamespace(),
+          cacheable: false,
+        }
+      : null;
     if (newId && params.isBootstrapping.value && !params.activeDirectory.value) {
       params.deferredSessionReloadId.value = newId;
       return;
@@ -61,7 +79,14 @@ export function useBackendSessionReload(params: {
 
     params.fwCloseAll();
     await nextTick();
-    if (oldId) params.msg.saveSessionState(oldId);
+    if (reloadRequestId !== params.sessionReloadRequestId.value) return;
+    if (oldId && previousCacheContext?.cacheable && previousCacheContext.backend !== 'codex') {
+      params.msg.saveSessionState({
+        namespace: previousCacheContext.namespace,
+        sessionId: oldId,
+      });
+    }
+    loadedMessageCacheContext = nextCacheContext;
 
     if (newId) {
       const sessionId = newId;
@@ -103,7 +128,13 @@ export function useBackendSessionReload(params: {
       params.clearRetryStatus();
       await nextTick();
 
-      const cacheHit = params.msg.tryLoadFromCache(sessionId);
+      const cacheHit = params.msg.tryLoadFromCache({
+        namespace: nextCacheContext?.namespace ?? params.getMessageCacheNamespace(),
+        sessionId,
+      });
+      if (cacheHit && loadedMessageCacheContext === nextCacheContext && nextCacheContext) {
+        nextCacheContext.cacheable = true;
+      }
       const descendantsHydrated = params.hydratedDescendantSessionIds.has(sessionId);
       if (!cacheHit) {
         params.hydratedDescendantSessionIds.delete(sessionId);
@@ -117,6 +148,9 @@ export function useBackendSessionReload(params: {
             ? await params.hydrateReferencedSubagents(sessionId, reloadRequestId)
             : undefined;
           if (reloadRequestId === params.sessionReloadRequestId.value) {
+            if (loadedMessageCacheContext === nextCacheContext && nextCacheContext) {
+              nextCacheContext.cacheable = true;
+            }
             if (referencedSessionIds) {
               params.scheduleDescendantSessionHistoryHydration(
                 sessionId,

--- a/app/composables/useBackendSessionReload.ts
+++ b/app/composables/useBackendSessionReload.ts
@@ -39,7 +39,9 @@ export function useBackendSessionReload(params: {
   codexApi: CodexApiLike;
   codexHistory: Ref<unknown[]>;
   codexReapplyBackfill: () => void;
-  fetchRootSessionHistory: (rootSessionId: string) => Promise<number>;
+  fetchRootSessionHistory: (
+    rootSessionId: string,
+  ) => Promise<{ requestId: number; loaded: boolean }>;
   waitForPendingRenders: () => Promise<void>;
   reserveRootHistoryRequestId: () => number;
   scheduleDescendantSessionHistoryHydration: (
@@ -164,20 +166,20 @@ export function useBackendSessionReload(params: {
       if (!cacheHit) {
         params.hydratedDescendantSessionIds.delete(sessionId);
         params.isLoadingHistory.value = true;
-        let rootHistoryRequestId = 0;
         try {
-          rootHistoryRequestId = await params.fetchRootSessionHistory(sessionId);
-          if (reloadRequestId !== params.sessionReloadRequestId.value) return;
-          if (loadedMessageCacheContext === nextCacheContext && nextCacheContext) {
-            nextCacheContext.cacheable = true;
+          const rootHistory = await params.fetchRootSessionHistory(sessionId);
+          if (rootHistory.loaded && reloadRequestId === params.sessionReloadRequestId.value) {
+            if (loadedMessageCacheContext === nextCacheContext && nextCacheContext) {
+              nextCacheContext.cacheable = true;
+            }
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+            await params.waitForPendingRenders();
+            await hydrateAndScheduleDescendantHistory(
+              sessionId,
+              rootHistory.requestId,
+              reloadRequestId,
+            );
           }
-          await new Promise((resolve) => requestAnimationFrame(resolve));
-          await params.waitForPendingRenders();
-          await hydrateAndScheduleDescendantHistory(
-            sessionId,
-            rootHistoryRequestId,
-            reloadRequestId,
-          );
         } catch {
           // Keep partial history if hydration/rendering fails.
         } finally {
@@ -210,7 +212,12 @@ export function useBackendSessionReload(params: {
     params.focusInput();
   }
 
+  function invalidateMessageCacheContext() {
+    loadedMessageCacheContext = null;
+  }
+
   return {
     reloadSelectedSessionState,
+    invalidateMessageCacheContext,
   };
 }

--- a/app/composables/useMessages.test.ts
+++ b/app/composables/useMessages.test.ts
@@ -408,6 +408,63 @@ describe('useMessages getDiffs', () => {
     expect(postTask.mock.calls[0]?.[1]).toEqual({ priority: 'background' });
   });
 
+  it('does not retain a session larger than the warm-cache byte budget', () => {
+    const messages = useMessages();
+    messages.loadHistory([{
+      info: {
+        id: 'oversized-cache-message',
+        sessionID: 'oversized-cache-session',
+        role: 'user',
+        time: { created: 1 },
+        agent: 'build',
+        model: { providerID: 'test', modelID: 'test-model' },
+      },
+      parts: [{
+        id: 'oversized-cache-part',
+        sessionID: 'oversized-cache-session',
+        messageID: 'oversized-cache-message',
+        type: 'text',
+        text: 'x'.repeat(17 * 1024 * 1024),
+        time: { start: 1, end: 1 },
+      }],
+    }]);
+
+    messages.saveSessionState({ namespace: 'opencode:a', sessionId: 'oversized-cache-session' });
+    messages.reset();
+
+    expect(messages.tryLoadFromCache({ namespace: 'opencode:a', sessionId: 'oversized-cache-session' })).toBe(false);
+  });
+
+  it('isolates warm entries by backend and directory identity', () => {
+    const messages = useMessages();
+    messages.loadHistory([{
+      info: {
+        id: 'scoped-cache-message',
+        sessionID: 'scoped-cache-session',
+        role: 'user',
+        time: { created: 1 },
+        agent: 'build',
+        model: { providerID: 'test', modelID: 'test-model' },
+      },
+      parts: [],
+    }]);
+
+    messages.saveSessionState({
+      namespace: 'opencode:endpoint-a:/repo-a',
+      sessionId: 'scoped-cache-session',
+    });
+    messages.reset();
+
+    expect(messages.tryLoadFromCache({
+      namespace: 'opencode:endpoint-b:/repo-a',
+      sessionId: 'scoped-cache-session',
+    })).toBe(false);
+    expect(messages.tryLoadFromCache({
+      namespace: 'opencode:endpoint-a:/repo-a',
+      sessionId: 'scoped-cache-session',
+    })).toBe(true);
+  });
+
   it('publishes each history chunk before yielding to the next browser task', async () => {
     const messages = useMessages();
     expect(messages.roots.value).toHaveLength(0);

--- a/app/composables/useMessages.ts
+++ b/app/composables/useMessages.ts
@@ -665,6 +665,10 @@ function tryLoadFromCache(identity: MessageCacheIdentity): boolean {
   return true;
 }
 
+function clearSessionCache() {
+  sessionCache.clear();
+}
+
 export function useMessages() {
   return {
     messages: readonly(messages),
@@ -696,6 +700,7 @@ export function useMessages() {
     reset,
     saveSessionState,
     tryLoadFromCache,
+    clearSessionCache,
     dispose,
     bindScope,
   };

--- a/app/composables/useMessages.ts
+++ b/app/composables/useMessages.ts
@@ -15,6 +15,12 @@ import type {
 } from '../types/sse';
 import type { SessionScope } from './useGlobalEvents';
 import { useDeltaAccumulator } from './useDeltaAccumulator';
+import { ByteWeightedLruCache } from '../utils/byteWeightedLru';
+
+export type MessageCacheIdentity = {
+  namespace: string;
+  sessionId: string;
+};
 
 type MessageEntry = {
   info?: MessageInfo;
@@ -30,14 +36,78 @@ const pendingMessageTriggers = new Set<ShallowRef<MessageEntry>>();
 const pendingCollectionTrigger = { value: false };
 let flushScheduled = false;
 const HISTORY_CHUNK_SIZE = 150;
+const MESSAGE_CACHE_NAMESPACE = 'messages';
 const MAX_SESSION_CACHE_ENTRIES = 5;
+const MAX_SESSION_CACHE_BYTES = 32 * 1024 * 1024;
+const MAX_SESSION_CACHE_ENTRY_BYTES = 16 * 1024 * 1024;
 
 type MessageCacheEntry = {
   messages: Map<string, { info?: MessageInfo; parts: MessagePart[] }>;
-  parts: Map<string, MessagePart>;
 };
 
-const sessionCache = new Map<string, MessageCacheEntry>();
+function estimateRetainedBytes(value: unknown, seen = new WeakSet<object>()): number {
+  switch (typeof value) {
+    case 'string':
+      return value.length * 2;
+    case 'number':
+    case 'boolean':
+    case 'bigint':
+      return 8;
+    case 'object':
+      return value === null ? 0 : estimateRetainedObjectBytes(value, seen);
+    default:
+      return 0;
+  }
+}
+
+function estimateRetainedObjectBytes(value: object, seen: WeakSet<object>): number {
+  if (seen.has(value)) return 0;
+  seen.add(value);
+
+  if (value instanceof Map) return estimateMapBytes(value, seen);
+  if (value instanceof Set || Array.isArray(value)) return estimateIterableBytes(value, seen);
+  return estimatePlainObjectBytes(value, seen);
+}
+
+function estimateMapBytes(value: Map<unknown, unknown>, seen: WeakSet<object>): number {
+  let bytes = 0;
+  for (const [key, entry] of value) {
+    bytes += estimateRetainedBytes(key, seen) + estimateRetainedBytes(entry, seen);
+  }
+  return bytes;
+}
+
+function estimateIterableBytes(value: Iterable<unknown>, seen: WeakSet<object>): number {
+  let bytes = 0;
+  for (const entry of value) bytes += estimateRetainedBytes(entry, seen);
+  return bytes;
+}
+
+function estimatePlainObjectBytes(value: object, seen: WeakSet<object>): number {
+  let bytes = 0;
+  for (const [key, entry] of Object.entries(value)) {
+    bytes += key.length * 2 + estimateRetainedBytes(entry, seen);
+  }
+  return bytes;
+}
+
+const sessionCache = new ByteWeightedLruCache<string, MessageCacheEntry>({
+  maxBytes: MAX_SESSION_CACHE_BYTES,
+  maxEntries: MAX_SESSION_CACHE_ENTRIES,
+  maxEntryBytes: MAX_SESSION_CACHE_ENTRY_BYTES,
+  weigh: messageCacheWeight,
+});
+
+function messageCacheKey(identity: MessageCacheIdentity): string {
+  return `${MESSAGE_CACHE_NAMESPACE}:${JSON.stringify([
+    identity.namespace,
+    identity.sessionId,
+  ])}`;
+}
+
+function messageCacheWeight(_key: string, entry: MessageCacheEntry): number {
+  return estimateRetainedBytes(entry.messages);
+}
 
 type BackgroundTaskScheduler = {
   postTask: (
@@ -547,22 +617,14 @@ function dispose() {
   for (const unsub of unsubs) unsub();
 }
 
-function saveSessionState(sessionId: string) {
-  if (!sessionId || messages.value.size === 0) return;
+function saveSessionState(identity: MessageCacheIdentity) {
+  if (!identity.namespace || !identity.sessionId || messages.value.size === 0) return;
 
   for (const messageRef of messages.value.values()) {
     if (resolveStatus(messageRef.value.info) === 'streaming') return;
   }
 
-  if (sessionCache.size >= MAX_SESSION_CACHE_ENTRIES) {
-    const oldestKey = sessionCache.keys().next().value;
-    if (oldestKey !== undefined) {
-      sessionCache.delete(oldestKey);
-    }
-  }
-
   const cachedMessages = new Map<string, { info?: MessageInfo; parts: MessagePart[] }>();
-  const cachedParts = new Map<string, MessagePart>();
 
   for (const [id, messageRef] of messages.value) {
     const entry = messageRef.value;
@@ -570,16 +632,18 @@ function saveSessionState(sessionId: string) {
     for (const partRef of entry.parts) {
       const part = partRef.value;
       partsList.push(part);
-      cachedParts.set(partLookupKey(part.messageID, part.id), part);
     }
     cachedMessages.set(id, { info: entry.info, parts: partsList });
   }
 
-  sessionCache.set(sessionId, { messages: cachedMessages, parts: cachedParts });
+  const key = messageCacheKey(identity);
+  const cached = { messages: cachedMessages };
+  sessionCache.set(key, cached);
 }
 
-function tryLoadFromCache(sessionId: string): boolean {
-  const cached = sessionCache.get(sessionId);
+function tryLoadFromCache(identity: MessageCacheIdentity): boolean {
+  if (!identity.namespace || !identity.sessionId) return false;
+  const cached = sessionCache.get(messageCacheKey(identity));
   if (!cached) return false;
 
   messages.value.clear();
@@ -595,12 +659,6 @@ function tryLoadFromCache(sessionId: string): boolean {
       entry.parts.add(partRef);
     }
     messages.value.set(id, shallowRef(entry));
-  }
-
-  for (const [key, part] of cached.parts) {
-    if (!parts.has(key)) {
-      parts.set(key, shallowRef(part));
-    }
   }
 
   triggerCollection();

--- a/app/composables/useMessagesAuthCache.test.ts
+++ b/app/composables/useMessagesAuthCache.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { useMessages } from './useMessages';
+
+describe('useMessages authentication cache lifecycle', () => {
+  it('clears all warm snapshots when the authentication context changes', () => {
+    const messages = useMessages();
+    messages.reset();
+    messages.updateMessage({
+      id: 'message-auth',
+      sessionID: 'session-auth',
+      role: 'user',
+      time: { created: 1 },
+      agent: 'build',
+      model: { providerID: 'test', modelID: 'test-model' },
+    });
+    messages.saveSessionState({
+      namespace: 'opencode:primary:/repo',
+      sessionId: 'session-auth',
+    });
+
+    messages.clearSessionCache();
+
+    expect(
+      messages.tryLoadFromCache({
+        namespace: 'opencode:primary:/repo',
+        sessionId: 'session-auth',
+      }),
+    ).toBe(false);
+    messages.reset();
+  });
+});

--- a/app/dev/stream-bench.ts
+++ b/app/dev/stream-bench.ts
@@ -362,7 +362,7 @@ function canonicalize(html: string): string {
 // Warmup (excluded from measurements)
 // ---------------------------------------------------------------------------
 async function warmupLegacyPool() {
-  // The pool has min(8, max(4, cores)) workers. Warm every worker with
+  // The pool has min(4, max(2, cores)) workers. Warm every worker with
   // REALISTIC ~150-line code, 3 rounds each: a tiny snippet compiles shiki
   // but leaves V8's optimizing tier cold, which confounds per-chunk latency
   // (observed: cold workers mask the code-size growth curve). Codes are

--- a/app/electronSmokeContract.test.ts
+++ b/app/electronSmokeContract.test.ts
@@ -154,6 +154,25 @@ describe('electron smoke driver contract', () => {
     expect(driverSource).toMatch(/writeFileSync\(RECEIPT_PATH[\s\S]*?catch \{\s*receipt\.pass = false;/);
   });
 
+  it('records a QA-only main-process memory receipt', () => {
+    expect(driverSource).toMatch(/process\.memoryUsage\(\)/);
+    expect(driverSource).toMatch(/receipt\.memory/);
+    expect(driverSource).toMatch(/rss/);
+    expect(driverSource).toMatch(/heapUsed/);
+  });
+
+  it('captures process, renderer, and Linux smaps memory evidence in both samples', () => {
+    expect(driverSource).toMatch(/getProcessMemoryInfo/);
+    expect(driverSource).toMatch(/getSystemMemoryInfo/);
+    expect(driverSource).toMatch(/getAppMetrics/);
+    expect(driverSource).toMatch(/performance\.memory/);
+    expect(driverSource).toMatch(/smaps_rollup/);
+    expect(driverSource).toMatch(/initial:\s*await captureMemory\(app, page\)/);
+    expect(driverSource).toMatch(/receipt\.memory\.relaunch\s*=\s*await captureMemory\(app, page\)/);
+    expect(driverSource).toMatch(/receipt\.memory\.relaunch/);
+    expect(driverSource).toMatch(/memory:\s*metric\.memory\s*\?/);
+  });
+
   it('tears down the app and the temp profile even on failure', () => {
     expect(driverSurface).toMatch(/finally/);
     expect(driverSurface).toMatch(/close\(\)/);

--- a/app/messageCacheAuth.app-contract.test.ts
+++ b/app/messageCacheAuth.app-contract.test.ts
@@ -10,6 +10,7 @@ describe('message cache authentication lifecycle', () => {
       /watch\(\s*\[\s*\(\) => credentials\.authHeader\.value,\s*\(\) => credentials\.codexBridgeToken\.value,\s*\(\) => credentials\.acpBridgeToken\.value,/,
     );
     expect(source).toContain('messageCacheAuthGeneration.value += 1;');
+    expect(source).toContain('sessionReloadRequestId.value += 1;');
     expect(source).toContain('msg.clearSessionCache();');
     expect(source).toContain('backendSessionReload.invalidateMessageCacheContext();');
     expect(source).toContain("{ flush: 'sync' }");

--- a/app/messageCacheAuth.app-contract.test.ts
+++ b/app/messageCacheAuth.app-contract.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(process.cwd(), 'app/App.vue'), 'utf8');
+
+describe('message cache authentication lifecycle', () => {
+  it('synchronously clears warm snapshots when any backend credential changes', () => {
+    expect(source).toMatch(
+      /watch\(\s*\[\s*\(\) => credentials\.authHeader\.value,\s*\(\) => credentials\.codexBridgeToken\.value,\s*\(\) => credentials\.acpBridgeToken\.value,/,
+    );
+    expect(source).toContain('messageCacheAuthGeneration.value += 1;');
+    expect(source).toContain('msg.clearSessionCache();');
+    expect(source).toContain('backendSessionReload.invalidateMessageCacheContext();');
+    expect(source).toContain("{ flush: 'sync' }");
+    expect(source).toMatch(
+      /getMessageCacheNamespace:[\s\S]*messageCacheAuthGeneration\.value,[\s\S]*\]\),/,
+    );
+  });
+});

--- a/app/ptyLifecycle.app-contract.test.ts
+++ b/app/ptyLifecycle.app-contract.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const appSource = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), 'App.vue'), 'utf8');
+
+describe('App PTY lifecycle invalidation contract', () => {
+  it('invalidates pending ownership when removing a PTY window', () => {
+    expect(appSource).toContain('pendingShellWindowCreates.invalidate(ptyId);');
+  });
+
+  it('invalidates all pending ownership on renderer unmount', () => {
+    expect(appSource).toContain('pendingShellWindowCreates.invalidateAll();');
+  });
+
+  it('opens the window only after the dynamic terminal import is current', () => {
+    const importIndex = appSource.indexOf("const { Terminal } = await import('@xterm/xterm');");
+    const openIndex = appSource.indexOf('fw.open(key, {', importIndex);
+    expect(importIndex).toBeGreaterThan(-1);
+    expect(openIndex).toBeGreaterThan(importIndex);
+  });
+
+  it('does not publish stale exit callbacks or window sizing metadata', () => {
+    const importIndex = appSource.indexOf("const { Terminal } = await import('@xterm/xterm');");
+    const exitCallbackIndex = appSource.indexOf('shellExitCallbacks.set(pty.id, options.onExit)');
+    const minimumsIndex = appSource.indexOf('shellWindowMinimums.set(key, {');
+    expect(exitCallbackIndex).toBeGreaterThan(importIndex);
+    expect(minimumsIndex).toBeGreaterThan(importIndex);
+  });
+
+  it('keeps unmount cleanup separate from backend PTY deletion', () => {
+    expect(appSource).toContain('disposeShellWindows();');
+    expect(appSource).toContain('removeShellWindow(ptyId);');
+  });
+});

--- a/app/ptyStaleFont.app-contract.test.ts
+++ b/app/ptyStaleFont.app-contract.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(process.cwd(), 'app/App.vue'), 'utf8');
+
+describe('PTY font-ready ownership', () => {
+  it('does not let a stale callback close a replacement window', () => {
+    expect(source).toContain(`if (shellSessionsByPtyId.get(pty.id)?.terminal !== terminal) {
+          terminal.dispose();
+          return;
+        }`);
+  });
+});

--- a/app/rootHistoryRequest.app-contract.test.ts
+++ b/app/rootHistoryRequest.app-contract.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(process.cwd(), 'app/App.vue'), 'utf8');
+
+describe('root history request ownership', () => {
+  it('allocates the request id exactly once inside fetchHistory', () => {
+    expect(source).toContain(`async function fetchRootSessionHistory(rootSessionId: string) {
+  const loaded = await fetchHistory(rootSessionId);
+  return { requestId: primaryHistoryRequestId, loaded };
+}`);
+  });
+});

--- a/app/utils/byteWeightedLru.test.ts
+++ b/app/utils/byteWeightedLru.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import { ByteWeightedLruCache } from './byteWeightedLru';
+
+describe('ByteWeightedLruCache', () => {
+  it('returns values and refreshes a hit as the most recently used entry', () => {
+    const cache = new ByteWeightedLruCache<string, string>({
+      maxBytes: 6,
+      weigh: (_key, value) => value.length,
+    });
+
+    cache.set('first', '111');
+    cache.set('second', '22');
+    expect(cache.get('first')).toBe('111');
+    cache.set('third', '333');
+
+    expect(cache.has('first')).toBe(true);
+    expect(cache.has('second')).toBe(false);
+    expect(cache.get('third')).toBe('333');
+    expect(cache.bytes).toBe(6);
+    expect(cache.size).toBe(2);
+  });
+
+  it('replaces an existing entry without double-counting its weight', () => {
+    const cache = new ByteWeightedLruCache<string, string>({
+      maxBytes: 10,
+      weigh: (_key, value) => value.length,
+    });
+
+    cache.set('key', '123');
+    cache.set('key', '123456');
+
+    expect(cache.get('key')).toBe('123456');
+    expect(cache.bytes).toBe(6);
+    expect(cache.size).toBe(1);
+  });
+
+  it('evicts entries until the byte budget is satisfied', () => {
+    const cache = new ByteWeightedLruCache<string, string>({
+      maxBytes: 5,
+      weigh: (_key, value) => value.length,
+    });
+
+    cache.set('a', '11');
+    cache.set('b', '22');
+    cache.set('c', '333');
+
+    expect([...cache.entries()]).toEqual([
+      ['b', '22'],
+      ['c', '333'],
+    ]);
+    expect(cache.bytes).toBe(5);
+  });
+
+  it('does not retain an entry larger than the byte budget', () => {
+    const cache = new ByteWeightedLruCache<string, string>({
+      maxBytes: 3,
+      weigh: (_key, value) => value.length,
+    });
+
+    cache.set('small', '12');
+    cache.set('large', '1234');
+
+    expect(cache.get('small')).toBe('12');
+    expect(cache.get('large')).toBeUndefined();
+    expect(cache.bytes).toBe(2);
+  });
+
+  it('supports deletion and clearing while maintaining accounting', () => {
+    const cache = new ByteWeightedLruCache<string, string>({
+      maxBytes: 5,
+      weigh: (_key, value) => value.length,
+    });
+
+    cache.set('a', '11');
+    cache.set('b', '222');
+    expect(cache.delete('a')).toBe(true);
+    expect(cache.delete('missing')).toBe(false);
+    expect(cache.bytes).toBe(3);
+    expect(cache.size).toBe(1);
+
+    cache.clear();
+    expect(cache.bytes).toBe(0);
+    expect(cache.size).toBe(0);
+    expect([...cache.entries()]).toEqual([]);
+  });
+
+  it('rejects invalid byte budgets and entry weights', () => {
+    expect(
+      () =>
+        new ByteWeightedLruCache<string, string>({
+          maxBytes: 0,
+          weigh: (_key, value) => value.length,
+        }),
+    ).toThrow(RangeError);
+
+    const cache = new ByteWeightedLruCache<string, string>({
+      maxBytes: 5,
+      weigh: () => -1,
+    });
+    expect(() => cache.set('key', 'value')).toThrow(RangeError);
+  });
+
+  it('accounts for key and value bytes and enforces optional limits', () => {
+    const cache = new ByteWeightedLruCache<string, string>({
+      maxBytes: 20,
+      maxEntries: 2,
+      maxEntryBytes: 10,
+      weigh: (key, value) => key.length + value.length,
+    });
+
+    cache.set('a', '1234');
+    cache.set('bb', '12345');
+    cache.set('ccc', '1');
+
+    expect(cache.has('a')).toBe(false);
+    expect(cache.has('bb')).toBe(true);
+    expect(cache.has('ccc')).toBe(true);
+    expect(cache.bytes).toBe(11);
+
+    cache.set('too-large', '123');
+    expect(cache.has('too-large')).toBe(false);
+    expect(cache.bytes).toBe(11);
+  });
+});

--- a/app/utils/byteWeightedLru.ts
+++ b/app/utils/byteWeightedLru.ts
@@ -1,0 +1,130 @@
+export type ByteWeight<K, V> = (key: K, value: V) => number;
+
+export interface ByteWeightedLruOptions<K, V> {
+  maxBytes: number;
+  maxEntries?: number;
+  maxEntryBytes?: number;
+  weigh: ByteWeight<K, V>;
+}
+
+type WeightedEntry<V> = {
+  value: V;
+  bytes: number;
+};
+
+export class ByteWeightedLruCache<K, V> {
+  private readonly entriesByKey = new Map<K, WeightedEntry<V>>();
+
+  private currentBytes = 0;
+
+  private readonly maxBytes: number;
+
+  private readonly maxEntries: number | undefined;
+
+  private readonly maxEntryBytes: number | undefined;
+
+  private readonly weigh: ByteWeight<K, V>;
+
+  public constructor(options: ByteWeightedLruOptions<K, V>) {
+    if (!Number.isFinite(options.maxBytes) || options.maxBytes <= 0) {
+      throw new RangeError('maxBytes must be a finite number greater than zero');
+    }
+    if (
+      options.maxEntries !== undefined &&
+      (!Number.isInteger(options.maxEntries) || options.maxEntries <= 0)
+    ) {
+      throw new RangeError('maxEntries must be a positive integer');
+    }
+    if (
+      options.maxEntryBytes !== undefined &&
+      (!Number.isFinite(options.maxEntryBytes) || options.maxEntryBytes <= 0)
+    ) {
+      throw new RangeError('maxEntryBytes must be a finite number greater than zero');
+    }
+    this.maxBytes = options.maxBytes;
+    this.maxEntries = options.maxEntries;
+    this.maxEntryBytes = options.maxEntryBytes;
+    this.weigh = options.weigh;
+  }
+
+  public get size(): number {
+    return this.entriesByKey.size;
+  }
+
+  public get bytes(): number {
+    return this.currentBytes;
+  }
+
+  public has(key: K): boolean {
+    return this.entriesByKey.has(key);
+  }
+
+  public get(key: K): V | undefined {
+    const entry = this.entriesByKey.get(key);
+    if (!entry) return undefined;
+    this.entriesByKey.delete(key);
+    this.entriesByKey.set(key, entry);
+    return entry.value;
+  }
+
+  public set(key: K, value: V): this {
+    const bytes = this.entryWeight(key, value);
+    this.delete(key);
+    if (!this.canStore(bytes)) return this;
+    this.evictUntilFits(bytes);
+
+    this.entriesByKey.set(key, { value, bytes });
+    this.currentBytes += bytes;
+    return this;
+  }
+
+  public delete(key: K): boolean {
+    const entry = this.entriesByKey.get(key);
+    if (!entry) return false;
+    this.entriesByKey.delete(key);
+    this.currentBytes -= entry.bytes;
+    return true;
+  }
+
+  public clear(): void {
+    this.entriesByKey.clear();
+    this.currentBytes = 0;
+  }
+
+  public entries(): IterableIterator<[K, V]> {
+    return this.valuesWithKeys();
+  }
+
+  private *valuesWithKeys(): IterableIterator<[K, V]> {
+    for (const [key, entry] of this.entriesByKey) {
+      yield [key, entry.value];
+    }
+  }
+
+  private entryWeight(key: K, value: V): number {
+    const bytes = this.weigh(key, value);
+    if (!Number.isFinite(bytes) || bytes < 0) {
+      throw new RangeError('entry weight must be a finite number greater than or equal to zero');
+    }
+    return bytes;
+  }
+
+  private canStore(bytes: number): boolean {
+    return bytes <= this.maxBytes && (this.maxEntryBytes === undefined || bytes <= this.maxEntryBytes);
+  }
+
+  private evictUntilFits(bytes: number): void {
+    while (this.exceedsBudget(bytes)) {
+      const oldest = this.entriesByKey.keys().next();
+      if (oldest.done) return;
+      this.delete(oldest.value);
+    }
+  }
+
+  private exceedsBudget(bytes: number): boolean {
+    const exceedsBytes = this.currentBytes + bytes > this.maxBytes;
+    const exceedsEntries =
+      this.maxEntries !== undefined && this.entriesByKey.size >= this.maxEntries;
+    return exceedsBytes || exceedsEntries;
+  }
+}

--- a/app/utils/ptyLifecycle.test.ts
+++ b/app/utils/ptyLifecycle.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import { createPendingPtyCreateRegistry, isCurrentPtySocket } from './ptyLifecycle';
+
+describe('createPendingPtyCreateRegistry', () => {
+  it('shares one in-flight PTY window creation for the same id', async () => {
+    let resolveCreation!: (value: string) => void;
+    const creation = new Promise<string>((resolve) => {
+      resolveCreation = resolve;
+    });
+    const registry = createPendingPtyCreateRegistry<string>();
+    let calls = 0;
+
+    const first = registry.getOrCreate('pty-1', () => {
+      calls += 1;
+      return creation;
+    });
+    const second = registry.getOrCreate('pty-1', () => {
+      calls += 1;
+      return Promise.resolve('duplicate');
+    });
+
+    expect(second).toBe(first);
+    expect(calls).toBe(1);
+    resolveCreation('created');
+    await expect(first).resolves.toBe('created');
+    expect(registry.get('pty-1')).toBeUndefined();
+  });
+
+  it('invalidates an in-flight creation before its deferred factory resolves', async () => {
+    let resolveCreation!: (value: string) => void;
+    const creation = new Promise<string>((resolve) => {
+      resolveCreation = resolve;
+    });
+    const registry = createPendingPtyCreateRegistry<string>();
+    let currentAtResolve = true;
+
+    const first = registry.getOrCreate('pty-1', async (isCurrent) => {
+      const value = await creation;
+      currentAtResolve = isCurrent();
+      return value;
+    });
+    registry.invalidate('pty-1');
+    resolveCreation('created');
+
+    await expect(first).resolves.toBe('created');
+    expect(currentAtResolve).toBe(false);
+    expect(registry.get('pty-1')).toBeUndefined();
+  });
+
+  it('invalidates every pending creation for renderer teardown', async () => {
+    let resolveCreation!: (value: string) => void;
+    const creation = new Promise<string>((resolve) => {
+      resolveCreation = resolve;
+    });
+    const registry = createPendingPtyCreateRegistry<string>();
+    let currentAtResolve = true;
+
+    const first = registry.getOrCreate('pty-1', (isCurrent) =>
+      creation.then((value) => {
+        currentAtResolve = isCurrent();
+        return value;
+      }),
+    );
+    registry.invalidateAll();
+    resolveCreation('created');
+
+    await expect(first).resolves.toBe('created');
+    expect(currentAtResolve).toBe(false);
+  });
+
+  it('does not let an invalidated create affect a newer create for the same id', async () => {
+    let resolveOld!: (value: string) => void;
+    let resolveNew!: (value: string) => void;
+    const oldCreation = new Promise<string>((resolve) => {
+      resolveOld = resolve;
+    });
+    const newCreation = new Promise<string>((resolve) => {
+      resolveNew = resolve;
+    });
+    const registry = createPendingPtyCreateRegistry<string>();
+    let oldCurrentAtResolve = true;
+
+    const oldPending = registry.getOrCreate('pty-1', async (isCurrent) => {
+      const value = await oldCreation;
+      oldCurrentAtResolve = isCurrent();
+      return value;
+    });
+    registry.invalidate('pty-1');
+    const newPending = registry.getOrCreate('pty-1', () => newCreation);
+
+    resolveOld('old');
+    await expect(oldPending).resolves.toBe('old');
+    expect(oldCurrentAtResolve).toBe(false);
+    expect(registry.get('pty-1')).toBe(newPending);
+
+    resolveNew('new');
+    await expect(newPending).resolves.toBe('new');
+  });
+});
+
+describe('isCurrentPtySocket', () => {
+  it('rejects callbacks from a socket replaced for the same PTY', () => {
+    const oldSocket = {};
+    const newSocket = {};
+    const session = { socket: oldSocket };
+    const sessions = new Map([['pty-1', session]]);
+    session.socket = newSocket;
+
+    expect(isCurrentPtySocket(sessions, 'pty-1', session, oldSocket)).toBe(false);
+    expect(isCurrentPtySocket(sessions, 'pty-1', session, newSocket)).toBe(true);
+  });
+
+  it('rejects callbacks from a removed session after its PTY id is reused', () => {
+    const oldSession = { socket: {} };
+    const currentSession = { socket: {} };
+    const sessions = new Map([['pty-1', currentSession]]);
+
+    expect(isCurrentPtySocket(sessions, 'pty-1', oldSession, oldSession.socket)).toBe(false);
+  });
+});

--- a/app/utils/ptyLifecycle.ts
+++ b/app/utils/ptyLifecycle.ts
@@ -1,0 +1,47 @@
+export function createPendingPtyCreateRegistry<T>() {
+  const pending = new Map<string, Promise<T>>();
+  const generations = new Map<string, number>();
+
+  function get(id: string) {
+    return pending.get(id);
+  }
+
+  function getOrCreate(id: string, factory: (isCurrent: () => boolean) => Promise<T>) {
+    const existing = pending.get(id);
+    if (existing) return existing;
+
+    const generation = generations.get(id) ?? 0;
+    let entry: Promise<T>;
+    const isCurrent = () =>
+      generations.get(id) === generation && pending.get(id) === entry;
+    const created = factory(isCurrent);
+    entry = created;
+    pending.set(id, created);
+    const clear = () => {
+      if (pending.get(id) === created) pending.delete(id);
+    };
+    void created.then(clear, clear);
+    return created;
+  }
+
+  function invalidate(id: string) {
+    generations.set(id, (generations.get(id) ?? 0) + 1);
+    pending.delete(id);
+  }
+
+  function invalidateAll() {
+    for (const id of pending.keys()) invalidate(id);
+    pending.clear();
+  }
+
+  return { get, getOrCreate, invalidate, invalidateAll };
+}
+
+export function isCurrentPtySocket<Session extends { socket?: Socket }, Socket>(
+  sessions: Map<string, Session>,
+  ptyId: string,
+  session: Session,
+  socket: Socket,
+) {
+  return sessions.get(ptyId) === session && session.socket === socket;
+}

--- a/app/utils/workerRenderer.test.ts
+++ b/app/utils/workerRenderer.test.ts
@@ -116,8 +116,22 @@ describe('startRenderWorkerStream', () => {
     // Then: token batches arrive at onBatch callbacks in arrival order
     const batches: Array<{ recall: number; stable: unknown[]; unstable: unknown[] }> = [];
     stream.onBatch((batch) => batches.push(batch));
-    streamWorker.emit({ kind: 'tokens', id: 'm1', streamId, recall: 0, stable: [{ content: 'const' }], unstable: [] });
-    streamWorker.emit({ kind: 'tokens', id: 'm2', streamId, recall: 2, stable: [{ content: 'b' }], unstable: [{ content: ';' }] });
+    streamWorker.emit({
+      kind: 'tokens',
+      id: 'm1',
+      streamId,
+      recall: 0,
+      stable: [{ content: 'const' }],
+      unstable: [],
+    });
+    streamWorker.emit({
+      kind: 'tokens',
+      id: 'm2',
+      streamId,
+      recall: 2,
+      stable: [{ content: 'b' }],
+      unstable: [{ content: ';' }],
+    });
     expect(batches.map((batch) => batch.recall)).toEqual([0, 2]);
     expect(batches[1]?.unstable).toEqual([{ content: ';' }]);
 
@@ -174,6 +188,23 @@ describe('startRenderWorkerStream', () => {
 });
 
 describe('single-shot regression', () => {
+  it('caps the single-shot render pool at the memory ceiling', async () => {
+    const mod = await import('../utils/workerRenderer');
+    const render = mod.renderWorkerHtml({
+      id: 'pool-ceiling',
+      code: 'pool ceiling',
+      lang: 'text',
+      theme: 'github-dark',
+    });
+
+    expect(workerState.FakeWorker.instances.length).toBeLessThanOrEqual(4);
+    expect(workerState.FakeWorker.instances.length).toBeGreaterThan(0);
+    const poolWorker = workerState.FakeWorker.instances[0];
+    if (!poolWorker) throw new Error('no pool worker');
+    poolWorker.emit({ id: 'pool-ceiling', ok: true, html: '<pool />' });
+    await expect(render).resolves.toBe('<pool />');
+  });
+
   it('rejects asynchronously and restores counters when worker construction fails', async () => {
     const mod = await import('../utils/workerRenderer');
     const renderState = await import('../composables/useRenderState');
@@ -360,6 +391,53 @@ describe('single-shot regression', () => {
     if (!secondWorker) throw new Error('copy-controls-off request was not posted');
     secondWorker.emit({ id: 'copy-controls-off', ok: true, html: '<h1>Result</h1>' });
     await expect(withoutControls).resolves.toBe('<h1>Result</h1>');
+  });
+
+  it('evicts completed renders by HTML byte budget before entry count', async () => {
+    const mod = await import('../utils/workerRenderer');
+    const firstRequest = {
+      id: 'byte-budget-first',
+      code: 'first byte-budget render',
+      lang: 'text',
+      theme: 'github-dark',
+    };
+    const secondRequest = {
+      id: 'byte-budget-second',
+      code: 'second byte-budget render',
+      lang: 'text',
+      theme: 'github-dark',
+    };
+    const first = mod.renderWorkerHtml(firstRequest);
+    const firstWorker = workerState.FakeWorker.instances.find((worker) =>
+      worker.posted.includes(firstRequest),
+    );
+    if (!firstWorker) throw new Error('first render was not posted');
+    const largeHtmlLength = (9 * 1024 * 1024) / 2;
+    firstWorker.emit({ id: firstRequest.id, ok: true, html: 'a'.repeat(largeHtmlLength) });
+    await expect(first).resolves.toHaveLength(largeHtmlLength);
+
+    const second = mod.renderWorkerHtml(secondRequest);
+    const secondWorker = workerState.FakeWorker.instances.find((worker) =>
+      worker.posted.includes(secondRequest),
+    );
+    if (!secondWorker) throw new Error('second render was not posted');
+    secondWorker.emit({ id: secondRequest.id, ok: true, html: 'b'.repeat(largeHtmlLength) });
+    await expect(second).resolves.toHaveLength(largeHtmlLength);
+
+    const firstAgain = mod.renderWorkerHtml({ ...firstRequest, id: 'byte-budget-first-again' });
+    expect(workerState.FakeWorker.instances.flatMap((worker) => worker.posted)).toHaveLength(3);
+    const firstAgainWorker = workerState.FakeWorker.instances.find((worker) =>
+      worker.posted.some(
+        (message) =>
+          typeof message === 'object' &&
+          message !== null &&
+          'id' in message &&
+          message.id === 'byte-budget-first-again',
+      ),
+    );
+    if (!firstAgainWorker) throw new Error('first render was unexpectedly cached');
+    firstAgainWorker.emit({ id: 'byte-budget-first-again', ok: true, html: '<first-again />' });
+    await expect(firstAgain).resolves.toBe('<first-again />');
   });
 
   it('renderWorkerHtml rejects when the pool worker reports an error', async () => {

--- a/app/utils/workerRenderer.ts
+++ b/app/utils/workerRenderer.ts
@@ -1,6 +1,7 @@
 import RenderWorker from '../workers/render-worker?worker';
 import { incrementPendingRenders, decrementPendingRenders } from '../composables/useRenderState';
 import { RenderCancelledError } from './renderErrors';
+import { ByteWeightedLruCache } from './byteWeightedLru';
 
 export { RenderCancelledError } from './renderErrors';
 // Streaming client lives in ./workerStream; re-exported here so the public
@@ -50,15 +51,19 @@ type RenderTask = {
   cancel: () => void;
 };
 
-const WORKER_POOL_SIZE = typeof navigator !== 'undefined'
-  ? Math.min(8, Math.max(4, navigator.hardwareConcurrency || 4))
-  : 4;
+const RENDER_WORKER_POOL_CEILING = 4;
+const WORKER_POOL_SIZE =
+  typeof navigator !== 'undefined'
+    ? Math.min(RENDER_WORKER_POOL_CEILING, Math.max(2, navigator.hardwareConcurrency || 2))
+    : RENDER_WORKER_POOL_CEILING;
 
 const workers: Worker[] = [];
 let workerIndex = 0;
 const pending = new Map<string, PendingEntry>();
-const completedCache = new Map<string, string>();
-const CACHE_LIMIT = 200;
+const completedCache = new ByteWeightedLruCache<string, string>({
+  maxBytes: 16 * 1024 * 1024,
+  weigh: (key, html) => (key.length + html.length) * 2,
+});
 
 function normalizeLines(value?: string[]) {
   return value && value.length > 0 ? value.join('\u0001') : '';
@@ -90,13 +95,7 @@ function getCacheKey(payload: RenderRequest) {
 }
 
 function cacheRenderedHtml(key: string, html: string) {
-  if (completedCache.has(key)) {
-    completedCache.delete(key);
-  }
   completedCache.set(key, html);
-  if (completedCache.size <= CACHE_LIMIT) return;
-  const oldestKey = completedCache.keys().next().value;
-  if (oldestKey) completedCache.delete(oldestKey);
 }
 
 function errorFromWorkerEvent(error: unknown): Error {

--- a/app/workers/render-worker.test.ts
+++ b/app/workers/render-worker.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ByteWeightedLruCache } from '../utils/byteWeightedLru';
 
 type WorkerResponse = {
   data: {
@@ -36,7 +37,7 @@ function request(id: string, theme: string): RenderPayload {
 }
 
 async function startWorker(
-  moduleSuffix: 'dark-baseline' | 'light-baseline' | 'overlap' | 'copy-controls',
+  moduleSuffix: 'dark-baseline' | 'light-baseline' | 'overlap' | 'copy-controls' | 'oversized',
 ) {
   const messages: WorkerResponse['data'][] = [];
   const waiters = new Map<string, (message: WorkerResponse['data']) => void>();
@@ -51,6 +52,11 @@ async function startWorker(
   priorSelf ??= Reflect.get(globalThis, 'self');
   Object.defineProperty(globalThis, 'self', { configurable: true, value: worker });
   await import(/* @vite-ignore */ `./render-worker?theme-regression-${moduleSuffix}`);
+  const cache = Reflect.get(globalThis, '__visRenderWorkerCacheForTests');
+  if (!(cache instanceof ByteWeightedLruCache)) {
+    throw new Error('render worker test cache is unavailable');
+  }
+  cache.clear();
 
   function render(payload: ReturnType<typeof request>) {
     return new Promise<string>((resolve, reject) => {
@@ -62,7 +68,7 @@ async function startWorker(
     });
   }
 
-  return { messages, render };
+  return { messages, render, cache };
 }
 
 describe('render worker theme isolation', () => {
@@ -103,5 +109,29 @@ describe('render worker theme isolation', () => {
     expect(html).not.toContain('md-copy-btn');
     expect(html).not.toContain('COPY');
     expect(html).not.toContain('Copied');
+  });
+
+  it('shares one byte budget across code and markdown entries with LRU promotion', async () => {
+    const { cache } = await startWorker('overlap');
+    const codeKey = `code:${'x'.repeat(10)}`;
+    const markdownKey = `markdown:${'y'.repeat(10)}`;
+    cache.set(codeKey, 'a'.repeat(1.5 * 1024 * 1024));
+    cache.set(markdownKey, 'b'.repeat(1.5 * 1024 * 1024));
+    expect(cache.get(codeKey)).toHaveLength(1.5 * 1024 * 1024);
+
+    cache.set('code:new', 'c'.repeat(2 * 1024 * 1024));
+
+    expect(cache.has(codeKey)).toBe(true);
+    expect(cache.has(markdownKey)).toBe(false);
+    expect(cache.get('code:new')).toHaveLength(2 * 1024 * 1024);
+  });
+
+  it('rejects an oversized worker cache entry without changing retained output', async () => {
+    const { cache, render } = await startWorker('oversized');
+    const oversized = 'z'.repeat(5 * 1024 * 1024);
+    cache.set('code:oversized', oversized);
+
+    expect(cache.has('code:oversized')).toBe(false);
+    await expect(render(request('exact-output', 'github-dark'))).resolves.toContain('42');
   });
 });

--- a/app/workers/render-worker.ts
+++ b/app/workers/render-worker.ts
@@ -17,6 +17,7 @@ import {
   isStreamWorkerRequest,
   type StreamWorkerRequest,
 } from './streamHandler';
+import { ByteWeightedLruCache } from '../utils/byteWeightedLru';
 
 type RenderRequest = {
   id: string;
@@ -86,17 +87,14 @@ type HighlighterContext = {
 
 const highlighterContexts = new Map<string, Promise<HighlighterContext>>();
 
-const HIGHLIGHT_CACHE_MAX = 512;
-let codeHtmlCache = new Map<string, string>();
-let mdHighlightCache = new Map<string, string>();
+const HIGHLIGHT_CACHE_MAX_BYTES = 8 * 1024 * 1024;
+const highlightCache = new ByteWeightedLruCache<string, string>({
+  maxBytes: HIGHLIGHT_CACHE_MAX_BYTES,
+  weigh: (key, html) => (key.length + html.length) * 2,
+});
 
-function pruneHighlightCache(cache: Map<string, string>) {
-  if (cache.size <= HIGHLIGHT_CACHE_MAX) return;
-  const target = Math.floor(HIGHLIGHT_CACHE_MAX / 2);
-  for (const key of cache.keys()) {
-    if (cache.size <= target) break;
-    cache.delete(key);
-  }
+if (import.meta.env.MODE === 'test') {
+  Reflect.set(globalThis, '__visRenderWorkerCacheForTests', highlightCache);
 }
 
 function getHighlighter(theme: string) {
@@ -118,7 +116,7 @@ function safeCodeToHtml(
   theme: string,
 ): string {
   const cacheKey = `${theme}\0${lang}\0${code}`;
-  const cached = codeHtmlCache.get(cacheKey);
+  const cached = highlightCache.get(`code:${cacheKey}`);
   if (cached !== undefined) return cached;
   let result: string;
   try {
@@ -126,8 +124,7 @@ function safeCodeToHtml(
   } catch {
     result = highlighter.codeToHtml(code, { lang: 'text', theme });
   }
-  codeHtmlCache.set(cacheKey, result);
-  pruneHighlightCache(codeHtmlCache);
+  highlightCache.set(`code:${cacheKey}`, result);
   return result;
 }
 
@@ -746,7 +743,7 @@ function getMarkdownIt(highlighter: Highlighter, theme: string) {
     const shikiHighlight = cachedMd.options.highlight;
     cachedMd.options.highlight = function (code, lang, attrs) {
       const cacheKey = `${theme}\0${lang}\0${code}`;
-      const cached = mdHighlightCache.get(cacheKey);
+      const cached = highlightCache.get(`markdown:${cacheKey}`);
       if (cached !== undefined) return cached;
       let result: string;
       try {
@@ -754,8 +751,7 @@ function getMarkdownIt(highlighter: Highlighter, theme: string) {
       } catch {
         result = safeCodeToHtml(highlighter, code, lang || 'text', theme);
       }
-      mdHighlightCache.set(cacheKey, result);
-      pruneHighlightCache(mdHighlightCache);
+      highlightCache.set(`markdown:${cacheKey}`, result);
       return result;
     };
   }

--- a/bridge/acpTerminalManager.js
+++ b/bridge/acpTerminalManager.js
@@ -19,11 +19,56 @@ export function createAcpTerminalManager(options = {}) {
   const terminals = new Map();
 
   function appendOutput(entry, chunk) {
-    entry.output = Buffer.concat([entry.output, Buffer.from(chunk)]);
-    if (entry.outputByteLimit !== null && entry.output.length > entry.outputByteLimit) {
-      entry.output = entry.output.subarray(entry.output.length - entry.outputByteLimit);
+    const buffer = Buffer.from(chunk);
+    if (buffer.length === 0) return;
+    if (entry.outputByteLimit === null) {
+      entry.outputChunks.push(buffer);
+      entry.outputByteLength += buffer.length;
+      return;
+    }
+    if (buffer.length >= entry.outputByteLimit) {
+      entry.outputChunks = entry.outputByteLimit === 0
+        ? []
+        : [buffer.subarray(buffer.length - entry.outputByteLimit)];
+      entry.outputByteLength = entry.outputByteLimit;
+      entry.truncated = true;
+      return;
+    }
+    entry.outputChunks.push(buffer);
+    entry.outputByteLength += buffer.length;
+    while (entry.outputByteLength > entry.outputByteLimit) {
+      const first = entry.outputChunks[0];
+      const remove = Math.min(first.length, entry.outputByteLength - entry.outputByteLimit);
+      if (remove === first.length) entry.outputChunks.shift();
+      else entry.outputChunks[0] = first.subarray(remove);
+      entry.outputByteLength -= remove;
       entry.truncated = true;
     }
+  }
+
+  function utf8SequenceWidth(byte) {
+    if (byte <= 0x7f) return 1;
+    if (byte >= 0xc2 && byte <= 0xdf) return 2;
+    if (byte >= 0xe0 && byte <= 0xef) return 3;
+    if (byte >= 0xf0 && byte <= 0xf4) return 4;
+    return 0;
+  }
+
+  function hasCompleteUtf8Sequence(buffer, start, width) {
+    if (start + width > buffer.length) return false;
+    return buffer
+      .subarray(start + 1, start + width)
+      .every((byte) => (byte & 0xc0) === 0x80);
+  }
+
+  function utf8SafeTail(buffer) {
+    for (let start = 0; start < buffer.length; start += 1) {
+      const width = utf8SequenceWidth(buffer[start]);
+      if (width > 0 && hasCompleteUtf8Sequence(buffer, start, width)) {
+        return buffer.subarray(start);
+      }
+    }
+    return Buffer.alloc(0);
   }
 
   async function create(params) {
@@ -52,7 +97,8 @@ export function createAcpTerminalManager(options = {}) {
     });
     const entry = {
       child,
-      output: Buffer.alloc(0),
+      outputChunks: [],
+      outputByteLength: 0,
       outputByteLimit,
       truncated: false,
       exitStatus: null,
@@ -71,6 +117,9 @@ export function createAcpTerminalManager(options = {}) {
     if (!launched) throw new Error('ACP terminal failed to start.');
     child.once('exit', (exitCode, signal) => {
       entry.exitStatus = { exitCode, signal };
+    });
+    child.once('close', (exitCode, signal) => {
+      entry.exitStatus ??= { exitCode, signal };
       resolveExit(entry.exitStatus);
     });
     return { terminalId };
@@ -85,7 +134,7 @@ export function createAcpTerminalManager(options = {}) {
   function output(terminalId) {
     const entry = requireTerminal(terminalId);
     return {
-      output: entry.output.toString('utf8'),
+      output: utf8SafeTail(Buffer.concat(entry.outputChunks)).toString('utf8'),
       truncated: entry.truncated,
       ...(entry.exitStatus ? { exitStatus: entry.exitStatus } : {}),
     };

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@types/node": "^24.13.3",
     "@vitejs/plugin-vue": "^6.0.8",
     "@xterm/xterm": "^6.0.0",
-    "electron": "^43.3.0",
+    "electron": "^43.4.1",
     "electron-builder": "^26.15.7",
     "esbuild": "^0.28.2",
     "happy-dom": "^20.11.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,8 +136,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       electron:
-        specifier: ^43.3.0
-        version: 43.3.0(supports-color@7.2.0)
+        specifier: ^43.4.1
+        version: 43.4.1(supports-color@7.2.0)
       electron-builder:
         specifier: ^26.15.7
         version: 26.15.7(electron-builder-squirrel-windows@26.15.7)(supports-color@7.2.0)
@@ -1654,8 +1654,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@43.3.0:
-    resolution: {integrity: sha512-nLlvu0WFjftWsSaTkV2B/c4NDuJBspTyXu8vKSQ6vLvFt8uG3NgN49LLKcXddwX0GqVvAQDhciWp+4xOdTdhew==}
+  electron@43.4.1:
+    resolution: {integrity: sha512-5b+EuiwkgG5iRcsEL34rimgRpkYp15SsfZOa0pC5kXs0Tb82TH4n95rpQzTZa7yRCbA7tm0WoEbuBL6NaAhAcA==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -4344,7 +4344,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@43.3.0(supports-color@7.2.0):
+  electron@43.4.1(supports-color@7.2.0):
     dependencies:
       '@electron-internal/extract-zip': 1.0.5
       '@electron/get': 5.1.0(supports-color@7.2.0)

--- a/scripts/qa/electron-smoke.mjs
+++ b/scripts/qa/electron-smoke.mjs
@@ -28,7 +28,7 @@
  *   VIS_ELECTRON_EXECUTABLE=dist-electron/linux-unpacked/vis pnpm qa:electron
  */
 import { _electron } from 'playwright';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
@@ -153,6 +153,92 @@ async function main() {
     return { app: electronApp, page };
   }
 
+  const unavailableMemory = (reason) => ({ available: false, reason });
+
+  const smapsField = (fields, name) => (fields.has(name) ? fields.get(name) : null);
+
+  const parseSmapsLine = (line) => {
+    const match = line.match(/^(Rss|Pss|Private_Clean|Private_Dirty|SwapPss):\s+(\d+)\s+kB$/);
+    return match ? [match[1], Number(match[2])] : null;
+  };
+
+  const parseSmapsRollup = (source) => {
+    const fields = new Map();
+    for (const line of source.split('\n')) {
+      const field = parseSmapsLine(line);
+      if (field) fields.set(field[0], field[1]);
+    }
+    return {
+      available: true,
+      rssKb: smapsField(fields, 'Rss'),
+      pssKb: smapsField(fields, 'Pss'),
+      privateCleanKb: smapsField(fields, 'Private_Clean'),
+      privateDirtyKb: smapsField(fields, 'Private_Dirty'),
+      swapPssKb: smapsField(fields, 'SwapPss'),
+    };
+  };
+
+  const readLinuxSmapsRollup = (pid) => {
+    try {
+      return parseSmapsRollup(readFileSync(`/proc/${pid}/smaps_rollup`, 'utf8'));
+    } catch {
+      return unavailableMemory('unavailable');
+    }
+  };
+
+  const readSmapsRollup = (pid) =>
+    process.platform === 'linux'
+      ? readLinuxSmapsRollup(pid)
+      : unavailableMemory('not-applicable');
+
+  const captureMemory = async (electronApp, page) => {
+    const main = await electronApp.evaluate(async ({ app }) => {
+      const [processMemory, systemMemory] = await Promise.all([
+        process.getProcessMemoryInfo(),
+        process.getSystemMemoryInfo(),
+      ]);
+      const appMetrics = app.getAppMetrics().map((metric) => ({
+        pid: metric.pid,
+        type: metric.type,
+        memory: metric.memory
+          ? {
+              workingSetSize: metric.memory.workingSetSize,
+              peakWorkingSetSize: metric.memory.peakWorkingSetSize,
+              privateBytes: metric.memory.privateBytes,
+            }
+          : null,
+        cpu: {
+          percentCPUUsage: metric.cpu.percentCPUUsage,
+          idleWakeupsPerSecond: metric.cpu.idleWakeupsPerSecond,
+        },
+      }));
+      return { processMemory, systemMemory, appMetrics };
+    });
+    const renderer = await page.evaluate(() => {
+      const memory = performance.memory;
+      if (!memory) return { available: false };
+      return {
+        available: true,
+        jsHeapSizeLimit: memory.jsHeapSizeLimit,
+        totalJSHeapSize: memory.totalJSHeapSize,
+        usedJSHeapSize: memory.usedJSHeapSize,
+      };
+    });
+    return {
+      main: {
+        ...main,
+        nodeMemory: await electronApp.evaluate(() => {
+          const { rss, heapUsed, external, arrayBuffers } = process.memoryUsage();
+          return { rss, heapUsed, external, arrayBuffers };
+        }),
+      },
+      renderer,
+      linuxSmapsRollup: Object.fromEntries(
+        main.appMetrics.map(({ pid }) => [String(pid), readSmapsRollup(pid)]),
+      ),
+    };
+  };
+
   try {
     let { app, page } = await launchAndProbe();
 
@@ -180,6 +266,9 @@ async function main() {
     receipt.electronVersion = versions.electron;
     receipt.platform = platformInfo;
     receipt.runtimeVersions = versions;
+    receipt.memory = {
+      initial: await captureMemory(app, page),
+    };
     record('platform-and-versions-captured', true, `${platformInfo.platform}/${platformInfo.arch} electron ${versions.electron} chrome ${versions.chrome} node ${versions.node}`);
 
     // Wait for the main window to become visible (ready-to-show), then check sandbox + URL.
@@ -258,6 +347,7 @@ async function main() {
     }, STORAGE_KEY);
     record('persistent-storage-remove', removed === null, `got ${JSON.stringify(removed)}`);
     receipt.persistentStorage = { key: STORAGE_KEY, roundTrip: storageRoundTrip === STORAGE_VALUE, survivedRelaunch: persisted === STORAGE_VALUE, removed: removed === null };
+    receipt.memory.relaunch = await captureMemory(app, page);
 
     // Console cleanliness (uncaught only; handled diagnostics recorded in the log).
     record('no-uncaught-console-errors', pageErrors.length === 0 && mainErrors.length === 0,


### PR DESCRIPTION
## Summary

- bound message and render caches by retained-byte budgets and reduce the Shiki worker pool ceiling to four
- make ACP terminal buffering linear and fence PTY renderer creation/socket ownership races
- upgrade Electron to 43.4.1 and extend isolated smoke receipts with per-process memory evidence

## Verification

- `pnpm lint`
- `pnpm test` (1848 passed)
- `pnpm build`
- `pnpm bridge:build`
- `pnpm electron:preview`
- `VIS_ELECTRON_EXECUTABLE=dist-electron/linux-unpacked/vis xvfb-run -a pnpm qa:electron`
- stream worker drivers: 62/62 passed
- 8-request cold burst: 4-worker median 236.8 ms vs 8-worker HEAD median 361.1 ms
- Fallow changed-code audit: pass
- five-lane target, code-quality, security, runtime-QA, and local-history review: pass

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound long-lived memory with byte-weighted LRU caches, PTY lifecycle invalidation, and output byte limits
> - Introduces `ByteWeightedLruCache` in [byteWeightedLru.ts](https://github.com/qiyuanhuakai/opencode-visualizer-cn/pull/112/files#diff-183cf7fe9e3099fcabecea31602c6494a2efe368bf13362cc0397d47af640a3d) and replaces unbounded `Map` caches in the message warm-cache (`useMessages.ts`), render-worker highlight caches (`render-worker.ts`), and completed-render cache (`workerRenderer.ts`) with byte-budgeted LRU eviction.
> - Adds `createPendingPtyCreateRegistry` and `isCurrentPtySocket` in [ptyLifecycle.ts](https://github.com/qiyuanhuakai/opencode-visualizer-cn/pull/112/files#diff-6e2a67a3e7e7e19326ec1f8a21dac57f49b27c217fc71b55774a5b03c5bd6b70) so concurrent `ensureShellWindow` calls for the same PTY are deduplicated, stale terminal creations are disposed, and superseded socket event handlers return early.
> - Namespaces the message cache by backend identity, directory, and auth generation; credential changes now synchronously clear warm snapshots and invalidate the reload context in `App.vue`.
> - Bounds `acpTerminalManager` output to `outputByteLimit` with head-truncation and UTF-8-safe tail boundaries; `waitForExit` now resolves on `close` instead of `exit` so late output is captured.
> - Reduces render worker pool ceiling from 8 to 4 and records memory evidence in the QA smoke script.
> - Behavioral Change: `saveSessionState`/`tryLoadFromCache` in `MessageStoreLike` now require a `MessageCacheIdentity` object; codex backend views are no longer saved to cache; render-worker and worker-renderer caches evict by total bytes rather than entry count, so large entries may be dropped sooner than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b016d86.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->