### PR TITLE
fix(app): cancel stale OpenCode initialization

### DIFF
--- a/app/App.vue
+++ b/app/App.vue
@@ -9573,6 +9573,7 @@ onMounted(() => {
     ge.on('connection.error', (payload) => {
       if (payload.statusCode === 401 || payload.statusCode === 403) {
         const msg = `${payload.message} (HTTP ${payload.statusCode})`;
+        abortInitialization();
         storageSet(StorageKeys.state.lastAuthError, msg);
         credentials.clear();
         uiInitState.value = 'login';

--- a/app/backendCancellation.app-contract.test.ts
+++ b/app/backendCancellation.app-contract.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(process.cwd(), 'app/App.vue'), 'utf8');
+
+describe('backend initialization cancellation lifecycle', () => {
+  it('invalidates startup before an SSE authentication failure clears credentials', () => {
+    const handlerStart = source.indexOf("ge.on('connection.error'");
+    const handlerEnd = source.indexOf("sessionScope.on('permission.asked'", handlerStart);
+    const handlerSource = source.slice(handlerStart, handlerEnd);
+
+    expect(handlerStart).toBeGreaterThan(-1);
+    expect(handlerEnd).toBeGreaterThan(handlerStart);
+    expect(handlerSource.indexOf('abortInitialization()')).toBeGreaterThan(-1);
+    expect(handlerSource.indexOf('abortInitialization()')).toBeLessThan(
+      handlerSource.indexOf('credentials.clear()'),
+    );
+  });
+});

--- a/app/composables/useBackendActivation.test.ts
+++ b/app/composables/useBackendActivation.test.ts
@@ -295,6 +295,57 @@ describe('useBackendActivation', () => {
     expect(harness.activation.initializationInFlight.value).toBe(false);
   });
 
+  it('keeps an aborted OpenCode bootstrap on the login screen after its work settles', async () => {
+    // Given: OpenCode is still selecting the initial project and session.
+    let finishBootstrap: (() => void) | undefined;
+    const harness = createHarness('opencode', {
+      bootstrapSelections: () =>
+        new Promise<void>((resolve) => {
+          finishBootstrap = resolve;
+        }),
+    });
+    const initialization = harness.activation.startInitialization();
+    await vi.waitFor(() => expect(harness.connectionState.value).toBe('bootstrapping'));
+
+    // When: the user aborts startup before selection finishes.
+    harness.activation.abortInitialization();
+    finishBootstrap?.();
+    await initialization;
+
+    // Then: the obsolete bootstrap cannot publish Ready or continue startup work.
+    expect(harness.uiInitState.value).toBe('login');
+    expect(harness.connectionState.value).toBe('connecting');
+    expect(harness.calls).not.toContain('hydrateActiveWorktreeResources');
+    expect(harness.calls).not.toContain('fetchGlobalProviderConfig');
+  });
+
+  it('preserves an SSE authentication failure after cancelling its pending bootstrap', async () => {
+    // Given: project selection is pending when SSE rejects the active credentials.
+    let finishBootstrap: (() => void) | undefined;
+    const harness = createHarness('opencode', {
+      bootstrapSelections: () =>
+        new Promise<void>((resolve) => {
+          finishBootstrap = resolve;
+        }),
+    });
+    const initialization = harness.activation.startInitialization();
+    await vi.waitFor(() => expect(harness.connectionState.value).toBe('bootstrapping'));
+
+    // When: the authentication handler cancels startup and returns the app to login.
+    harness.activation.abortInitialization();
+    harness.connectionState.value = 'error';
+    harness.initErrorMessage.value = 'Authentication failed. (HTTP 401)';
+    harness.uiInitState.value = 'login';
+    finishBootstrap?.();
+    await initialization;
+
+    // Then: the pending bootstrap cannot overwrite the authentication failure.
+    expect(harness.connectionState.value).toBe('error');
+    expect(harness.initErrorMessage.value).toBe('Authentication failed. (HTTP 401)');
+    expect(harness.uiInitState.value).toBe('login');
+    expect(harness.calls).not.toContain('hydrateActiveWorktreeResources');
+  });
+
   it('keeps Ready state when resource hydration rejects after activation', async () => {
     // Given: hydration fails after the UI is already Ready
     let rejectHydration: ((error: unknown) => void) | undefined;

--- a/app/composables/useBackendActivation.test.ts
+++ b/app/composables/useBackendActivation.test.ts
@@ -4,6 +4,9 @@ import { useBackendActivation } from './useBackendActivation';
 import type { BackendKind } from '../backends/types';
 
 type HarnessOverrides = {
+  codexConnect?: () => Promise<void>;
+  connectOpenCode?: () => Promise<void>;
+  bootstrapAcpWorkspace?: () => Promise<void>;
   bootstrapSelections?: () => Promise<void>;
   hydrateActiveWorktreeResources?: () => Promise<void>;
 };
@@ -23,9 +26,12 @@ function createHarness(initialBackend: BackendKind = 'opencode', overrides: Harn
     bridgeToken: ref(''),
     activeThreadId: ref('thread-1'),
     visibleThreads: ref([{ id: 'thread-1' }]),
-    connect: vi.fn(async () => {
-      calls.push('codex.connect');
-    }),
+    connect: vi.fn(
+      overrides.codexConnect ??
+        (async () => {
+          calls.push('codex.connect');
+        }),
+    ),
     disconnect: vi.fn(() => {
       calls.push('codex.disconnect');
     }),
@@ -37,9 +43,12 @@ function createHarness(initialBackend: BackendKind = 'opencode', overrides: Harn
     }),
   };
   const ge = {
-    connect: vi.fn(async () => {
-      calls.push('ge.connect');
-    }),
+    connect: vi.fn(
+      overrides.connectOpenCode ??
+        (async () => {
+          calls.push('ge.connect');
+        }),
+    ),
     disconnect: vi.fn(() => {
       calls.push('ge.disconnect');
     }),
@@ -104,11 +113,13 @@ function createHarness(initialBackend: BackendKind = 'opencode', overrides: Harn
     configureAcpBackend,
     disconnectAcpBackend,
     disconnectCodexBackend,
-    bootstrapAcpWorkspace: async () => {
-      calls.push('bootstrapAcpWorkspace');
-      selectedProjectId.value = 'acp';
-      selectedSessionId.value = 'acp-session';
-    },
+    bootstrapAcpWorkspace:
+      overrides.bootstrapAcpWorkspace ??
+      (async () => {
+        calls.push('bootstrapAcpWorkspace');
+        selectedProjectId.value = 'acp';
+        selectedSessionId.value = 'acp-session';
+      }),
     fetchGlobalProviderConfig: async () => {
       calls.push('fetchGlobalProviderConfig');
     },
@@ -345,6 +356,46 @@ describe('useBackendActivation', () => {
     expect(harness.uiInitState.value).toBe('login');
     expect(harness.calls).not.toContain('hydrateActiveWorktreeResources');
   });
+
+  it.each(['codex', 'acp'] satisfies BackendKind[])(
+    'keeps a new OpenCode initialization owned after a stale %s activation settles',
+    async (staleBackend) => {
+      // Given: a backend activation remains pending while a replacement OpenCode login starts.
+      let finishStaleActivation: (() => void) | undefined;
+      let finishOpenCodeConnect: (() => void) | undefined;
+      const harness = createHarness(staleBackend, {
+        codexConnect: () =>
+          new Promise<void>((resolve) => {
+            finishStaleActivation = resolve;
+          }),
+        bootstrapAcpWorkspace: () =>
+          new Promise<void>((resolve) => {
+            finishStaleActivation = resolve;
+          }),
+        connectOpenCode: () =>
+          new Promise<void>((resolve) => {
+            finishOpenCodeConnect = resolve;
+          }),
+      });
+      const staleInitialization = harness.activation.startInitialization();
+      await vi.waitFor(() => expect(finishStaleActivation).toBeTypeOf('function'));
+      harness.activation.abortInitialization();
+      harness.credentials.backendKind.value = 'opencode';
+      const currentInitialization = harness.activation.startInitialization();
+      await vi.waitFor(() => expect(finishOpenCodeConnect).toBeTypeOf('function'));
+
+      // When: the obsolete activation reaches its finalizer.
+      finishStaleActivation?.();
+      await staleInitialization;
+
+      // Then: the replacement still owns the lock and can finish reaching Ready.
+      expect(harness.activation.initializationInFlight.value).toBe(true);
+      finishOpenCodeConnect?.();
+      await currentInitialization;
+      expect(harness.connectionState.value).toBe('ready');
+      expect(harness.uiInitState.value).toBe('ready');
+    },
+  );
 
   it('keeps Ready state when resource hydration rejects after activation', async () => {
     // Given: hydration fails after the UI is already Ready

--- a/app/composables/useBackendActivation.ts
+++ b/app/composables/useBackendActivation.ts
@@ -111,7 +111,7 @@ export function useBackendActivation(options: UseBackendActivationOptions) {
     options.selectedModel.value = '';
   }
 
-  async function activateCodex() {
+  async function activateCodex(generation: number) {
     options.ge.disconnect();
     options.disconnectAcpBackend();
     options.activeBackendKind.value = 'codex';
@@ -170,7 +170,7 @@ export function useBackendActivation(options: UseBackendActivationOptions) {
       options.initErrorMessage.value = options.toErrorMessage(error);
       options.uiInitState.value = 'login';
     } finally {
-      initializationInFlight.value = false;
+      if (generation === initializationGeneration) initializationInFlight.value = false;
     }
   }
 
@@ -222,7 +222,7 @@ export function useBackendActivation(options: UseBackendActivationOptions) {
     }
   }
 
-  async function activateAcp() {
+  async function activateAcp(generation: number) {
     try {
       options.ge.disconnect();
       options.disconnectCodexBackend();
@@ -262,22 +262,23 @@ export function useBackendActivation(options: UseBackendActivationOptions) {
       options.initErrorMessage.value = options.toErrorMessage(error);
       options.uiInitState.value = 'login';
     } finally {
-      initializationInFlight.value = false;
+      if (generation === initializationGeneration) initializationInFlight.value = false;
     }
   }
 
   async function startInitialization() {
     if (initializationInFlight.value) return;
     initializationInFlight.value = true;
+    const generation = ++initializationGeneration;
     if (options.credentials.backendKind.value === 'codex') {
-      await activateCodex();
+      await activateCodex(generation);
       return;
     }
     if (options.credentials.backendKind.value === 'acp') {
-      await activateAcp();
+      await activateAcp(generation);
       return;
     }
-    await activateOpenCode(++initializationGeneration);
+    await activateOpenCode(generation);
   }
 
   function cancelInitialization() {

--- a/app/composables/useBackendActivation.ts
+++ b/app/composables/useBackendActivation.ts
@@ -78,6 +78,11 @@ export type UseBackendActivationOptions = {
 
 export function useBackendActivation(options: UseBackendActivationOptions) {
   const initializationInFlight = { value: false } as Ref<boolean>;
+  let initializationGeneration = 0;
+
+  function ownsInitialization(generation: number) {
+    return initializationInFlight.value && generation === initializationGeneration;
+  }
 
   function markStartup(name: string) {
     if (typeof performance !== 'undefined' && typeof performance.mark === 'function') {
@@ -169,7 +174,7 @@ export function useBackendActivation(options: UseBackendActivationOptions) {
     }
   }
 
-  async function activateOpenCode() {
+  async function activateOpenCode(generation: number) {
     options.disconnectAcpBackend();
     options.disconnectCodexBackend();
     options.activeBackendKind.value = 'opencode';
@@ -182,11 +187,14 @@ export function useBackendActivation(options: UseBackendActivationOptions) {
       options.connectionState.value = 'connecting';
       options.initLoadingMessage.value = options.t('app.connection.connecting');
       await options.ge.connect({ failFast: true, timeoutMs: 10000 });
+      if (!ownsInitialization(generation)) return;
       options.connectionState.value = 'bootstrapping';
       options.initLoadingMessage.value = options.t('app.status.loadingServerPath');
       await options.fetchHomePath();
+      if (!ownsInitialization(generation)) return;
       options.initLoadingMessage.value = options.t('app.status.loadingProjects');
       await options.bootstrapSelections();
+      if (!ownsInitialization(generation)) return;
       markStartup('vis:opencode-session-selectable');
       options.connectionState.value = 'ready';
       options.uiInitState.value = 'ready';
@@ -197,7 +205,7 @@ export function useBackendActivation(options: UseBackendActivationOptions) {
       await options.fetchGlobalProviderConfig();
       await Promise.all([options.fetchProviders(true), options.fetchAgents()]);
     } catch (error) {
-      if (!initializationInFlight.value) return;
+      if (!ownsInitialization(generation)) return;
       // Once the UI reached Ready, only connect/path/hydration/selection
       // failures (all pre-Ready) may send the user back to login.
       if (options.uiInitState.value === 'ready') return;
@@ -210,7 +218,7 @@ export function useBackendActivation(options: UseBackendActivationOptions) {
       options.initErrorMessage.value = message;
       options.uiInitState.value = 'login';
     } finally {
-      initializationInFlight.value = false;
+      if (generation === initializationGeneration) initializationInFlight.value = false;
     }
   }
 
@@ -269,15 +277,20 @@ export function useBackendActivation(options: UseBackendActivationOptions) {
       await activateAcp();
       return;
     }
-    await activateOpenCode();
+    await activateOpenCode(++initializationGeneration);
+  }
+
+  function cancelInitialization() {
+    initializationGeneration += 1;
+    initializationInFlight.value = false;
   }
 
   function abortInitialization() {
+    cancelInitialization();
     options.ge.disconnect();
     options.disconnectAcpBackend();
     if (options.credentials.backendKind.value === 'codex') options.codexApi.disconnectTransport();
     options.disconnectCodexBackend();
-    initializationInFlight.value = false;
     options.connectionState.value = 'connecting';
     options.uiInitState.value = 'login';
     options.initErrorMessage.value = '';


### PR DESCRIPTION
## Scope

Minimal lifecycle follow-up stacked on PR #113. A production-reachable OpenCode race allowed initialization that was already awaiting `/path` or bootstrap selection to finish after user cancellation or a SharedWorker 401/403, overwrite the login/error state with Ready, and leave the worker transport requested. This PR adds ownership fencing only to the pre-Ready OpenCode initialization and routes SSE authentication failures through the existing abort cleanup before clearing credentials.

Explicitly not included: credential revisions/CAS or multiwindow races, model visibility lifecycle, Codex/ACP redesign, and daemon shutdown admission. Those broader historical changes were not reproduced and remain rejected. Requested history objects `56ce96616` and `234196b1f` were unavailable locally/remotely; the closest verified related commit was `234f45835`, so no behavior was inferred from missing objects.

## RED / GREEN

- RED before production edit: `pnpm vitest run app/composables/useBackendActivation.test.ts` -> 1 failed, 14 passed; aborted bootstrap expected `login` but stale completion produced `ready`.
- GREEN after fix: `pnpm vitest run app/backendCancellation.app-contract.test.ts app/composables/useBackendActivation.test.ts` -> 2 files, 17 tests passed.
- Contract coverage asserts the production SSE 401/403 handler aborts before credential clearing.

## Verification

- Exact pushed head: `20f1ea396c5178a135ab48af7461770589b04024`
- Stacked base: `bc6eea22fa58063a48bd77852a4f22b91630bdeb` (`feat/raycast-snippets`, PR #113)
- Full suite: 259 files passed, 1 skipped; 2,010 tests passed, 2 skipped
- `pnpm lint`: PASS (`oxlint` + `vue-tsc --noEmit`)
- `pnpm build`: PASS (Vite production build)
- `pnpm bridge:build`: PASS (SEA bridge artifact generated)
- `git diff --check`: PASS
- Fallow changed-code audit: no introduced dead code or complexity; advisory warning only for inherited CSS duplication in touched `App.vue`
- Fallow decision surface: zero structural decisions

Full Vitest exits successfully after reporting all tests passed, but still emits the repository-existing fork-worker teardown/close warnings. The Draft does not claim those warnings are fixed.

## Live browser evidence

A Playwright driver loaded the Vite UI with a mocked SharedWorker, held `/path` pending, emitted a 401, then released the stale request. Observed:

```json
{"loginVisible":true,"readyHeaderCount":0,"errorText":"Authentication failed. (HTTP 401)","workerDisconnects":1,"consoleErrors":[]}
```

This demonstrates both state fencing and actual disconnect ordering through the user-facing login surface.

## Five-lane review

All required lanes PASS on exact commit `20f1ea396`:

| Area | Session | Verdict |
| --- | --- | --- |
| Goal and constraints, fresh re-review | `ses_f8e3dda44ffeQdE1p5a4Zz0zhc` | PASS, 0.97 confidence |
| Hands-on QA | `ses_f8e42ca8cfferD7VQ9gnIiJZYS` | PASS, 0.88 confidence |
| Code quality | `ses_f8e42c9b7ffeyB5CXZun7tvCV7` | PASS, 0.88 confidence; direct event/retry test expansion is non-blocking |
| Security | `ses_f8e42c0ceffeFDclkAINerfW3p` | PASS; no blocking security findings |
| Context and history | `ses_f8e42c14dffeEe5XqZJPTySMQz` | PASS, 0.90 confidence |

The first goal review was superseded because it incorrectly treated uncommitted runtime evidence as absent and broadened scope to unreproduced post-Ready provider cancellation. The fresh independent lane verified the commands/evidence and the user-authorized pre-Ready boundary.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cancel stale OpenCode initialization on SSE auth failure
> - Adds a monotonic generation counter to `useBackendActivation` so each initialization attempt owns a unique generation; asynchronous work checks ownership before publishing results or clearing the in-flight flag.
> - `activateOpenCode` checks ownership after connection, home-path fetch, and selection bootstrap, so a cancelled initialization exits without applying stale errors or moving to Ready.
> - `cancelInitialization` advances the generation and clears the in-flight flag without disconnecting backends or changing UI state, making the lifecycle available for a replacement attempt immediately.
> - The SSE auth-error handler in [App.vue](https://github.com/qiyuanhuakai/opencode-visualizer-cn/pull/114/files#diff-b0f1d2fd02c89170e22be5bca533bf7d5988bd1be5835047f65fdf991793a273) now cancels pending initialization before clearing credentials and switching to login.
> - Risk: all three activation routines (`activateCodex`, `activateOpenCode`, `activateAcp`) in [useBackendActivation.ts](https://github.com/qiyuanhuakai/opencode-visualizer-cn/pull/114/files#diff-ff7806a383771c155c019bf08da7a599d35ec1c154e63dc699f4351b41d7f1e2) must pass and check the generation; a missed check lets stale work overwrite a newer initialization.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62fb497.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->