### PR TITLE
fix: 修复文件树刷新、PTY 与斜杠命令发送，并扩写 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | 功能类别 | 改进内容 | 状态 |
 |---|---|---|
 | **国际化 (i18n)** | 完整 i18n 框架支持，支持简体中文、繁体中文、日语、世界语 | ✅ 已上线 |
-| **字体管理** | 支持设置 Shell 字体、界面等宽字体，支持设置终端/代码/消息/UI 字体大小，系统字体自动发现 | 🅱️ Beta |
+| **字体管理** | 支持设置 Shell 字体、界面等宽字体，支持设置终端/代码/消息/UI/侧边栏字体大小，系统字体自动发现 | 🅱️ Beta |
 | **供应商与模型管理** | 查看/启用/禁用本地模型和供应商；支持所有提供商的 Web 端连接、自定义提供商连接；完善的 i18n 支持 | ✅ 已上线 |
 | **状态监控** | 查看服务器、MCP、LSP、Plugin、Skills 状态；支持关闭 MCP 连接；实时显示当前会话 Token 消耗（上下文限制、输入/输出/推理 Token、使用率进度条） | ✅ 已上线 |
 | **主题设置** | 自定义各卡片不同组件颜色 | 🅱️ Beta |
@@ -44,10 +44,13 @@
 | **会话重命名** | 重命名 Session | ✅ 已上线 |
 | **悬浮窗管理** | 全面覆盖的关闭/最小化按钮，底部 Dock 栏存放最小化窗口 | ✅ 已上线 |
 | **悬浮窗预览自动换行** | 在设置中开启/关闭；超大文件使用可变行高虚拟滚动，换行时仍限制实际挂载行数 | ✅ 已上线 |
-| **快捷命令** | 支持 `@` 显式召唤代理 | ✅ 已上线 |
+| **快捷命令** | 支持 `@` 显式召唤代理、`$` 召唤技能 | ✅ 已上线 |
+| **代码片段 (Snippets)** | 自定义触发词（`\name` 或 `::name`、`;name` 等带标点前缀）与动态变量（`{date}`、`{time}`、`{datetime}`、`{uuid}`、`{clipboard}`、`{activeFile}`、`{cwd}`、`{selection}`、`{cursor}`）；标签筛选、启用开关、导入/导出；可从收藏一键创建；输入触发词后显式选择补全展开 | ✅ 已上线 |
+| **本地文件编辑** | 内置 CodeMirror 6 编辑器，在 Web 端编辑本地文件：三个后端均通过桥接 `/fs/writeFile` 写入（OpenCode 经已连接的 vis_bridge 并回读校验，Codex / ACP 经各自桥接工作区接口）；编辑器字号、缩进与键盘快捷键可自定义；桌面端可用本地应用打开临时副本并将每次保存同步回后端，带磁盘变更冲突保护 | ✅ 已上线 |
+| **文件树 Git 操作** | 基于 git status 的文件树，支持暂存区/变更/全部三种视图与 diff 统计；分支搜索、创建（输入新名称）、切换、合并、变基、删除本地分支；ahead/behind 徽标提供 push/pull，分支与上游操作菜单提供 fetch。切换分支与 fetch 直接执行，合并/变基/删除/push/pull 需确认；这些用户触发的分支操作在一次性 PTY（`/bin/sh -c`）中运行，成功后自动关闭并刷新文件树 | ✅ 已上线 |
 | **性能优化** | 超大 Session 懒加载、超多 Session 后台 Hydration、冷启动加速、输出面板连续批次加载、悬浮窗弹出性能优化 | ✅ 已上线 |
-| **桌面应用** | Electron 桌面端打包，支持 Windows / macOS / Linux | ✅ 已上线 |
-| **Codex 集成 (Alpha)** | vis_bridge 轻量桥接器转发 Codex app-server JSON-RPC；Codex Panel 最小化悬浮窗面板；设置中开启实验性功能 | 🅰️ Alpha |
+| **桌面应用** | Electron 桌面端打包，支持 Windows / macOS / Linux；应用与 vis_bridge 的应用内更新检查与下载、系统托盘（最小化/关闭到托盘）、任务完成桌面通知与可选提示音 | ✅ 已上线 |
+| **Codex 集成 (Alpha)** | vis_bridge 轻量桥接器转发 Codex app-server JSON-RPC；Codex Panel 最小化悬浮窗面板，内置模型、技能、插件市场、MCP 服务器与本地文件管理；运行时检查器按方法探测 app-server 能力（支持/不支持/需开启实验开关）；设置中开启实验性功能 | 🅰️ Alpha |
 | **ACP Agent 集成 (Alpha)** | ACP v1 作为第三后端复用主会话界面；状态监控中管理 Pi、Oh My Pi、Kimi Code 等 ACP Agent | 🅰️ Alpha |
 | **Forge 集成 (Beta)** | 基于 zsh PTY 的 Forge 悬浮终端；命令菜单、结构化会话侧栏、状态读取与刷新恢复 | 🅱️ Beta |
 
@@ -207,6 +210,19 @@ forge setup
 
 ---
 
+## 代码片段（Snippets）使用说明
+
+代码片段让你把常用提示词保存为可复用模板，在输入框中通过触发词展开。
+
+1. 进入 Vis 的"设置" → "片段"，确认"启用片段"已开启
+2. 新建片段：设置触发词、正文，可附加标签便于筛选；保存自动完成
+3. 触发词默认以 `\name` 形式展开；使用 `::name`、`;name` 等带标点的触发词可自定义前缀
+4. 正文中可使用动态变量：`{date}`、`{time}`、`{datetime}`、`{uuid}`、`{clipboard}`、`{activeFile}`、`{cwd}`、`{selection}`，以及 `{cursor}` 指定展开后的光标位置
+5. 在输入框中输入触发词，从补全列表选择对应片段或按 Enter 展开；Space 和 Tab 保持原有输入行为
+6. 收藏夹中的消息可通过"从收藏创建片段"直接转为代码片段；片段支持导出/导入 JSON 文件
+
+---
+
 ## 功能展示
 
 ### 1. 主界面与简体中文支持
@@ -273,6 +289,10 @@ pnpm dev
 - 独立应用窗口，无需浏览器，支持 macOS 隐藏式标题栏
 - 安全沙箱（`contextIsolation` + `sandbox`），外部链接通过系统浏览器打开
 - 开发模式下自动处理 CORS，便于本地调试
+- 应用与 vis_bridge 分别检查更新：Windows / Linux 安装版支持应用内下载安装；macOS 应用下载 DMG 后手动安装，vis_bridge 使用 PKG 安装包。自动检查与自动下载默认关闭，安装始终需要确认
+- 可选"最小化到托盘"与"关闭到托盘"（默认关闭），托盘菜单可退出
+- 会话任务完成时弹出桌面通知（窗口聚焦时不打扰），可选系统提示音（默认关闭）；macOS ad-hoc 构建不支持原生通知，仅保留声音回退
+- 原生菜单跟随应用语言，保留退出与刷新入口
 - 支持 NSIS / AppImage / deb / dmg 各平台安装包
 - 运行时基线：Electron **43.4.1**（Chromium 150 / Node 24.18.1），Chromium 沙箱全程开启
 
@@ -340,21 +360,25 @@ All upstream [Vis](https://github.com/xenodrive/vis) core features are fully pre
 | Category | Feature | Status |
 |---|---|---|
 | **Internationalization (i18n)** | Full i18n framework supporting English, Simplified Chinese, Traditional Chinese, Japanese, and Esperanto | ✅ Available |
-| **Font Management** | Shell font, UI monospace font, system font auto-discovery | 🅱️ Beta |
+| **Font Management** | Shell font, UI monospace font, adjustable terminal/code/message/UI/sidebar font sizes, system font auto-discovery | 🅱️ Beta |
 | **Provider & Model Management** | View/enable/disable local models and providers; support all provider Web connections and custom provider connections; full i18n support | ✅ Available |
 | **Status Monitor** | View server, MCP, LSP, Plugin, Skills status; close MCP connections; real-time session token usage (context limit, input/output/reasoning tokens, usage progress bar) | ✅ Available |
 | **Theme Settings** | Customize colors for different card components | 🅱️ Beta |
 | **Editor Integration** | Open text files with system `$EDITOR` | ✅ Available |
 | **Code Line Comment** | Drag to select range and append comment to input | ✅ Available |
-| **Session Tree Management** | Added a session tree panel in the sidebar; sessions are pinned based on a three-level hierarchy of project-sandbox-session. ✅ Available |
-| **Batch Management** | Top bar "Management" button for multi-select Session operations. ✅ Available |
-| **Unarchive** | Restore archived Sessions. ✅ Available |
-| **Rename Session** | Rename Session. ✅ Available |
+| **Session Tree Management** | Added a session tree panel in the sidebar; sessions are pinned based on a three-level hierarchy of project-sandbox-session | ✅ Available |
+| **Batch Management** | Top bar "Management" button for multi-select Session operations | ✅ Available |
+| **Unarchive** | Restore archived Sessions | ✅ Available |
+| **Rename Session** | Rename Session | ✅ Available |
 | **Floating Window Management** | Close/minimize buttons for all popups, bottom Dock bar | ✅ Available |
-| **Quick Commands** | `@` shortcut to explicitly summon agents | ✅ Available |
+| **Floating Preview Auto-Wrap** | Toggle in Settings; oversized files use variable-row-height virtual scrolling, still capping actually mounted rows while wrapped | ✅ Available |
+| **Quick Commands** | `@` to explicitly summon agents, `$` to invoke skills | ✅ Available |
+| **Snippets** | Custom triggers (`\name`, or punctuation-prefixed like `::name` / `;name`) with dynamic variables (`{date}`, `{time}`, `{datetime}`, `{uuid}`, `{clipboard}`, `{activeFile}`, `{cwd}`, `{selection}`, `{cursor}`); tag filtering, per-snippet toggle, JSON import/export; create snippets from favorites; type a trigger and pick its completion or press Enter to expand | ✅ Available |
+| **Local File Editing** | Embedded CodeMirror 6 editor; edit local files from the web UI on all three backends via the bridged `/fs/writeFile` (OpenCode writes through the connected vis_bridge with a verify-read, Codex / ACP through their bridged workspace endpoints); adjustable editor font size, indent, and remappable keyboard shortcuts; on desktop, open a temporary copy in a local application and sync each save back to the backend with on-disk conflict protection | ✅ Available |
+| **File Tree Git Actions** | git-status-based file tree with Index/Changes/All views and diff stats; branch search, create (prompts for a name), checkout, merge, rebase, and local branch deletion; push/pull on ahead/behind badges, and fetch in the branch/upstream action menu. Checkout and fetch run immediately; merge/rebase/delete/push/pull ask for confirmation; these user-triggered branch actions run in a one-shot PTY (`/bin/sh -c`) that closes on success and refreshes the file tree | ✅ Available |
 | **Performance** | Lazy loading for large sessions, background hydration, faster cold start, continuous batched output loading, floating window popup optimization | ✅ Available |
-| **Desktop App** | Electron desktop packaging for Windows / macOS / Linux | ✅ Available |
-| **Codex Integration (Alpha)** | vis_bridge lightweight bridge for Codex app-server JSON-RPC; Codex Panel minimal floating panel; experimental features toggle in settings | 🅰️ Alpha |
+| **Desktop App** | Electron desktop packaging for Windows / macOS / Linux; in-app update checks and downloads for both the app and vis_bridge, system tray (minimize/close to tray), desktop completion notifications with optional sound | ✅ Available |
+| **Codex Integration (Alpha)** | vis_bridge lightweight bridge for Codex app-server JSON-RPC; Codex Panel minimal floating panel with built-in model, skill, plugin marketplace, MCP server, and local file management; runtime inspector probes app-server capabilities per method (supported/unsupported/gated); experimental features toggle in settings | 🅰️ Alpha |
 | **ACP Agent Integration (Alpha)** | ACP v1 as a third backend using the shared main chat UI; manage Pi, Oh My Pi, Kimi Code, and other ACP agents in Status Monitor | 🅰️ Alpha |
 | **Forge Integration (Beta)** | zsh PTY-based Forge floating terminal with command menus, structured conversation sidebar, status reads, and refresh restoration | 🅱️ Beta |
 
@@ -515,6 +539,19 @@ Drag the sidebar to resize it. Dragging it right past the hide threshold collaps
 
 ---
 
+## Snippets Usage
+
+Snippets save reusable prompt templates that expand from triggers in the composer.
+
+1. Go to Vis **Settings** → **Snippets** and make sure **Enable snippets** is on
+2. Create a snippet with a trigger, body, and optional tags for filtering; changes save automatically
+3. A plain trigger expands as `\name`; include punctuation such as `::name` or `;name` for a custom prefix
+4. The body supports dynamic variables: `{date}`, `{time}`, `{datetime}`, `{uuid}`, `{clipboard}`, `{activeFile}`, `{cwd}`, `{selection}`, plus `{cursor}` to place the caret after expansion
+5. Type a trigger in the composer and pick its completion or press Enter to expand; Space and Tab keep their normal behavior
+6. Favorited messages can be turned into snippets via **Create snippet from favorite**; snippets export and import as JSON files
+
+---
+
 ## Development & Building
 
 ### Web Development
@@ -532,8 +569,14 @@ This project supports packaging the Web UI as a native desktop application using
 - Standalone app window, no browser required, supports macOS hidden-inset title bar
 - Secure sandbox (`contextIsolation` + `sandbox`); external links open in system browser
 - Auto CORS handling in development mode for local debugging
+- Separate update checks for the app and vis_bridge: in-app download and install for Windows / Linux installed builds; on macOS, install the app manually from a DMG and vis_bridge from a PKG installer. Automatic checks and downloads are off by default and installing always asks for confirmation
+- Optional minimize-to-tray and close-to-tray (both off by default), with quit from the tray menu
+- Desktop notifications when a session task completes (suppressed while the window is focused), with an optional system sound (off by default); macOS ad-hoc builds do not support native notifications and keep only the sound fallback
+- Native menus follow the app language and keep only Quit and Reload entries
 - Supports NSIS / AppImage / deb / dmg installers for each platform
 - Runtime baseline: Electron **43.4.1** (Chromium 150 / Node 24.18.1), Chromium sandbox always enabled
+
+For details on in-app updates, tray behavior, and notification sounds, see [docs/desktop-integration.md](docs/desktop-integration.md).
 
 **macOS Signing Status (Important):** macOS builds are **ad-hoc signed** (no Developer ID, no assigned TeamIdentifier, no notarization; `mac.identity: "-"`, `mac.notarize: false`). Both Intel and Apple Silicon artifacts have passed `codesign --verify --deep --strict` on macOS runners, with checks against the app bundles mounted from DMG and extracted from ZIP. Gatekeeper still shows the standard "cannot verify the developer" warning; right-click → Open is required. macOS **Notifications are unavailable** and notarization is not configured. These limits are accepted decisions for this release — see `CHANGELOG.md`.
 

--- a/app/App.vue
+++ b/app/App.vue
@@ -625,6 +625,7 @@ import {
   useBackendSessionLifecycle,
 } from './composables/useBackendSessionLifecycle';
 import { useBackendMessageSend } from './composables/useBackendMessageSend';
+import type { CommandFilePart } from './composables/backendMessageSend.types';
 import { useBackendSessionReload } from './composables/useBackendSessionReload';
 import { useBackendSessionStatus } from './composables/useBackendSessionStatus';
 import { useBackendSelectionBootstrap } from './composables/useBackendSelectionBootstrap';
@@ -6965,7 +6966,12 @@ function runDebugCommand(args: string): { ok: boolean; message: string } {
   return { ok: false, message: t('app.debug.unknownSubcommand', { sub }) };
 }
 
-async function sendCommand(sessionId: string, command: CommandInfo, commandArgs: string) {
+async function sendCommand(
+  sessionId: string,
+  command: CommandInfo,
+  commandArgs: string,
+  parts: CommandFilePart[],
+) {
   if (!ensureConnectionReady(t('app.actions.sendingCommands'))) return;
   const directory = activeDirectory.value.trim();
   const sendCommand = requireBackendMethod(backend().sendCommand, 'session command sending');
@@ -6976,6 +6982,7 @@ async function sendCommand(sessionId: string, command: CommandInfo, commandArgs:
     agent: command.agent || resolvePromptAgentMode(selectedMode.value),
     model: command.model || selectedModel.value,
     variant: selectedThinking.value,
+    parts,
   });
 }
 

--- a/app/App.vue
+++ b/app/App.vue
@@ -2725,7 +2725,13 @@ const {
   branchListLoading,
   refreshBranchEntries,
   ensureBranchEntriesLoaded,
-} = useFileTree({ activeDirectory, activeBackendKind });
+} = useFileTree({
+  activeDirectory,
+  activeBackendKind,
+  refreshEnabled: computed(
+    () => uiInitState.value === 'ready' && connectionState.value === 'ready',
+  ),
+});
 
 const treeDirectoryName = computed(() => {
   const raw = activeDirectory.value.trim();

--- a/app/backends/acp/acpAdapter.ts
+++ b/app/backends/acp/acpAdapter.ts
@@ -331,6 +331,7 @@ export class AcpAdapter implements BackendAdapter {
       agent?: string;
       model?: string;
       variant?: string;
+      parts?: Array<{ type: 'file'; mime: string; url: string; filename?: string }>;
     },
   ) {
     const argumentsText = payload.arguments.trim();
@@ -341,6 +342,7 @@ export class AcpAdapter implements BackendAdapter {
       variant: payload.variant,
       parts: [
         { type: 'text', text: `/${payload.command}${argumentsText ? ` ${argumentsText}` : ''}` },
+        ...(payload.parts ?? []),
       ],
     });
   }

--- a/app/backends/acp/acpModesCommands.test.ts
+++ b/app/backends/acp/acpModesCommands.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, beforeEach } from 'vitest';
 import {
   createAcpAgentList,
   createAcpPermissionModeList,
   createAcpUiModeState,
   resolveAcpModeSelection,
 } from './configOptions';
-import { initializeAdapter, sent } from './acpTestHarness';
+import { initializeAdapter, MockAcpWebSocket, sent } from './acpTestHarness';
 
 const modeConfig = {
   id: 'mode',
@@ -22,6 +22,10 @@ const modeConfig = {
 };
 
 describe('ACP mode and command adaptation', () => {
+  beforeEach(() => {
+    MockAcpWebSocket.instances = [];
+  });
+
   it('separates agent modes from permission policies', () => {
     expect(createAcpAgentList([modeConfig], 'Oh My Pi')).toEqual([
       expect.objectContaining({ name: 'default' }),
@@ -87,6 +91,47 @@ describe('ACP mode and command adaptation', () => {
       params: {
         sessionId: 'session-1',
         prompt: [{ type: 'text', text: '/plan inspect auth' }],
+      },
+    });
+    socket.receive({ jsonrpc: '2.0', id: 3, result: { stopReason: 'end_turn' } });
+    await sending;
+  });
+
+  it('forwards command file parts as prompt content blocks', async () => {
+    const { adapter, socket } = await initializeAdapter();
+    const creating = adapter.createSession('/workspace');
+    await expect.poll(() => socket.sent.length).toBe(2);
+    socket.receive({
+      jsonrpc: '2.0',
+      id: 2,
+      result: { sessionId: 'session-1', configOptions: [modeConfig] },
+    });
+    await creating;
+
+    const sending = adapter.sendCommand?.('session-1', {
+      directory: '/workspace',
+      command: 'plan',
+      arguments: 'inspect auth',
+      agent: 'default',
+      model: 'default',
+      parts: [
+        {
+          type: 'file',
+          mime: 'image/png',
+          url: 'data:image/png;base64,AA==',
+          filename: 'image.png',
+        },
+      ],
+    });
+    await expect.poll(() => socket.sent.length).toBe(3);
+    expect(sent(socket, 2)).toMatchObject({
+      method: 'session/prompt',
+      params: {
+        sessionId: 'session-1',
+        prompt: [
+          { type: 'text', text: '/plan inspect auth' },
+          { type: 'image', mimeType: 'image/png', data: 'AA==' },
+        ],
       },
     });
     socket.receive({ jsonrpc: '2.0', id: 3, result: { stopReason: 'end_turn' } });

--- a/app/backends/types.ts
+++ b/app/backends/types.ts
@@ -209,6 +209,7 @@ export type BackendAdapter = {
       agent?: string;
       model?: string;
       variant?: string;
+      parts?: Array<{ type: 'file'; mime: string; url: string; filename?: string }>;
     },
   ): Promise<void>;
   sendPromptAsync?(

--- a/app/components/InputPanel.enterToSend.test.ts
+++ b/app/components/InputPanel.enterToSend.test.ts
@@ -1,0 +1,129 @@
+import { createApp, defineComponent, h, nextTick } from 'vue';
+import { createI18n } from 'vue-i18n';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import InputPanel from './InputPanel.vue';
+import type { TextTransformer } from '../utils/textTransformers';
+import en from '../locales/en';
+
+vi.mock('@iconify/vue', () => ({ Icon: () => null }));
+const settings = vi.hoisted(() => ({
+  enterToSend: { value: true, __v_isRef: true },
+  textTransformersEnabled: { value: false, __v_isRef: true },
+  textTransformers: { value: [] as TextTransformer[], __v_isRef: true },
+}));
+vi.mock('../composables/useSettings', () => ({
+  useSettings: () => settings,
+}));
+
+const mountedApps: Array<() => void> = [];
+
+function mountInputPanel(messageInput: string) {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  const onSend = vi.fn();
+  const app = createApp(
+    defineComponent({
+      setup() {
+        return () =>
+          h(InputPanel, {
+            messageInput,
+            canSend: true,
+            selectedMode: 'build',
+            agentOptions: [{ id: 'build', label: 'Build' }],
+            hasAgentOptions: true,
+            selectedModel: 'openai/gpt',
+            selectedThinking: undefined,
+            modelOptions: [
+              {
+                id: 'openai/gpt',
+                modelID: 'gpt',
+                label: 'GPT',
+                displayName: 'GPT',
+                providerID: 'openai',
+              },
+            ],
+            thinkingOptions: [undefined],
+            hasModelOptions: true,
+            hasThinkingOptions: true,
+            isThinking: false,
+            canAbort: false,
+            commands: [{ name: 'goal' }],
+            attachments: [],
+            onSend,
+          });
+      },
+    }),
+  );
+  app.use(createI18n({ legacy: false, locale: 'en', messages: { en } }));
+  app.provide('showConfirm', async () => true);
+  app.mount(root);
+  mountedApps.push(() => {
+    app.unmount();
+    root.remove();
+  });
+  return { root, onSend };
+}
+
+function pressEnter(root: HTMLElement, options: { ctrlKey?: boolean } = {}) {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    ctrlKey: options.ctrlKey ?? false,
+  });
+  root.querySelector('textarea')?.dispatchEvent(event);
+  return event;
+}
+
+afterEach(() => {
+  while (mountedApps.length > 0) mountedApps.pop()?.();
+  settings.enterToSend.value = true;
+  document.body.innerHTML = '';
+});
+
+describe('InputPanel enterToSend setting', () => {
+  it('does not send a recognized slash command on Enter when enterToSend is disabled', async () => {
+    // Given: enter-to-send is off and the input holds a recognized slash command.
+    settings.enterToSend.value = false;
+    const { root, onSend } = mountInputPanel('/goal ship it');
+    await nextTick();
+
+    // When: Enter is pressed without modifiers.
+    const event = pressEnter(root);
+    await nextTick();
+
+    // Then: no send fires and the newline default is preserved.
+    expect(onSend).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('sends a recognized slash command on Enter when enterToSend is enabled', async () => {
+    // Given: enter-to-send is on and the input holds a recognized slash command.
+    settings.enterToSend.value = true;
+    const { root, onSend } = mountInputPanel('/goal ship it');
+    await nextTick();
+
+    // When: Enter is pressed without modifiers.
+    const event = pressEnter(root);
+    await nextTick();
+
+    // Then: the command is sent and the newline default is suppressed.
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('still sends on Ctrl+Enter when enterToSend is disabled', async () => {
+    // Given: enter-to-send is off and the input holds a recognized slash command.
+    settings.enterToSend.value = false;
+    const { root, onSend } = mountInputPanel('/goal ship it');
+    await nextTick();
+
+    // When: Ctrl+Enter is pressed.
+    const event = pressEnter(root, { ctrlKey: true });
+    await nextTick();
+
+    // Then: the always-send shortcut still fires.
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+});

--- a/app/components/InputPanel.vue
+++ b/app/components/InputPanel.vue
@@ -1371,20 +1371,6 @@ function applySkillSelection(name: string) {
   });
 }
 
-function extractSlashCommand(value: string) {
-  if (!value.startsWith('/')) return '';
-  const trimmed = value.slice(1);
-  const match = trimmed.match(/^(\S+)/);
-  return match?.[1] ?? '';
-}
-
-function hasMatchingCommand(name: string) {
-  if (!name) return false;
-  return (props.commands ?? []).some(
-    (command) => command.name.toLowerCase() === name.toLowerCase(),
-  );
-}
-
 function nextCyclicIndex(current: string | undefined, options: Array<string | undefined>) {
   if (options.length === 0) return -1;
   const index = options.indexOf(current);
@@ -1544,21 +1530,11 @@ function handleKeydown(event: KeyboardEvent) {
     !event.ctrlKey &&
     !event.metaKey &&
     !event.shiftKey &&
-    !event.altKey
+    !event.altKey &&
+    enterToSend.value
   ) {
-    if (enterToSend.value) {
-      event.preventDefault();
-      emit('send');
-      return;
-    }
-    // Default: send only for recognized slash commands
-    if (messageValue.value.startsWith('/')) {
-      const commandName = extractSlashCommand(messageValue.value);
-      if (hasMatchingCommand(commandName)) {
-        event.preventDefault();
-        emit('send');
-      }
-    }
+    event.preventDefault();
+    emit('send');
   }
 }
 

--- a/app/components/SettingsModal.desktop.test.ts
+++ b/app/components/SettingsModal.desktop.test.ts
@@ -1,6 +1,7 @@
 import { createApp, h, nextTick } from 'vue';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { desktopMessages } from '../locales/desktop';
+import enLocale from '../locales/en';
 import type { DesktopApi, DesktopState } from '../types/desktop';
 
 vi.mock('@iconify/vue', () => ({
@@ -141,5 +142,91 @@ describe('SettingsModal desktop mounting', () => {
     expect(api.getState).toHaveBeenCalled();
     const cards = modalBody(host).querySelectorAll('.desktop-update-card');
     expect(cards).toHaveLength(2);
+  });
+});
+
+describe('SettingsModal local application row layout', () => {
+  function mountWithLocalFile(path: string) {
+    localStorage.setItem('opencode.settings.localApplicationPath.v1', path);
+    const localFile = {
+      selectApplication: vi.fn(() => Promise.resolve(null)),
+      clearApplication: vi.fn(() => Promise.resolve()),
+    };
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: { desktop: createDesktopApi(), localFile },
+    });
+    return { localFile };
+  }
+
+  async function openEditorPage(host: HTMLElement) {
+    const editorLink = pageRows(host).find(
+      (row) => row.querySelector('.setting-label')?.textContent === enLocale.settings.editor.label,
+    );
+    expect(editorLink, 'editor link row must exist').toBeDefined();
+    editorLink!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await flushAsync();
+  }
+
+  function localApplicationRow(host: HTMLElement) {
+    const row = pageRows(host).find(
+      (candidate) =>
+        candidate.querySelector('.setting-label')?.textContent ===
+        enLocale.settings.editor.localApplication.label,
+    );
+    expect(row, 'local application row must exist on the editor page').toBeDefined();
+    return row as HTMLElement;
+  }
+
+  it('places the path input and app buttons on a separate row below the label and description', async () => {
+    // Given: an Electron runtime with the local file API and a configured path.
+    mountWithLocalFile('/usr/bin/code');
+    const host = await mountModal();
+
+    // When: the editor page is opened.
+    await openEditorPage(host);
+
+    // Then: the row stacks vertically so the controls sit on their own row.
+    const row = localApplicationRow(host);
+    expect(row.getAttribute('class')).toBe('setting-row setting-row-column');
+    const info = row.querySelector(':scope > .setting-info');
+    const controls = row.querySelector(':scope > .local-application-controls');
+    expect(info, 'row must lead with the label/description block').not.toBeNull();
+    expect(controls, 'row must render the controls block').not.toBeNull();
+    expect(
+      info!.compareDocumentPosition(controls!) & Node.DOCUMENT_POSITION_FOLLOWING,
+      'controls must come after the label/description in DOM order',
+    ).not.toBe(0);
+
+    // And: the controls row carries the readonly path input with both buttons.
+    const input = controls!.querySelector('input.font-stack-input[readonly]');
+    expect(input).not.toBeNull();
+    expect((input as HTMLInputElement).value).toBe('/usr/bin/code');
+    const buttonLabels = Array.from(controls!.querySelectorAll('button')).map((button) =>
+      button.textContent?.trim(),
+    );
+    expect(buttonLabels).toEqual([
+      enLocale.settings.editor.localApplication.browse,
+      enLocale.settings.editor.localApplication.clear,
+    ]);
+  });
+
+  it('omits the remove button when no local application is configured', async () => {
+    // Given: an Electron runtime without a configured local application path.
+    mountWithLocalFile('');
+    const host = await mountModal();
+
+    // When: the editor page is opened.
+    await openEditorPage(host);
+
+    // Then: only the browse action renders inside the controls row.
+    const controls = localApplicationRow(host).querySelector(
+      ':scope > .local-application-controls',
+    );
+    expect(controls).not.toBeNull();
+    const buttonLabels = Array.from(controls!.querySelectorAll('button')).map((button) =>
+      button.textContent?.trim(),
+    );
+    expect(buttonLabels).toEqual([enLocale.settings.editor.localApplication.browse]);
   });
 });

--- a/app/components/SettingsModal.vue
+++ b/app/components/SettingsModal.vue
@@ -689,7 +689,7 @@
             v-if="isElectron"
             :label="$t('settings.editor.localApplication.label')"
             :description="$t('settings.editor.localApplication.description')"
-            class="setting-row-stack"
+            class="setting-row-column"
           >
             <div class="local-application-controls">
               <input
@@ -2830,6 +2830,12 @@ watch(
 
 .setting-row-stack {
   align-items: flex-start;
+}
+
+.setting-row-column {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
 }
 
 .setting-row.theme-settings-section {

--- a/app/components/settings/DesktopSettings.test.ts
+++ b/app/components/settings/DesktopSettings.test.ts
@@ -185,6 +185,125 @@ describe('DesktopSettings', () => {
     await clickToggle(sound);
     expect(desktop.api.configure).toHaveBeenCalledWith({ notificationSound: true });
   });
+  it('shares one row between the version text and the check actions in each update card', async () => {
+    // Given: mounted settings with the desktop runtime.
+    const desktop = createDesktopApi(makeState());
+    Object.defineProperty(window, 'electronAPI', { configurable: true, value: { desktop: desktop.api } });
+    const { host } = await mountDesktopSettings();
+    await flushAsync();
+
+    // Then: in both cards the versions block and the actions block share a single summary row.
+    for (const component of ['app', 'bridge'] as const) {
+      const card = cardFor(host, component);
+      const versions = card.querySelector('.desktop-update-versions');
+      const actions = card.querySelector('.desktop-update-actions');
+      expect(versions, `${component} card must render the versions block`).not.toBeNull();
+      expect(actions, `${component} card must render its check action`).not.toBeNull();
+      const summary = card.querySelector(':scope > .desktop-update-summary');
+      expect(
+        summary,
+        `${component} card must place versions and the check action inside a shared summary row`,
+      ).not.toBeNull();
+      expect(versions!.parentElement).toBe(summary);
+      expect(actions!.parentElement).toBe(summary);
+      expect(
+        versions!.compareDocumentPosition(actions!) & Node.DOCUMENT_POSITION_FOLLOWING,
+        `${component} card must render the versions before the check action`,
+      ).not.toBe(0);
+
+      // And: the summary row holds only the check button, never the phase actions.
+      const summaryButtons = Array.from(actions!.querySelectorAll('button')).map((button) =>
+        button.textContent?.trim(),
+      );
+      expect(summaryButtons).toEqual([en.updates.actions.check]);
+      expect(card.querySelector('.desktop-update-extra-actions')).toBeNull();
+    }
+  });
+
+  it('places download and install actions on a separate row below the summary', async () => {
+    // Given: mounted settings with an available app update and a downloaded bridge update.
+    const desktop = createDesktopApi(
+      makeState({
+        app: { phase: 'available', availableVersion: '1.5.0', assetName: 'Vis-1.5.0.AppImage' },
+        bridge: { phase: 'downloaded', availableVersion: '0.9.2', progress: 100 },
+      }),
+    );
+    Object.defineProperty(window, 'electronAPI', { configurable: true, value: { desktop: desktop.api } });
+    const { host } = await mountDesktopSettings();
+    await flushAsync();
+
+    // Then: the app card keeps Check in the summary and Download on the extra row below.
+    const appCard = cardFor(host, 'app');
+    const appSummary = appCard.querySelector(':scope > .desktop-update-summary')!;
+    const appExtra = appCard.querySelector(':scope > .desktop-update-extra-actions');
+    expect(appExtra, 'app card must render the extra actions row below the summary').not.toBeNull();
+    expect(
+      appSummary.compareDocumentPosition(appExtra!) & Node.DOCUMENT_POSITION_FOLLOWING,
+      'extra actions must come after the summary row',
+    ).not.toBe(0);
+    expect(
+      Array.from(appSummary.querySelectorAll('button')).map((button) => button.textContent?.trim()),
+    ).toEqual([en.updates.actions.check]);
+    expect(
+      Array.from(appExtra!.querySelectorAll('button')).map((button) => button.textContent?.trim()),
+    ).toEqual([en.updates.actions.download]);
+
+    // And: the bridge card keeps Check in the summary and the manual install action below.
+    const bridgeCard = cardFor(host, 'bridge');
+    const bridgeExtra = bridgeCard.querySelector(':scope > .desktop-update-extra-actions');
+    expect(bridgeExtra).not.toBeNull();
+    expect(
+      Array.from(bridgeCard.querySelectorAll(':scope > .desktop-update-summary button')).map(
+        (button) => button.textContent?.trim(),
+      ),
+    ).toEqual([en.updates.actions.check]);
+    expect(
+      Array.from(bridgeExtra!.querySelectorAll('button')).map((button) => button.textContent?.trim()),
+    ).toEqual([en.updates.actions.openInstaller]);
+  });
+
+  it('places the retry action on the extra row while the error phase keeps check in the summary', async () => {
+    // Given: an app update in the error phase.
+    const desktop = createDesktopApi(
+      makeState({ app: { phase: 'error', error: 'network unreachable' } }),
+    );
+    Object.defineProperty(window, 'electronAPI', { configurable: true, value: { desktop: desktop.api } });
+    const { host } = await mountDesktopSettings();
+    await flushAsync();
+
+    // Then: the summary keeps only the check action and retry lives on the extra row.
+    const appCard = cardFor(host, 'app');
+    expect(
+      Array.from(appCard.querySelectorAll(':scope > .desktop-update-summary button')).map(
+        (button) => button.textContent?.trim(),
+      ),
+    ).toEqual([en.updates.actions.check]);
+    const extra = appCard.querySelector(':scope > .desktop-update-extra-actions');
+    expect(extra).not.toBeNull();
+    expect(
+      Array.from(extra!.querySelectorAll('button')).map((button) => button.textContent?.trim()),
+    ).toEqual([en.updates.actions.retry]);
+  });
+
+  it('keeps the versions row intact without actions for an unsupported component', async () => {
+    // Given: a bridge component unsupported on this platform.
+    const desktop = createDesktopApi(
+      makeState({ bridge: { phase: 'unsupported', installKind: 'unsupported' } }),
+    );
+    Object.defineProperty(window, 'electronAPI', { configurable: true, value: { desktop: desktop.api } });
+    const { host } = await mountDesktopSettings();
+    await flushAsync();
+
+    // Then: the summary row still holds the versions while the notice stays below it.
+    const bridgeCard = cardFor(host, 'bridge');
+    const summary = bridgeCard.querySelector(':scope > .desktop-update-summary');
+    expect(summary).not.toBeNull();
+    expect(summary!.querySelector('.desktop-update-versions')).not.toBeNull();
+    expect(summary!.querySelector('button')).toBeNull();
+    const notice = bridgeCard.querySelector(':scope > .desktop-notice');
+    expect(notice, 'unsupported notice must remain on its own row below the summary').not.toBeNull();
+  });
+
   it('renders nothing when the desktop API is unavailable (web)', async () => {
     // Given: a web runtime without window.electronAPI.
     const { host } = await mountDesktopSettings();

--- a/app/components/settings/DesktopUpdateCard.vue
+++ b/app/components/settings/DesktopUpdateCard.vue
@@ -9,10 +9,17 @@
         <span class="desktop-badge">{{ t(`desktopSettings.updates.installKind.${state.installKind}`) }}</span>
       </span>
     </div>
-    <div class="desktop-update-versions">
-      <span v-if="state.component === 'app'">{{ t('desktopSettings.updates.currentVersion', { version: state.currentVersion ?? t('desktopSettings.updates.unknownVersion') }) }}</span>
-      <span v-if="state.component === 'bridge' && connectedBridgeText !== null" data-testid="bridge-connected-version">{{ connectedBridgeText }}</span>
-      <span v-if="state.availableVersion">{{ t(state.component === 'bridge' ? 'desktopSettings.updates.availableLocalVersion' : 'desktopSettings.updates.availableVersion', { version: state.availableVersion }) }}</span>
+    <div class="desktop-update-summary">
+      <div class="desktop-update-versions">
+        <span v-if="state.component === 'app'">{{ t('desktopSettings.updates.currentVersion', { version: state.currentVersion ?? t('desktopSettings.updates.unknownVersion') }) }}</span>
+        <span v-if="state.component === 'bridge' && connectedBridgeText !== null" data-testid="bridge-connected-version">{{ connectedBridgeText }}</span>
+        <span v-if="state.availableVersion">{{ t(state.component === 'bridge' ? 'desktopSettings.updates.availableLocalVersion' : 'desktopSettings.updates.availableVersion', { version: state.availableVersion }) }}</span>
+      </div>
+      <div v-if="state.phase !== 'unsupported'" class="desktop-update-actions">
+        <button type="button" class="desktop-button" :disabled="busy" @click="$emit('check')">
+          {{ t(state.phase === 'checking' ? 'desktopSettings.updates.actions.checking' : 'desktopSettings.updates.actions.check') }}
+        </button>
+      </div>
     </div>
     <div v-if="state.phase === 'downloading' && state.progress !== null" class="desktop-progress"
       role="progressbar" :aria-label="t('desktopSettings.updates.progressLabel')"
@@ -24,10 +31,7 @@
     <div v-if="state.phase === 'installer-opened'" class="desktop-notice">{{ t('desktopSettings.updates.manualInstallerOpenedNotice') }}</div>
     <div v-if="state.component === 'bridge' && interruptPhases.has(state.phase)" class="desktop-notice">{{ t('desktopSettings.updates.bridgeInterruptNotice') }}</div>
     <div v-if="state.phase === 'unsupported'" class="desktop-notice">{{ t('desktopSettings.updates.unsupportedNotice') }}</div>
-    <div v-else class="desktop-update-actions">
-      <button type="button" class="desktop-button" :disabled="busy" @click="$emit('check')">
-        {{ t(state.phase === 'checking' ? 'desktopSettings.updates.actions.checking' : 'desktopSettings.updates.actions.check') }}
-      </button>
+    <div v-if="hasExtraActions" class="desktop-update-extra-actions">
       <button v-if="state.phase === 'available'" type="button" class="desktop-button" :disabled="busy" @click="$emit('download')">
         {{ t('desktopSettings.updates.actions.download') }}
       </button>
@@ -56,6 +60,12 @@ const props = defineProps<{
 defineEmits<{ check: []; download: []; install: [] }>();
 const { t } = useI18n();
 const errorText = computed(() => props.actionError ?? (props.state.phase === 'error' ? props.state.error : null));
+const hasExtraActions = computed(
+  () =>
+    props.state.phase === 'available' ||
+    props.state.phase === 'downloaded' ||
+    props.state.phase === 'error',
+);
 const connectedBridgeText = computed(() => {
   const bridge = props.connectedBridge;
   if (!bridge) return null;

--- a/app/components/settings/desktop-settings.css
+++ b/app/components/settings/desktop-settings.css
@@ -32,12 +32,22 @@
   background: var(--theme-modal-control-bg, var(--theme-surface-panel-muted));
 }
 .desktop-update-card { flex-direction: column; align-items: stretch; }
-.desktop-update-header, .desktop-update-versions, .desktop-update-actions, .desktop-update-badges {
+.desktop-update-header, .desktop-update-versions, .desktop-update-actions, .desktop-update-extra-actions, .desktop-update-badges {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;
 }
+.desktop-update-summary {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px 16px;
+}
+.desktop-update-summary .desktop-update-versions { flex: 1 1 auto; min-width: 0; }
+.desktop-update-summary .desktop-update-actions { flex: 0 0 auto; }
+.desktop-update-summary .desktop-button { flex: 0 0 auto; }
 .desktop-update-header { justify-content: space-between; }
 .desktop-update-name {
   color: var(--theme-modal-text, var(--theme-text-primary));
@@ -73,7 +83,7 @@
   padding: 8px;
   border-left: 2px solid var(--theme-modal-border, var(--theme-border-default));
 }
-.desktop-update-actions { justify-content: flex-end; }
+.desktop-update-actions, .desktop-update-extra-actions { justify-content: flex-end; }
 .desktop-button {
   min-height: 30px;
   padding: 0 12px;

--- a/app/composables/backendMessageSend.openCode.ts
+++ b/app/composables/backendMessageSend.openCode.ts
@@ -1,5 +1,7 @@
+import type { ComposerAttachment } from '../types/composer';
 import type {
   BackendMessageSendParams,
+  CommandFilePart,
   RequestGuard,
   SendPreflight,
 } from './backendMessageSend.types';
@@ -61,6 +63,41 @@ async function buildOpenCodeParts(
   return parts;
 }
 
+function buildOpenCodeCommand(
+  params: BackendMessageSendParams,
+  attachments: readonly ComposerAttachment[],
+  argumentText: string,
+): { arguments: string; parts: CommandFilePart[] } {
+  const notes: string[] = [];
+  const parts: CommandFilePart[] = [];
+  for (const item of attachments) {
+    if (!item.lineComment) {
+      parts.push({ type: 'file', mime: item.mime, url: item.dataUrl, filename: item.filename });
+      continue;
+    }
+    notes.push(
+      params.formatCommentNote(
+        item.lineComment.path,
+        item.lineComment.startLine,
+        item.lineComment.endLine,
+        item.lineComment.text,
+      ),
+    );
+    parts.push({
+      type: 'file',
+      mime: 'text/plain',
+      url: params.buildLineCommentFileUrl(
+        item.lineComment.path,
+        item.lineComment.startLine,
+        item.lineComment.endLine,
+      ),
+      filename: item.filename.split(':')[0] || item.filename,
+    });
+  }
+  const combined = [argumentText, ...notes].filter((value) => value.length > 0);
+  return { arguments: combined.join('\n'), parts };
+}
+
 export async function runOpenCodeSend(
   params: BackendMessageSendParams,
   preflight: SendPreflight,
@@ -68,10 +105,16 @@ export async function runOpenCodeSend(
 ): Promise<OpenCodeExecutionResult> {
   if (preflight.slash && preflight.commandMatch) {
     if (!guard.isCurrent()) return { kind: 'stale' };
+    const command = buildOpenCodeCommand(
+      params,
+      preflight.attachments,
+      preflight.transformText(preflight.slash.arguments),
+    );
     await params.sendCommand(
       preflight.sessionId,
       preflight.commandMatch,
-      preflight.transformText(preflight.slash.arguments),
+      command.arguments,
+      command.parts,
     );
     return guard.isCurrent() ? { kind: 'command' } : { kind: 'stale' };
   }

--- a/app/composables/backendMessageSend.types.ts
+++ b/app/composables/backendMessageSend.types.ts
@@ -34,6 +34,13 @@ export type ParsedSlashCommand = {
   readonly arguments: string;
 };
 
+export type CommandFilePart = {
+  readonly type: 'file';
+  readonly mime: string;
+  readonly url: string;
+  readonly filename?: string;
+};
+
 export type OpenCodeApiLike = {
   readonly sendPromptAsync: (
     sessionId: string,
@@ -133,6 +140,7 @@ export type BackendMessageSendParams = {
     sessionId: string,
     command: CommandInfo,
     commandArgs: string,
+    parts: CommandFilePart[],
   ) => Promise<void>;
   readonly buildLineCommentFileUrl: (path: string, startLine: number, endLine: number) => string;
   readonly formatCommentNote: (

--- a/app/composables/useBackendMessageSend.behavior.test.ts
+++ b/app/composables/useBackendMessageSend.behavior.test.ts
@@ -149,7 +149,8 @@ describe('useBackendMessageSend behavior', () => {
     expect(base.isSending.value).toBe(false);
   });
 
-  it('retains attachments after a successful OpenCode command', async () => {
+  it('sends attachments as file parts with an OpenCode command and clears them', async () => {
+    // Given: a recognized slash command with a queued image attachment.
     const base = createBaseParams();
     base.messageInput.value = '/fix issue';
     base.attachments.value = [imageAttachment()];
@@ -162,11 +163,105 @@ describe('useBackendMessageSend behavior', () => {
       sendCommand,
     });
 
+    // When: the command is sent.
     await runtime.sendMessage();
 
-    expect(sendCommand).toHaveBeenCalledWith('session-1', { name: 'fix' }, 'issue');
-    expect(base.attachments.value).toHaveLength(1);
+    // Then: the attachment rides the command payload as a file part and is consumed.
+    expect(sendCommand).toHaveBeenCalledWith('session-1', { name: 'fix' }, 'issue', [
+      { type: 'file', mime: 'image/png', url: 'data:image/png;base64,AA==', filename: 'image.png' },
+    ]);
+    expect(base.attachments.value).toEqual([]);
     expect(base.clearComposerDraftForCurrentContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('folds line-comment notes into command arguments and keeps the file part', async () => {
+    // Given: a recognized slash command with a line-comment attachment.
+    const base = createBaseParams();
+    base.messageInput.value = '/fix issue';
+    base.attachments.value = [
+      {
+        id: 'c1',
+        filename: 'a.ts:1-2',
+        mime: 'text/plain',
+        dataUrl: '',
+        lineComment: { path: 'src/a.ts', startLine: 1, endLine: 2, text: 'note' },
+      },
+    ];
+    const sendCommand = vi.fn().mockResolvedValue(undefined);
+    const runtime = useBackendMessageSend({
+      ...base,
+      activeBackendKind: ref('opencode'),
+      openCodeApi: { sendPromptAsync: vi.fn() },
+      codexApi: createCodexApi(),
+      sendCommand,
+    });
+
+    // When: the command is sent.
+    await runtime.sendMessage();
+
+    // Then: the note text joins the arguments and the referenced lines ride as a file part.
+    expect(sendCommand).toHaveBeenCalledWith(
+      'session-1',
+      { name: 'fix' },
+      'issue\nsrc/a.ts:1-2:note',
+      [{ type: 'file', mime: 'text/plain', url: 'src/a.ts:1-2', filename: 'a.ts' }],
+    );
+    expect(base.attachments.value).toEqual([]);
+  });
+
+  it('clears command attachments only after the forwarded request resolves', async () => {
+    // Given: a recognized slash command with an attachment and a pending command request.
+    const pending = deferred<void>();
+    const sendCommand = vi.fn().mockReturnValue(pending.promise);
+    const base = createBaseParams();
+    base.messageInput.value = '/fix issue';
+    base.attachments.value = [imageAttachment()];
+    const runtime = useBackendMessageSend({
+      ...base,
+      activeBackendKind: ref('opencode'),
+      openCodeApi: { sendPromptAsync: vi.fn() },
+      codexApi: createCodexApi(),
+      sendCommand,
+    });
+
+    // When: the send starts but the forwarded request has not resolved yet.
+    const sending = runtime.sendMessage();
+    await vi.waitFor(() => expect(sendCommand).toHaveBeenCalledTimes(1));
+
+    // Then: the attachment is still queued.
+    expect(base.attachments.value).toHaveLength(1);
+
+    // When: the forwarded request resolves.
+    pending.resolve(undefined);
+    await sending;
+
+    // Then: the attachment is cleared.
+    expect(base.attachments.value).toEqual([]);
+  });
+
+  it('retains attachments when an OpenCode command send fails', async () => {
+    // Given: a recognized slash command with a queued attachment and a failing command request.
+    const base = createBaseParams();
+    base.messageInput.value = '/fix issue';
+    base.attachments.value = [imageAttachment()];
+    const sendCommand = vi.fn().mockRejectedValue(new Error('command rejected'));
+    const runtime = useBackendMessageSend({
+      ...base,
+      activeBackendKind: ref('opencode'),
+      openCodeApi: { sendPromptAsync: vi.fn() },
+      codexApi: createCodexApi(),
+      sendCommand,
+    });
+
+    // When: the forwarded command request rejects.
+    await runtime.sendMessage();
+
+    // Then: the attachment is retained for retry and the failure is surfaced.
+    expect(base.attachments.value).toHaveLength(1);
+    expect(base.setSendStatusKey).toHaveBeenLastCalledWith('app.error.sendFailed', {
+      message: 'Error: command rejected',
+    });
+    expect(base.isSending.value).toBe(false);
   });
 
   it('keeps ACP isSending true while prompt is pending', async () => {

--- a/app/composables/useBackendMessageSend.test.ts
+++ b/app/composables/useBackendMessageSend.test.ts
@@ -86,7 +86,7 @@ describe('useBackendMessageSend', () => {
 
     await runtime.sendMessage();
 
-    expect(sendCommand).toHaveBeenCalledWith('session-1', { name: 'fix' }, 'issue');
+    expect(sendCommand).toHaveBeenCalledWith('session-1', { name: 'fix' }, 'issue', []);
     expect(sendPromptAsync).not.toHaveBeenCalled();
   });
 

--- a/app/composables/useBackendMessageSend.ts
+++ b/app/composables/useBackendMessageSend.ts
@@ -53,7 +53,7 @@ export function useBackendMessageSend(params: BackendMessageSendParams) {
   ) {
     if (!guard.isCurrent() || result.kind === 'stale' || result.kind === 'no-directory') return;
     params.setSendStatusKey('app.status.sent');
-    if (result.kind === 'prompt') params.attachments.value = [];
+    if (result.kind === 'prompt' || result.kind === 'command') params.attachments.value = [];
     params.clearComposerDraftForCurrentContext();
   }
 

--- a/app/composables/useFileTree.test.ts
+++ b/app/composables/useFileTree.test.ts
@@ -38,13 +38,25 @@ async function flushAsyncWork() {
   await nextTick();
 }
 
+function ptyScripts() {
+  return mockRunOneShotPtyCommand.mock.calls.map((call) => call[1]?.at(-1) ?? '');
+}
+
+function statusRefreshCount() {
+  return ptyScripts().filter((script) => script.includes('status --porcelain')).length;
+}
+
 async function mountComposable() {
   vi.resetModules();
 
-  let api!: Awaited<typeof import('./useFileTree')>['useFileTree'] extends (...args: never[]) => infer T
+  let api!: Awaited<typeof import('./useFileTree')>['useFileTree'] extends (
+    ...args: never[]
+  ) => infer T
     ? T
     : never;
   const activeDirectory = ref('/repo');
+  const activeBackendKind = ref('opencode');
+  const refreshEnabled = ref(true);
   const { useFileTree } = await import('./useFileTree');
 
   const i18n = createI18n({
@@ -59,7 +71,7 @@ async function mountComposable() {
   const app = createApp(
     defineComponent({
       setup() {
-        api = useFileTree({ activeDirectory });
+        api = useFileTree({ activeDirectory, activeBackendKind, refreshEnabled });
         return () => null;
       },
     }),
@@ -72,6 +84,8 @@ async function mountComposable() {
   return {
     api,
     activeDirectory,
+    activeBackendKind,
+    refreshEnabled,
     async settle() {
       await flushAsyncWork();
     },
@@ -119,8 +133,9 @@ describe('useFileTree', () => {
   });
 
   afterEach(async () => {
-    await vi.runOnlyPendingTimersAsync();
+    vi.clearAllTimers();
     vi.useRealTimers();
+    vi.restoreAllMocks();
     document.body.innerHTML = '';
   });
 
@@ -312,6 +327,377 @@ describe('useFileTree', () => {
       expect(call[1]?.at(-1)).toContain('status --porcelain');
       expect(call[1]?.at(-1)).not.toContain('ls-files --cached --others --exclude-standard');
     }
+
+    mounted.unmount();
+  });
+
+  it('keeps expanded ignored directories loaded while reconciling additions and deletions', async () => {
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    let snapshot = 0;
+    mockRunOneShotPtyCommand.mockImplementation(async (_command, args = []) => {
+      const script = args.at(-1) ?? '';
+      if (script.includes('status --porcelain')) {
+        return '## main\0##PREFIX\0\0##HEAD\0abc123\0##DIFFSTAT\0\0##DIFFSTAT_CACHED\0';
+      }
+      if (script.includes('git ls-files --others --exclude-standard -z')) return '0';
+      if (script.includes('ls-files --cached --others --exclude-standard')) {
+        return snapshot === 0 ? 'cache/tracked.ts\0src/old.ts\0' : 'cache/tracked.ts\0src/new.ts\0';
+      }
+      return '';
+    });
+    mockListFiles.mockImplementation(async ({ path }) => {
+      if (path === '.') return [{ path: '/repo/cache', type: 'directory', ignored: true }];
+      if (path === 'cache') {
+        return snapshot === 0
+          ? [
+              { path: '/repo/cache/nested', type: 'directory', ignored: true },
+              { path: '/repo/cache/old.log', type: 'file', ignored: true },
+            ]
+          : [
+              { path: '/repo/cache/nested', type: 'directory', ignored: true },
+              { path: '/repo/cache/new.log', type: 'file', ignored: true },
+            ];
+      }
+      if (path === 'cache/nested') {
+        return snapshot === 0
+          ? [{ path: '/repo/cache/nested/old.tmp', type: 'file', ignored: true }]
+          : [{ path: '/repo/cache/nested/new.tmp', type: 'file', ignored: true }];
+      }
+      return [];
+    });
+
+    const mounted = await mountComposable();
+    await mounted.settle();
+    mounted.api.toggleTreeDirectory('cache');
+    await mounted.settle();
+    mounted.api.toggleTreeDirectory('cache/nested');
+    await mounted.settle();
+
+    snapshot = 1;
+    await vi.advanceTimersByTimeAsync(5_000);
+    await mounted.settle();
+
+    const cache = mounted.api.treeNodes.value.find((node) => node.path === 'cache');
+    const nested = cache?.children?.find((node) => node.path === 'cache/nested');
+    expect(mounted.api.expandedTreePaths.value).toEqual(['cache', 'cache/nested']);
+    expect(cache).toMatchObject({ loaded: true, ignored: true });
+    expect(cache?.children?.map((node) => node.path)).toEqual([
+      'cache/nested',
+      'cache/new.log',
+      'cache/tracked.ts',
+    ]);
+    expect(nested).toMatchObject({ loaded: true, ignored: true });
+    expect(nested?.children?.map((node) => node.path)).toEqual(['cache/nested/new.tmp']);
+    expect(mounted.api.files.value).toEqual(['cache/tracked.ts', 'src/new.ts']);
+
+    mounted.unmount();
+  });
+
+  it('reconciles ignored children inside an expanded tracked root directory', async () => {
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    let snapshot = 0;
+    mockRunOneShotPtyCommand.mockImplementation(async (_command, args = []) => {
+      const script = args.at(-1) ?? '';
+      if (script.includes('status --porcelain')) {
+        return '## main\0##PREFIX\0\0##HEAD\0abc123\0##DIFFSTAT\0\0##DIFFSTAT_CACHED\0';
+      }
+      if (script.includes('git ls-files --others --exclude-standard -z')) return '0';
+      if (script.includes('ls-files --cached --others --exclude-standard')) {
+        return 'src/tracked.ts\0';
+      }
+      return '';
+    });
+    mockListFiles.mockImplementation(async ({ path }) => {
+      if (path === '.') return [];
+      if (path === 'src') {
+        return snapshot === 0
+          ? [
+              { path: '/repo/src/cache', type: 'directory', ignored: true },
+              { path: '/repo/src/old.tmp', type: 'file', ignored: true },
+              { path: '/repo/src/tracked.ts', type: 'file' },
+            ]
+          : [
+              { path: '/repo/src/cache', type: 'directory', ignored: true },
+              { path: '/repo/src/new.tmp', type: 'file', ignored: true },
+              { path: '/repo/src/tracked.ts', type: 'file' },
+            ];
+      }
+      return [];
+    });
+
+    const mounted = await mountComposable();
+    await mounted.settle();
+    mounted.api.toggleTreeDirectory('src');
+    await mounted.settle();
+
+    snapshot = 1;
+    await vi.advanceTimersByTimeAsync(5_000);
+    await mounted.settle();
+
+    const src = mounted.api.treeNodes.value.find((node) => node.path === 'src');
+    expect(mounted.api.expandedTreePaths.value).toEqual(['src']);
+    expect(src).toMatchObject({ loaded: true, ignored: false });
+    expect(src?.children?.map((node) => node.path)).toEqual([
+      'src/cache',
+      'src/new.tmp',
+      'src/tracked.ts',
+    ]);
+
+    mounted.unmount();
+  });
+
+  it('drops a queued snapshot refresh when refresh is disabled during an in-flight status request', async () => {
+    const mounted = await mountComposable();
+    await mounted.settle();
+    mockRunOneShotPtyCommand.mockClear();
+
+    let releaseStatus: VoidFunction | undefined;
+    mockRunOneShotPtyCommand.mockImplementation(async (_command, args = []) => {
+      const script = args.at(-1) ?? '';
+      if (script.includes('status --porcelain')) {
+        await new Promise<void>((resolve) => {
+          releaseStatus = resolve;
+        });
+        return '## main\0##PREFIX\0\0##HEAD\0abc123\0##DIFFSTAT\0\0##DIFFSTAT_CACHED\0';
+      }
+      if (script.includes('ls-files --cached --others --exclude-standard')) return 'src/a.ts\0';
+      return '0';
+    });
+
+    const first = mounted.api.refreshGitStatus({ includeFileSnapshot: false });
+    await Promise.resolve();
+    void mounted.api.refreshGitStatus({ includeFileSnapshot: true });
+    mounted.refreshEnabled.value = false;
+    await nextTick();
+
+    if (!releaseStatus) throw new Error('expected the status refresh to be waiting');
+    releaseStatus();
+    await first;
+    await mounted.settle();
+
+    expect(statusRefreshCount()).toBe(1);
+    expect(
+      ptyScripts().filter((script) =>
+        script.includes('ls-files --cached --others --exclude-standard'),
+      ),
+    ).toHaveLength(0);
+
+    mounted.unmount();
+  });
+
+  it('does not retry a failed refresh after refresh is disabled', async () => {
+    const mounted = await mountComposable();
+    await mounted.settle();
+    mockRunOneShotPtyCommand.mockClear();
+    mockRunOneShotPtyCommand.mockImplementation(async (_command, args = []) => {
+      const script = args.at(-1) ?? '';
+      if (script.includes('status --porcelain')) throw new Error('status failed');
+      return '';
+    });
+
+    const refresh = mounted.api.refreshGitStatus({ includeFileSnapshot: false });
+    await Promise.resolve();
+    mounted.refreshEnabled.value = false;
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(200);
+    await refresh;
+
+    expect(statusRefreshCount()).toBe(1);
+
+    mounted.unmount();
+  });
+
+  it('clears debounced file watcher work when refresh is disabled', async () => {
+    const mounted = await mountComposable();
+    await mounted.settle();
+    mockListFiles.mockClear();
+    mockRunOneShotPtyCommand.mockClear();
+
+    mounted.api.feed({ file: '/repo/src/new.ts', event: 'add' });
+    mounted.refreshEnabled.value = false;
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(200);
+    await mounted.settle();
+
+    expect(mockListFiles).not.toHaveBeenCalled();
+    expect(mockRunOneShotPtyCommand).not.toHaveBeenCalled();
+
+    mounted.unmount();
+  });
+
+  it('refreshes the git tree and status from disk while the workspace is active', async () => {
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    const mounted = await mountComposable();
+    await mounted.settle();
+
+    mockRunOneShotPtyCommand.mockClear();
+    mockListFiles.mockClear();
+    mockRunOneShotPtyCommand.mockImplementation(async (_command, args = []) => {
+      const script = args.at(-1) ?? '';
+      if (script.includes('status --porcelain')) {
+        return [
+          '## main',
+          '##PREFIX',
+          '',
+          '##HEAD',
+          'def456',
+          '##DIFFSTAT',
+          '',
+          '##DIFFSTAT_CACHED',
+          '',
+        ].join('\0');
+      }
+      if (script.includes('git ls-files --others --exclude-standard -z')) return '0';
+      if (script.includes('ls-files --cached --others --exclude-standard')) {
+        return 'src/a.ts\0src/after-commit.ts\0';
+      }
+      return '';
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await mounted.settle();
+
+    expect(mounted.api.gitStatus.value?.branch.headShort).toBe('def456');
+    expect(mounted.api.gitStatus.value?.files).toEqual([]);
+    expect(mounted.api.files.value).toEqual(['src/a.ts', 'src/after-commit.ts']);
+    expect(statusRefreshCount()).toBe(1);
+
+    mounted.unmount();
+  });
+
+  it('refreshes a non-git file tree from disk while the workspace is active', async () => {
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    mockGetVcsInfo.mockResolvedValue(null);
+    mockListFiles.mockResolvedValue([{ path: '/repo/src', type: 'directory' }]);
+    const mounted = await mountComposable();
+    await mounted.settle();
+
+    mockListFiles.mockClear();
+    mockRunOneShotPtyCommand.mockClear();
+    mockListFiles.mockImplementation(async ({ path }) => {
+      if (path === '.') {
+        return [
+          { path: '/repo/src', type: 'directory' },
+          { path: '/repo/new.txt', type: 'file' },
+        ];
+      }
+      return [{ path: '/repo/src/a.ts', type: 'file' }];
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await mounted.settle();
+
+    expect(mounted.api.files.value).toEqual(['new.txt', 'src/a.ts']);
+    expect(statusRefreshCount()).toBe(1);
+
+    mounted.unmount();
+  });
+
+  it('ignores a polling response from the previous backend', async () => {
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    const mounted = await mountComposable();
+    await mounted.settle();
+
+    let releasePreviousBackend: VoidFunction | undefined;
+    let releaseActiveBackend: VoidFunction | undefined;
+    let statusCallCount = 0;
+    mockRunOneShotPtyCommand.mockImplementation(async (_command, args = []) => {
+      const script = args.at(-1) ?? '';
+      if (script.includes('status --porcelain')) {
+        statusCallCount += 1;
+        if (statusCallCount === 1) {
+          await new Promise<void>((resolve) => {
+            releasePreviousBackend = resolve;
+          });
+          return '## main\0##PREFIX\0\0##HEAD\0stale123\0##DIFFSTAT\0\0##DIFFSTAT_CACHED\0';
+        }
+        if (statusCallCount === 2) {
+          await new Promise<void>((resolve) => {
+            releaseActiveBackend = resolve;
+          });
+        }
+        return '## main\0##PREFIX\0\0##HEAD\0fresh456\0##DIFFSTAT\0\0##DIFFSTAT_CACHED\0';
+      }
+      if (script.includes('git ls-files --others --exclude-standard -z')) return '0';
+      if (script.includes('ls-files --cached --others --exclude-standard')) return 'src/a.ts\0';
+      return '';
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    mounted.activeBackendKind.value = 'codex';
+    await nextTick();
+    if (!releasePreviousBackend) throw new Error('expected the old backend refresh to be waiting');
+    releasePreviousBackend();
+    await mounted.settle();
+    vi.runAllTicks();
+    await mounted.settle();
+
+    expect(statusCallCount).toBe(2);
+    expect(mounted.api.gitStatus.value?.branch.headShort).not.toBe('stale123');
+
+    if (!releaseActiveBackend) throw new Error('expected the active backend refresh to be waiting');
+    releaseActiveBackend();
+    await vi.advanceTimersByTimeAsync(0);
+    await mounted.settle();
+
+    mounted.unmount();
+  });
+
+  it('does not let a retried file listing from the previous backend replace the active tree', async () => {
+    const mounted = await mountComposable();
+    await mounted.settle();
+
+    let fileListCallCount = 0;
+    mockRunOneShotPtyCommand.mockImplementation(async (_command, args = []) => {
+      const script = args.at(-1) ?? '';
+      if (script.includes('status --porcelain')) {
+        return '## main\0##PREFIX\0\0##HEAD\0abc123\0##DIFFSTAT\0\0##DIFFSTAT_CACHED\0';
+      }
+      if (script.includes('git ls-files --others --exclude-standard -z')) return '0';
+      if (script.includes('ls-files --cached --others --exclude-standard')) {
+        fileListCallCount += 1;
+        if (fileListCallCount === 1) throw new Error('previous backend disconnected');
+        if (fileListCallCount === 2) return 'src/fresh.ts\0';
+        return 'src/stale.ts\0';
+      }
+      return '';
+    });
+
+    const staleRefresh = mounted.api.refreshGitStatus({ includeFileSnapshot: true });
+    await Promise.resolve();
+    mounted.activeBackendKind.value = 'codex';
+    await mounted.settle();
+    await vi.advanceTimersByTimeAsync(200);
+    await staleRefresh;
+    await mounted.settle();
+
+    expect(mounted.api.files.value).toEqual(['src/fresh.ts']);
+
+    mounted.unmount();
+  });
+
+  it('stops polling while workspace refresh is disabled and resumes immediately', async () => {
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    const mounted = await mountComposable();
+    await mounted.settle();
+
+    mockRunOneShotPtyCommand.mockClear();
+    mounted.refreshEnabled.value = false;
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(statusRefreshCount()).toBe(0);
+
+    mounted.refreshEnabled.value = true;
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(0);
+    await mounted.settle();
+    expect(statusRefreshCount()).toBe(1);
 
     mounted.unmount();
   });

--- a/app/composables/useFileTree.ts
+++ b/app/composables/useFileTree.ts
@@ -1,4 +1,4 @@
-import { computed, ref, watch } from 'vue';
+import { computed, onScopeDispose, ref, watch } from 'vue';
 import type { Ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { FileWatcherUpdatedPacket } from '../types/sse';
@@ -12,6 +12,7 @@ import type {
 import { getActiveBackendAdapter } from '../backends/registry';
 import { normalizeDirectory } from '../utils/path';
 import { uniqueBy } from '../utils/array';
+import { createWorkspaceRefreshLoop } from '../utils/workspaceRefreshLoop';
 import { usePtyOneshot } from './usePtyOneshot';
 
 const GIT_ENV_PREAMBLE = [
@@ -76,6 +77,7 @@ type FileTreeStrategy = 'filesystem' | 'git';
 type UseFileTreeOptions = {
   activeDirectory: Ref<string>;
   activeBackendKind?: Ref<string>;
+  refreshEnabled?: Readonly<Ref<boolean>>;
 };
 
 type DirectorySidebarSnapshot = {
@@ -128,7 +130,9 @@ let branchEntriesLoadedForDirectory = false;
 let gitStatusRefreshInFlight: Promise<void> | null = null;
 let gitStatusRefreshQueued = false;
 let gitStatusRefreshQueuedIncludeFileSnapshot = false;
+let gitStatusRefreshQueuedToken = 0;
 let untrackedCountRefreshInFlight: Promise<void> | null = null;
+let workspaceRefreshToken = 0;
 const pendingFileWatcherEvents: FileWatcherUpdatedPacket[] = [];
 
 const BRANCH_LIST_FORMAT =
@@ -290,6 +294,10 @@ function isPathInsideDirectory(path: string, directory: string) {
   );
 }
 
+function isRefreshCurrent(directory: string, token: number) {
+  return token === workspaceRefreshToken && getOptions().activeDirectory.value.trim() === directory;
+}
+
 function parentDirectoryPath(relativePath: string) {
   if (!relativePath.includes('/')) return '.';
   return relativePath.slice(0, relativePath.lastIndexOf('/')) || '.';
@@ -326,7 +334,7 @@ function replaceDirectoryFilesInCache(parentPath: string, children: TreeNode[]) 
     if (!filePath.startsWith(prefix)) return true;
     return filePath.slice(prefix.length).includes('/');
   });
-  const next = uniqueBy([...preserved, ...directFiles], x => x).sort((a, b) =>
+  const next = uniqueBy([...preserved, ...directFiles], (x) => x).sort((a, b) =>
     a.localeCompare(b),
   );
   const changed =
@@ -434,7 +442,10 @@ function parseShortstatLine(line: string): { additions: number; deletions: numbe
   };
 }
 
-function parseGitStatusOutput(output: string): { status: GitStatus; repoRelativeCwdPrefix: string } {
+function parseGitStatusOutput(output: string): {
+  status: GitStatus;
+  repoRelativeCwdPrefix: string;
+} {
   const cleaned = stripAnsi(output).replace(/\r/g, '');
   const tokens = cleaned.split('\0');
 
@@ -591,7 +602,10 @@ function mapGitStatusPathToActiveDirectory(path: string, repoRelativeCwdPrefix: 
   return normalizedPath;
 }
 
-function normalizeGitStatusToActiveDirectory(status: GitStatus, repoRelativeCwdPrefix: string): GitStatus {
+function normalizeGitStatusToActiveDirectory(
+  status: GitStatus,
+  repoRelativeCwdPrefix: string,
+): GitStatus {
   return {
     ...status,
     files: status.files.map((entry) => ({
@@ -715,14 +729,19 @@ async function retryOnce<T>(runner: (attempt: number) => Promise<T>, shouldRetry
   throw lastError;
 }
 
-async function listFilesWithRetry(directory: string, path: string) {
+async function listFilesWithRetry(
+  directory: string,
+  path: string,
+  refreshToken = workspaceRefreshToken,
+) {
   const data = await retryOnce(
     async () => {
+      if (!isRefreshCurrent(directory, refreshToken)) return [];
       const listFiles = getActiveBackendAdapter().listFiles;
       if (!listFiles) throw new Error('Active backend does not support file listing.');
       return await listFiles({ directory, path });
     },
-    () => getOptions().activeDirectory.value.trim() === directory,
+    () => isRefreshCurrent(directory, refreshToken),
   );
   return Array.isArray(data) ? data : [];
 }
@@ -782,6 +801,7 @@ function buildFullTreeFromPaths(allPaths: string[]): TreeNode[] {
 }
 
 async function detectFileTreeStrategy(directory: string): Promise<FileTreeStrategy> {
+  const refreshToken = workspaceRefreshToken;
   try {
     const raw = await retryOnce(
       async () => {
@@ -789,7 +809,7 @@ async function detectFileTreeStrategy(directory: string): Promise<FileTreeStrate
         if (!getVcsInfo) throw new Error('Active backend does not support VCS info.');
         return await getVcsInfo(directory);
       },
-      () => getOptions().activeDirectory.value.trim() === directory,
+      () => isRefreshCurrent(directory, refreshToken),
     );
     if (!raw || typeof raw !== 'object') return 'filesystem';
     const branch = (raw as Record<string, unknown>).branch;
@@ -798,38 +818,6 @@ async function detectFileTreeStrategy(directory: string): Promise<FileTreeStrate
   } catch {
     return 'filesystem';
   }
-}
-
-function deepMergeGitTree(existing: TreeNode[], incoming: TreeNode[]): TreeNode[] {
-  if (existing.length === 0) return incoming;
-  const existingByPath = new Map(existing.map((node) => [node.path, node]));
-  const incomingByPath = new Map(incoming.map((node) => [node.path, node]));
-
-  const merged = incoming.map((node) => {
-    const prev = existingByPath.get(node.path);
-    if (!prev || node.type !== 'directory' || prev.type !== 'directory') return node;
-
-    if (prev.loaded && Array.isArray(prev.children)) {
-      // Already expanded via /file — keep its children (includes ignored items)
-      return { ...node, children: prev.children, loaded: true };
-    }
-
-    // Not loaded, but recurse to preserve any loaded subdirectories deeper down
-    if (Array.isArray(prev.children) && Array.isArray(node.children)) {
-      return { ...node, children: deepMergeGitTree(prev.children, node.children) };
-    }
-
-    return node;
-  });
-
-  // Preserve existing nodes not in incoming (e.g., ignored root entries from /file)
-  for (const [path, node] of existingByPath) {
-    if (!incomingByPath.has(path)) {
-      merged.push(node);
-    }
-  }
-
-  return sortTreeNodes(merged);
 }
 
 function mergeApiWithGitChildren(apiChildren: TreeNode[], gitChildren: TreeNode[]): TreeNode[] {
@@ -844,7 +832,7 @@ function mergeApiWithGitChildren(apiChildren: TreeNode[], gitChildren: TreeNode[
       // Directory exists in both — use API metadata but keep git-derived subtree
       merged.push({
         ...apiNode,
-        children: gitNode.children,
+        children: apiNode.loaded ? apiNode.children : gitNode.children,
       });
     } else {
       merged.push(apiNode);
@@ -860,9 +848,74 @@ function mergeApiWithGitChildren(apiChildren: TreeNode[], gitChildren: TreeNode[
   return sortTreeNodes(merged);
 }
 
-async function loadIgnoredRootNodes(directory: string): Promise<TreeNode[]> {
+async function refreshLoadedDirectory(
+  directory: string,
+  apiNode: TreeNode,
+  gitNode: TreeNode | undefined,
+  previousNode: TreeNode,
+  refreshToken: number,
+): Promise<TreeNode> {
+  const list = await listFilesWithRetry(directory, apiNode.path, refreshToken);
+  if (!isRefreshCurrent(directory, refreshToken)) return apiNode;
+
+  const apiChildren = buildTreeNodes(list, directory, apiNode.path);
+  const gitChildren = gitNode?.type === 'directory' ? (gitNode.children ?? []) : [];
+  const mergedChildren = mergeApiWithGitChildren(apiChildren, gitChildren);
+  const previousByPath = new Map((previousNode.children ?? []).map((node) => [node.path, node]));
+  const gitByPath = new Map(gitChildren.map((node) => [node.path, node]));
+  const children = await Promise.all(
+    mergedChildren.map(async (child) => {
+      const previousChild = previousByPath.get(child.path);
+      if (
+        child.type !== 'directory' ||
+        previousChild?.type !== 'directory' ||
+        !previousChild.loaded
+      ) {
+        return child;
+      }
+      return refreshLoadedDirectory(
+        directory,
+        child,
+        gitByPath.get(child.path),
+        previousChild,
+        refreshToken,
+      );
+    }),
+  );
+
+  return { ...apiNode, children: sortTreeNodes(children), loaded: true };
+}
+
+async function reconcileLoadedRootNodes(
+  directory: string,
+  gitTree: TreeNode[],
+  ignoredRoot: TreeNode[],
+  previousTree: TreeNode[],
+  refreshToken: number,
+) {
+  const gitByPath = new Map(gitTree.map((node) => [node.path, node]));
+  const previousByPath = new Map(previousTree.map((node) => [node.path, node]));
+  const mergedRoot = mergeApiWithGitChildren(ignoredRoot, gitTree);
+  return Promise.all(
+    mergedRoot.map(async (node) => {
+      const previousNode = previousByPath.get(node.path);
+      if (node.type !== 'directory' || previousNode?.type !== 'directory' || !previousNode.loaded) {
+        return node;
+      }
+      return refreshLoadedDirectory(
+        directory,
+        node,
+        gitByPath.get(node.path),
+        previousNode,
+        refreshToken,
+      );
+    }),
+  );
+}
+
+async function loadIgnoredRootNodes(directory: string, refreshToken: number): Promise<TreeNode[]> {
   try {
-    const list = await listFilesWithRetry(directory, '.');
+    const list = await listFilesWithRetry(directory, '.', refreshToken);
     const nodes = buildTreeNodes(list, directory, '.');
     return nodes.filter((node) => node.ignored);
   } catch {
@@ -878,15 +931,15 @@ function parseGitFileList(output: string): string[] {
     .filter(Boolean);
 }
 
-async function refreshGitFileSnapshot() {
+async function refreshGitFileSnapshot(refreshToken = workspaceRefreshToken) {
   const { activeDirectory } = getOptions();
   const directory = activeDirectory.value.trim();
-  if (!directory) return;
+  if (!directory || !isRefreshCurrent(directory, refreshToken)) return;
 
   const { runOneShotPtyCommand } = usePtyOneshot();
+  const generation = ++gitFileListGeneration;
   await retryOnce(
     async () => {
-      const generation = ++gitFileListGeneration;
       const output = await runOneShotPtyCommand('bash', [
         '--noprofile',
         '--norc',
@@ -894,28 +947,27 @@ async function refreshGitFileSnapshot() {
         GIT_FILE_LIST_SCRIPT,
       ]);
       if (generation !== gitFileListGeneration) return;
-      if (activeDirectory.value.trim() !== directory) return;
+      if (!isRefreshCurrent(directory, refreshToken)) return;
 
       const allPaths = parseGitFileList(output);
-      if (allPaths.length === 0) {
-        treeNodes.value = [];
-        files.value = [];
-        fileCacheVersion.value += 1;
-        cacheCurrentDirectoryState(directory);
-        return;
-      }
-
       const gitTree = buildFullTreeFromPaths(allPaths);
-      const ignoredRoot = await loadIgnoredRootNodes(directory);
+      const previousTree = treeNodes.value;
+      const ignoredRoot = await loadIgnoredRootNodes(directory, refreshToken);
       if (generation !== gitFileListGeneration) return;
-      if (activeDirectory.value.trim() !== directory) return;
+      if (!isRefreshCurrent(directory, refreshToken)) return;
 
-      const mergedRoot = ignoredRoot.length > 0 ? deepMergeGitTree(ignoredRoot, gitTree) : gitTree;
-      // On manual refresh, replace the tree entirely rather than merging with old state.
-      // This ensures deleted files are removed from the sidebar.
-      treeNodes.value = mergedRoot;
+      const nextTree = await reconcileLoadedRootNodes(
+        directory,
+        gitTree,
+        ignoredRoot,
+        previousTree,
+        refreshToken,
+      );
+      if (generation !== gitFileListGeneration) return;
+      if (!isRefreshCurrent(directory, refreshToken)) return;
+      treeNodes.value = nextTree;
 
-      const sorted = uniqueBy(allPaths, x => x).sort((a, b) => a.localeCompare(b));
+      const sorted = uniqueBy(allPaths, (x) => x).sort((a, b) => a.localeCompare(b));
       if (
         sorted.length !== files.value.length ||
         sorted.some((path, index) => path !== files.value[index])
@@ -925,7 +977,7 @@ async function refreshGitFileSnapshot() {
       }
       cacheCurrentDirectoryState(directory);
     },
-    () => activeDirectory.value.trim() === directory,
+    () => isRefreshCurrent(directory, refreshToken),
   );
 }
 
@@ -942,7 +994,9 @@ function setGitStatus(next: GitStatus | null) {
   gitStatusByPath.value = byPath;
 }
 
-function updateUntrackedSummary(updater: (current: GitStatus['untracked']) => GitStatus['untracked']) {
+function updateUntrackedSummary(
+  updater: (current: GitStatus['untracked']) => GitStatus['untracked'],
+) {
   if (!gitStatus.value) return;
   gitStatus.value = {
     ...gitStatus.value,
@@ -951,7 +1005,7 @@ function updateUntrackedSummary(updater: (current: GitStatus['untracked']) => Gi
   cacheCurrentDirectoryState(getOptions().activeDirectory.value.trim());
 }
 
-async function refreshGitStatusOnly() {
+async function refreshGitStatusOnly(refreshToken = workspaceRefreshToken) {
   const { activeDirectory } = getOptions();
   const directory = activeDirectory.value.trim();
   if (!directory) {
@@ -959,10 +1013,11 @@ async function refreshGitStatusOnly() {
     return;
   }
 
+  if (!isRefreshCurrent(directory, refreshToken)) return;
   const { runOneShotPtyCommand } = usePtyOneshot();
+  const generation = ++gitStatusGeneration;
   await retryOnce(
     async () => {
-      const generation = ++gitStatusGeneration;
       const output = await runOneShotPtyCommand('bash', [
         '--noprofile',
         '--norc',
@@ -970,6 +1025,7 @@ async function refreshGitStatusOnly() {
         GIT_STATUS_SCRIPT,
       ]);
       if (generation !== gitStatusGeneration) return;
+      if (!isRefreshCurrent(directory, refreshToken)) return;
       if (!output.trim()) {
         setGitStatus(null);
         cacheCurrentDirectoryState(directory);
@@ -991,14 +1047,14 @@ async function refreshGitStatusOnly() {
       setGitStatus(normalizedStatus);
       cacheCurrentDirectoryState(directory);
     },
-    () => activeDirectory.value.trim() === directory,
+    () => isRefreshCurrent(directory, refreshToken),
   );
 }
 
-async function refreshUntrackedEligibleCount() {
+async function refreshUntrackedEligibleCount(refreshToken = workspaceRefreshToken) {
   const { activeDirectory } = getOptions();
   const directory = activeDirectory.value.trim();
-  if (!directory || !gitStatus.value) return;
+  if (!directory || !gitStatus.value || !isRefreshCurrent(directory, refreshToken)) return;
   if (untrackedCountRefreshInFlight) return untrackedCountRefreshInFlight;
 
   updateUntrackedSummary((current) => ({
@@ -1007,11 +1063,11 @@ async function refreshUntrackedEligibleCount() {
   }));
 
   const { runOneShotPtyCommand } = usePtyOneshot();
+  const generation = ++untrackedCountGeneration;
   untrackedCountRefreshInFlight = (async () => {
     try {
       await retryOnce(
         async () => {
-          const generation = ++untrackedCountGeneration;
           const output = await runOneShotPtyCommand('bash', [
             '--noprofile',
             '--norc',
@@ -1019,21 +1075,21 @@ async function refreshUntrackedEligibleCount() {
             GIT_UNTRACKED_COUNT_SCRIPT,
           ]);
           if (generation !== untrackedCountGeneration) return;
-          if (activeDirectory.value.trim() !== directory) return;
+          if (!isRefreshCurrent(directory, refreshToken)) return;
           const match = output.match(/\d+/);
           const eligibleFileCount = match ? Number.parseInt(match[0], 10) || 0 : 0;
           updateUntrackedSummary(() => ({ eligibleFileCount, pending: false }));
         },
-        () => activeDirectory.value.trim() === directory,
+        () => isRefreshCurrent(directory, refreshToken),
       );
     } catch {
-      if (activeDirectory.value.trim() !== directory) return;
+      if (!isRefreshCurrent(directory, refreshToken)) return;
       updateUntrackedSummary((current) => ({
         eligibleFileCount: current?.eligibleFileCount ?? 0,
         pending: false,
       }));
     } finally {
-      if (activeDirectory.value.trim() === directory) {
+      if (isRefreshCurrent(directory, refreshToken)) {
         untrackedCountRefreshInFlight = null;
       }
     }
@@ -1042,12 +1098,17 @@ async function refreshUntrackedEligibleCount() {
   return untrackedCountRefreshInFlight;
 }
 
-async function refreshGitStatus(options: RefreshGitStatusOptions = {}) {
+async function refreshGitStatus(
+  options: RefreshGitStatusOptions = {},
+  refreshToken = workspaceRefreshToken,
+) {
+  if (refreshToken !== workspaceRefreshToken) return;
   const includeFileSnapshot = options.includeFileSnapshot ?? true;
   if (gitStatusRefreshInFlight) {
-    if (!gitStatusRefreshQueued) {
+    if (!gitStatusRefreshQueued || gitStatusRefreshQueuedToken !== refreshToken) {
       gitStatusRefreshQueued = true;
       gitStatusRefreshQueuedIncludeFileSnapshot = includeFileSnapshot;
+      gitStatusRefreshQueuedToken = refreshToken;
     } else {
       gitStatusRefreshQueuedIncludeFileSnapshot ||= includeFileSnapshot;
     }
@@ -1058,25 +1119,28 @@ async function refreshGitStatus(options: RefreshGitStatusOptions = {}) {
   gitStatusRefreshInFlight = (async () => {
     try {
       if (!includeFileSnapshot || fileTreeStrategy.value !== 'git') {
-        await refreshGitStatusOnly().catch(() => {});
+        await refreshGitStatusOnly(refreshToken).catch(() => {});
         return;
       }
       const [statusResult] = await Promise.allSettled([
-        refreshGitStatusOnly(),
-        refreshGitFileSnapshot(),
+        refreshGitStatusOnly(refreshToken),
+        refreshGitFileSnapshot(refreshToken),
       ]);
       if (statusResult.status === 'rejected') {
         return;
       }
-      void refreshUntrackedEligibleCount();
+      void refreshUntrackedEligibleCount(refreshToken);
     } finally {
       gitStatusRefreshInFlight = null;
       if (gitStatusRefreshQueued) {
         const nextIncludeFileSnapshot = gitStatusRefreshQueuedIncludeFileSnapshot;
+        const nextRefreshToken = gitStatusRefreshQueuedToken;
         gitStatusRefreshQueued = false;
         gitStatusRefreshQueuedIncludeFileSnapshot = false;
+        gitStatusRefreshQueuedToken = 0;
         queueMicrotask(() => {
-          void refreshGitStatus({ includeFileSnapshot: nextIncludeFileSnapshot });
+          if (nextRefreshToken !== workspaceRefreshToken) return;
+          void refreshGitStatus({ includeFileSnapshot: nextIncludeFileSnapshot }, nextRefreshToken);
         });
       }
     }
@@ -1174,11 +1238,12 @@ async function refreshBranchEntries(options: RefreshBranchEntriesOptions = {}) {
   }
 
   branchListLoading.value = true;
+  const refreshToken = workspaceRefreshToken;
   const { runOneShotPtyCommand } = usePtyOneshot();
+  const generation = ++branchListGeneration;
   try {
     await retryOnce(
       async () => {
-        const generation = ++branchListGeneration;
         const output = await runOneShotPtyCommand('git', [
           '--no-pager',
           '-c',
@@ -1192,17 +1257,18 @@ async function refreshBranchEntries(options: RefreshBranchEntriesOptions = {}) {
           `--format=${BRANCH_LIST_FORMAT}`,
         ]);
         if (generation !== branchListGeneration) return;
+        if (!isRefreshCurrent(directory, refreshToken)) return;
         branchEntries.value = parseBranchEntries(output);
         branchEntriesLoadedForDirectory = true;
         cacheCurrentDirectoryState(directory);
       },
-      () => activeDirectory.value.trim() === directory,
+      () => isRefreshCurrent(directory, refreshToken),
     );
   } catch {
-    if (activeDirectory.value.trim() !== directory) return;
+    if (!isRefreshCurrent(directory, refreshToken)) return;
     branchEntriesLoadedForDirectory = false;
   } finally {
-    if (activeDirectory.value.trim() === directory) {
+    if (isRefreshCurrent(directory, refreshToken)) {
       branchListLoading.value = false;
     }
   }
@@ -1247,13 +1313,13 @@ async function loadSingleDirectory(path: string) {
       const apiChildren = buildTreeNodes(list, directory, path);
       const parent = findTreeNodeByPath(treeNodes.value, path);
       const gitChildren = parent?.children ?? [];
-       const merged = mergeApiWithGitChildren(apiChildren, gitChildren);
-       treeNodes.value = updateTreeNodeChildren(treeNodes.value, path, merged);
-       cacheCurrentDirectoryState(directory);
-     } catch (error) {
-       console.error('[useFileTree] loadSingleDirectory (git) failed:', error);
-       return;
-     }
+      const merged = mergeApiWithGitChildren(apiChildren, gitChildren);
+      treeNodes.value = updateTreeNodeChildren(treeNodes.value, path, merged);
+      cacheCurrentDirectoryState(directory);
+    } catch (error) {
+      console.error('[useFileTree] loadSingleDirectory (git) failed:', error);
+      return;
+    }
     return;
   }
 
@@ -1272,20 +1338,21 @@ async function loadSingleDirectory(path: string) {
       return;
     }
 
-     const parent = findTreeNodeByPath(treeNodes.value, path);
-     const mergedChildren = mergeTreeNodeChildren(parent?.children ?? [], children);
-     treeNodes.value = updateTreeNodeChildren(treeNodes.value, path, mergedChildren);
-     replaceDirectoryFilesInCache(path, mergedChildren);
-     cacheCurrentDirectoryState(directory);
-   } catch (error) {
-     console.error('[useFileTree] loadSingleDirectory (fs) failed:', error);
-   }
+    const parent = findTreeNodeByPath(treeNodes.value, path);
+    const mergedChildren = mergeTreeNodeChildren(parent?.children ?? [], children);
+    treeNodes.value = updateTreeNodeChildren(treeNodes.value, path, mergedChildren);
+    replaceDirectoryFilesInCache(path, mergedChildren);
+    cacheCurrentDirectoryState(directory);
+  } catch (error) {
+    console.error('[useFileTree] loadSingleDirectory (fs) failed:', error);
+  }
 }
 
 function feed(packet: FileWatcherUpdatedPacket) {
   const options = getOptions();
   const directory = options.activeDirectory.value.trim();
   if (!directory) return;
+  if (!(options.refreshEnabled?.value ?? true)) return;
   if (!isPathInsideDirectory(packet.file, directory)) return;
   if (treeLoading.value) {
     pendingFileWatcherEvents.push(packet);
@@ -1391,7 +1458,7 @@ async function rebuildFileCache() {
 
     if (buildId !== fileCacheBuildId) return;
     if (options.activeDirectory.value.trim() !== directory) return;
-    files.value = uniqueBy(collected, x => x).sort((a, b) => a.localeCompare(b));
+    files.value = uniqueBy(collected, (x) => x).sort((a, b) => a.localeCompare(b));
     fileCacheVersion.value += 1;
     cacheCurrentDirectoryState(directory);
   } catch (error) {
@@ -1414,6 +1481,29 @@ async function reloadTree() {
   await rebuildFileCache();
 }
 
+async function refreshWorkspaceFromDisk() {
+  const directory = getOptions().activeDirectory.value.trim();
+  if (!directory) return;
+  if (fileTreeStrategy.value === 'git') {
+    await refreshGitStatus({ includeFileSnapshot: true });
+    return;
+  }
+  await Promise.allSettled([reloadTree(), refreshGitStatus({ includeFileSnapshot: false })]);
+}
+
+function invalidateWorkspaceRefreshes() {
+  workspaceRefreshToken += 1;
+  fileCacheBuildId += 1;
+  gitStatusGeneration += 1;
+  gitFileListGeneration += 1;
+  untrackedCountGeneration += 1;
+  branchListGeneration += 1;
+  untrackedCountRefreshInFlight = null;
+  gitStatusRefreshQueued = false;
+  gitStatusRefreshQueuedIncludeFileSnapshot = false;
+  gitStatusRefreshQueuedToken = 0;
+}
+
 function initializeFileTree(options: UseFileTreeOptions) {
   if (boundOptions) return;
   boundOptions = options;
@@ -1424,12 +1514,7 @@ function initializeFileTree(options: UseFileTreeOptions) {
       clearScheduledDirectoryReloads();
       clearScheduledGitStatusReload();
 
-      fileCacheBuildId += 1;
-      gitStatusGeneration += 1;
-      gitFileListGeneration += 1;
-      untrackedCountGeneration += 1;
-      branchListGeneration += 1;
-      untrackedCountRefreshInFlight = null;
+      invalidateWorkspaceRefreshes();
       treeLoading.value = false;
       branchListLoading.value = false;
       expandedTreePathSet.value = new Set();
@@ -1450,6 +1535,31 @@ function initializeFileTree(options: UseFileTreeOptions) {
     },
     { immediate: true },
   );
+
+  const workspaceRefreshLoop = createWorkspaceRefreshLoop(refreshWorkspaceFromDisk, {
+    isEnabled: () => options.refreshEnabled?.value ?? true,
+  });
+  workspaceRefreshLoop.start();
+  const stopRefreshEnabledWatch = options.refreshEnabled
+    ? watch(
+        options.refreshEnabled,
+        (enabled) => {
+          if (!enabled) {
+            clearScheduledDirectoryReloads();
+            clearScheduledGitStatusReload();
+            invalidateWorkspaceRefreshes();
+            treeLoading.value = false;
+            branchListLoading.value = false;
+          }
+          workspaceRefreshLoop.sync();
+        },
+        { flush: 'sync' },
+      )
+    : undefined;
+  onScopeDispose(() => {
+    stopRefreshEnabledWatch?.();
+    workspaceRefreshLoop.stop();
+  });
 }
 
 function getT() {
@@ -1466,8 +1576,6 @@ function getT() {
   }
   return tFunction;
 }
-
-
 
 export function useFileTree(options?: UseFileTreeOptions) {
   const { t } = useI18n();

--- a/app/dev/settings-layout-fixture.html
+++ b/app/dev/settings-layout-fixture.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      http-equiv="Content-Security-Policy"
+        content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* https://api.iconify.design; img-src 'self' data: blob:; font-src 'self' data:; worker-src 'self' blob:;"
+    />
+    <title>Settings Layout Fixture (dev-only, mocked IPC)</title>
+    <script type="module" src="./settings-layout-fixture.ts"></script>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: #0d1117;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/app/dev/settings-layout-fixture.ts
+++ b/app/dev/settings-layout-fixture.ts
@@ -1,0 +1,147 @@
+import '../styles/tailwind.css';
+import type { Locale } from '../i18n/types';
+import type { DesktopApi, DesktopComponent, DesktopState, DesktopUpdateState } from '../types/desktop';
+import type { ConnectedBridgeVersion } from '../composables/useConnectedBridgeVersion';
+
+const params = new URLSearchParams(window.location.search);
+const page = params.get('page') === 'desktop' ? 'desktop' : 'editor';
+const locales: readonly Locale[] = ['en', 'zh-CN', 'zh-TW', 'ja', 'eo'];
+const requestedLocale = params.get('locale') ?? 'en';
+const locale = locales.find((candidate) => candidate === requestedLocale) ?? 'en';
+const localApplicationPath =
+  params.get('path') ?? '/opt/homebrew/bin/code --goto /Users/dev/project/src/index.ts';
+
+const phases: readonly DesktopUpdateState['phase'][] = [
+  'idle', 'checking', 'available', 'downloading', 'downloaded',
+  'installing', 'installer-opened', 'up-to-date', 'error', 'unsupported',
+];
+const requestedPhase = params.get('phase') ?? 'idle';
+const phase = phases.find((candidate) => candidate === requestedPhase) ?? 'idle';
+
+function phaseOverrides(value: DesktopUpdateState['phase']): Partial<DesktopUpdateState> {
+  switch (value) {
+    case 'available':
+      return { phase: value, availableVersion: '1.5.0', assetName: 'Vis-1.5.0.AppImage' };
+    case 'downloading':
+      return { phase: value, availableVersion: '1.5.0', progress: 45 };
+    case 'downloaded':
+      return { phase: value, availableVersion: '1.5.0', progress: 100 };
+    case 'error':
+      return { phase: value, error: 'network unreachable' };
+    default:
+      return { phase: value };
+  }
+}
+
+let state: DesktopState = {  preferences: {
+    locale: 'en',
+    minimizeToTray: true,
+    closeToTray: false,
+    autoCheckUpdates: true,
+    autoDownloadUpdates: false,
+    idleNotifications: true,
+    notificationSound: false,
+  },
+  trayAvailable: true,
+  nativeNotificationsAvailable: true,
+  updates: {
+    app: {
+      component: 'app',
+      currentVersion: '1.4.0',
+      availableVersion: null,
+      phase: 'idle',
+      progress: null,
+      error: null,
+      installKind: 'automatic',
+      assetName: null,
+      ...phaseOverrides(phase),
+    },
+    bridge: {
+      component: 'bridge',
+      currentVersion: '0.9.1',
+      availableVersion: null,
+      phase: 'idle',
+      progress: null,
+      error: null,
+      installKind: 'manual',
+      assetName: null,
+      ...phaseOverrides(phase),
+    },
+  },
+};
+
+const desktop: DesktopApi = {
+  getState: () => Promise.resolve(state),
+  configure: (patch) => {
+    Object.assign(state.preferences, patch);
+    return Promise.resolve(state);
+  },
+  reportBridgeVersion: () => Promise.resolve(state),
+  check: (component: DesktopComponent) => {
+    state = {
+      ...state,
+      updates: {
+        ...state.updates,
+        [component]: { ...state.updates[component], phase: 'up-to-date' },
+      },
+    };
+    return Promise.resolve(state);
+  },
+  download: () => Promise.resolve(state),
+  install: () => Promise.resolve(state),
+  notify: () => Promise.resolve(),
+  onState: () => () => {},
+  onNotificationClick: () => () => {},
+};
+
+window.electronAPI = {
+  platform: 'darwin',
+  versions: { node: '24.0.0', electron: '43.4.1', chrome: '150.0.0' },
+  getAppVersion: () => Promise.resolve('1.4.0'),
+  getPlatform: () => Promise.resolve('darwin'),
+  desktop,
+  localFile: {
+    selectApplication: () => Promise.resolve(null),
+    clearApplication: () => Promise.resolve(),
+    open: (payload) => Promise.resolve({ sessionId: payload.sessionId }),
+    close: () => Promise.resolve(),
+    onChanged: () => {},
+    offChanged: () => {},
+    onError: () => {},
+    offError: () => {},
+  },
+};
+
+window.localStorage.setItem('opencode.settings.localApplicationPath.v1', localApplicationPath);
+
+const [{ createApp, h, nextTick, ref }, { default: SettingsModal }, { i18n, setLocale }, { useRegionTheme }] =
+  await Promise.all([
+    import('vue'),
+    import('../components/SettingsModal.vue'),
+    import('../i18n'),
+    import('../composables/useRegionTheme'),
+  ]);
+
+setLocale(locale);
+
+const connectedBridgeState: ConnectedBridgeVersion = { status: 'ready', version: '0.9.2' };
+
+const open = ref(false);
+const app = createApp({
+  setup() {
+    useRegionTheme();
+    return () =>
+      h(SettingsModal, {
+        open: open.value,
+        initialPage: page,
+        connectedBridgeState,
+        refreshBridgeVersion: () => Promise.resolve(true),
+      });
+  },
+});
+app.use(i18n);
+app.mount('#app');
+await nextTick();
+open.value = true;
+await nextTick();
+document.body.dataset.fixtureReady = 'true';

--- a/app/utils/opencode.test.ts
+++ b/app/utils/opencode.test.ts
@@ -247,6 +247,44 @@ describe('opencode utilities', () => {
       );
     });
 
+    it('sendCommand includes attachment file parts in the POST body', async () => {
+      const mockFetch = vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: async () => ({}),
+        text: async () => '{}',
+      } as Response);
+      const parts = [
+        {
+          type: 'file' as const,
+          mime: 'image/png',
+          url: 'data:image/png;base64,AA==',
+          filename: 'image.png',
+        },
+      ];
+
+      await sendCommand('s1', {
+        directory: '/dir',
+        command: 'goal',
+        arguments: 'ship it',
+        parts,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/session/s1/command?directory=%2Fdir',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            directory: '/dir',
+            command: 'goal',
+            arguments: 'ship it',
+            parts,
+          }),
+        }),
+      );
+    });
+
     it('readFileContentBytes preserves auth and directory headers', async () => {
       const bytes = new Uint8Array([0x69, 0x63, 0x6e, 0x73]);
       const mockFetch = vi.mocked(fetch).mockResolvedValue({

--- a/app/utils/opencode.ts
+++ b/app/utils/opencode.ts
@@ -434,6 +434,7 @@ export async function sendCommand(
     agent?: string;
     model?: string;
     variant?: string;
+    parts?: Array<{ type: 'file'; mime: string; url: string; filename?: string }>;
   },
 ) {
   await sendJson(`/session/${sessionId}/command`, 'POST', {

--- a/app/utils/ptyLifecycle.test.ts
+++ b/app/utils/ptyLifecycle.test.ts
@@ -3,6 +3,20 @@ import { describe, expect, it } from 'vitest';
 import { createPendingPtyCreateRegistry, isCurrentPtySocket } from './ptyLifecycle';
 
 describe('createPendingPtyCreateRegistry', () => {
+  it('allows the first PTY window to open after its terminal module loads', async () => {
+    // Given a PTY id which has never been invalidated.
+    const registry = createPendingPtyCreateRegistry<boolean>();
+
+    // When its asynchronous terminal import completes.
+    const creation = registry.getOrCreate('new-pty', async (isCurrent) => {
+      await Promise.resolve();
+      return isCurrent();
+    });
+
+    // Then the window creation remains eligible to commit.
+    await expect(creation).resolves.toBe(true);
+  });
+
   it('shares one in-flight PTY window creation for the same id', async () => {
     let resolveCreation!: (value: string) => void;
     const creation = new Promise<string>((resolve) => {

--- a/app/utils/ptyLifecycle.ts
+++ b/app/utils/ptyLifecycle.ts
@@ -13,7 +13,7 @@ export function createPendingPtyCreateRegistry<T>() {
     const generation = generations.get(id) ?? 0;
     let entry: Promise<T>;
     const isCurrent = () =>
-      generations.get(id) === generation && pending.get(id) === entry;
+      (generations.get(id) ?? 0) === generation && pending.get(id) === entry;
     const created = factory(isCurrent);
     entry = created;
     pending.set(id, created);

--- a/app/utils/workspaceRefreshLoop.test.ts
+++ b/app/utils/workspaceRefreshLoop.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWorkspaceRefreshLoop } from './workspaceRefreshLoop';
+
+describe('createWorkspaceRefreshLoop', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('pauses while inactive and coalesces attention events into one refresh', async () => {
+    let hidden = true;
+    let focused = false;
+    vi.spyOn(document, 'hidden', 'get').mockImplementation(() => hidden);
+    vi.spyOn(document, 'hasFocus').mockImplementation(() => focused);
+    const refresh = vi.fn(async () => {});
+    const loop = createWorkspaceRefreshLoop(refresh, { intervalMs: 5_000 });
+    loop.start();
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(refresh).not.toHaveBeenCalled();
+
+    hidden = false;
+    focused = true;
+    document.dispatchEvent(new Event('visibilitychange'));
+    window.dispatchEvent(new Event('focus'));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    loop.stop();
+  });
+
+  it('waits for a slow refresh before scheduling the next one', async () => {
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    let releaseFirstRefresh: VoidFunction | undefined;
+    const refresh = vi.fn(async () => {
+      if (refresh.mock.calls.length === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirstRefresh = resolve;
+        });
+      }
+    });
+    const loop = createWorkspaceRefreshLoop(refresh, { intervalMs: 5_000 });
+    loop.start();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    document.dispatchEvent(new Event('visibilitychange'));
+    window.dispatchEvent(new Event('focus'));
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    if (!releaseFirstRefresh) throw new Error('expected the disk refresh to be waiting');
+    releaseFirstRefresh();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    loop.stop();
+  });
+
+  it('continues scheduling after a refresh rejects', async () => {
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    const refresh = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('refresh failed'))
+      .mockResolvedValue(undefined);
+    const onError = vi.fn();
+    const loop = createWorkspaceRefreshLoop(refresh, { intervalMs: 5_000, onError });
+    loop.start();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'refresh failed' }));
+    loop.stop();
+  });
+});

--- a/app/utils/workspaceRefreshLoop.ts
+++ b/app/utils/workspaceRefreshLoop.ts
@@ -1,0 +1,94 @@
+const WORKSPACE_REFRESH_INTERVAL_MS = 5_000;
+
+export type WorkspaceRefreshLoop = {
+  readonly start: () => void;
+  readonly stop: () => void;
+  readonly sync: () => void;
+};
+
+export type WorkspaceRefreshLoopOptions = {
+  readonly intervalMs?: number;
+  readonly isEnabled?: () => boolean;
+  readonly onError?: (error: unknown) => void;
+};
+
+function isWindowAttentive() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return false;
+  return !document.hidden && document.hasFocus();
+}
+
+export function createWorkspaceRefreshLoop(
+  refresh: () => Promise<void>,
+  options: WorkspaceRefreshLoopOptions = {},
+): WorkspaceRefreshLoop {
+  const intervalMs = options.intervalMs ?? WORKSPACE_REFRESH_INTERVAL_MS;
+  let started = false;
+  let refreshRunning = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearTimer() {
+    if (timer === null) return;
+    clearTimeout(timer);
+    timer = null;
+  }
+
+  function canRefresh() {
+    return (options.isEnabled?.() ?? true) && isWindowAttentive();
+  }
+
+  function schedule(delayMs: number) {
+    clearTimer();
+    if (!started || refreshRunning || !canRefresh()) return;
+    timer = setTimeout(() => {
+      timer = null;
+      void runRefresh();
+    }, delayMs);
+  }
+
+  async function runRefresh() {
+    if (!started || refreshRunning || !canRefresh()) return;
+    refreshRunning = true;
+    try {
+      await refresh();
+    } catch (error) {
+      if (options.onError) options.onError(error);
+      else console.error('[workspace-refresh] refresh failed:', error);
+    } finally {
+      refreshRunning = false;
+      schedule(intervalMs);
+    }
+  }
+
+  function sync() {
+    if (!canRefresh()) {
+      clearTimer();
+      return;
+    }
+    schedule(0);
+  }
+
+  function handleAttentionChange() {
+    sync();
+  }
+
+  function start() {
+    if (started) return;
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+    started = true;
+    window.addEventListener('focus', handleAttentionChange);
+    window.addEventListener('blur', handleAttentionChange);
+    document.addEventListener('visibilitychange', handleAttentionChange);
+    schedule(intervalMs);
+  }
+
+  function stop() {
+    if (!started) return;
+    started = false;
+    clearTimer();
+    window.removeEventListener('focus', handleAttentionChange);
+    window.removeEventListener('blur', handleAttentionChange);
+    document.removeEventListener('visibilitychange', handleAttentionChange);
+  }
+
+  return { start, stop, sync };
+}

--- a/scripts/qa/settings-layout.mjs
+++ b/scripts/qa/settings-layout.mjs
@@ -1,0 +1,207 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { chromium } from 'playwright';
+
+const output = path.resolve(process.env.VIS_SETTINGS_LAYOUT_QA_OUT ?? '/tmp/opencode/settings-layout-qa');
+mkdirSync(output, { recursive: true });
+const baseUrl = process.env.VIS_SETTINGS_LAYOUT_QA_URL ?? 'http://127.0.0.1:5173';
+const longWindowsPath = 'C:\\Users\\dev\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe --goto D:\\workspace\\project\\src\\index.ts';
+const fixture = (page, { locale, localPath, phase } = {}) => {
+  const params = new URLSearchParams({ page });
+  if (locale) params.set('locale', locale);
+  if (localPath) params.set('path', localPath);
+  if (phase) params.set('phase', phase);
+  return `${baseUrl}/dev/settings-layout-fixture.html?${params}`;
+};
+const editorRowLabel = { en: 'Local application', 'zh-CN': '本地应用' };
+
+const observations = [];
+let server;
+let browser;
+try {
+  server = spawn('pnpm', ['dev'], { cwd: path.resolve(import.meta.dirname, '../..'), stdio: ['ignore', 'pipe', 'pipe'] });
+  let serverLog = '';
+  server.stdout.on('data', (chunk) => { serverLog += chunk.toString(); });
+  server.stderr.on('data', (chunk) => { serverLog += chunk.toString(); });
+  const deadline = Date.now() + 60000;
+  for (;;) {
+    try {
+      const response = await fetch(`${baseUrl}/dev/settings-layout-fixture.html`);
+      if (response.ok) break;
+    } catch { /* server not up yet */ }
+    if (Date.now() > deadline) throw new Error(`vite dev server did not start\n${serverLog}`);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  browser = await chromium.launch({ chromiumSandbox: true });
+  const page = await browser.newPage();
+  const pageErrors = [];
+  page.on('pageerror', (error) => pageErrors.push(String(error)));
+
+  const shot = async (name, url, width, scrollSelector) => {
+    await page.setViewportSize({ width, height: 900 });
+    await page.goto(url);
+    await page.waitForSelector('body[data-fixture-ready="true"]', { state: 'attached' });
+    await page.waitForSelector('dialog[open]', { state: 'attached' });
+    await page.waitForSelector('dialog[open] .modal-close-button svg path', { state: 'attached', timeout: 15000 });
+    if (scrollSelector) {
+      await page.locator(scrollSelector).first().evaluate((element) => element.scrollIntoView({ block: 'center' }));
+    }
+    await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+    const screenshot = path.join(output, `${name}-${width}.png`);
+    await page.screenshot({ path: screenshot });
+    return screenshot;
+  };
+
+  const editorGeometry = async (label) => {
+    return page.evaluate((rowLabel) => {
+      const row = Array.from(document.querySelectorAll('dialog[open] .setting-row')).find(
+        (candidate) => candidate.querySelector('.setting-label')?.textContent === rowLabel,
+      );
+      if (!row) return { found: false };
+      const info = row.querySelector('.setting-info').getBoundingClientRect();
+      const controls = row.querySelector('.local-application-controls');
+      const controlsRect = controls.getBoundingClientRect();
+      const children = Array.from(controls.children).map((child) => {
+        const rect = child.getBoundingClientRect();
+        return { tag: child.tagName.toLowerCase(), top: rect.top, left: rect.left, width: rect.width };
+      });
+      return {
+        found: true,
+        direction: getComputedStyle(row).flexDirection,
+        controlsBelowInfo: controlsRect.top >= info.bottom - 1,
+        infoWidth: info.width,
+        controlsWidth: controlsRect.width,
+        rowWidth: row.getBoundingClientRect().width,
+        children,
+        input: row.querySelector('.local-application-controls input').getBoundingClientRect().toJSON(),
+      };
+    }, label);
+  };
+
+  const desktopGeometry = async () => {
+    return page.evaluate(() => {
+      const cards = Array.from(document.querySelectorAll('dialog[open] .desktop-update-card'));
+      return cards.map((card) => {
+        const header = card.querySelector('.desktop-update-header').getBoundingClientRect();
+        const versions = card.querySelector('.desktop-update-versions').getBoundingClientRect();
+        const actions = card.querySelector('.desktop-update-actions')?.getBoundingClientRect() ?? null;
+        const summary = card.querySelector('.desktop-update-summary');
+        const extra = card.querySelector('.desktop-update-extra-actions');
+        return {
+          component: card.getAttribute('data-testid'),
+          headerAboveVersions: header.bottom <= versions.top + 1,
+          versions: versions.toJSON(),
+          actions: actions ? actions.toJSON() : null,
+          sameRow: actions ? actions.top < versions.bottom && versions.top < actions.bottom : null,
+          actionsRightOfVersions: actions ? actions.left >= versions.left : null,
+          summaryButtonCount: summary ? summary.querySelectorAll('button').length : null,
+          extraActions: extra
+            ? {
+                buttonCount: extra.querySelectorAll('button').length,
+                belowSummary: extra.getBoundingClientRect().top >= summary.getBoundingClientRect().bottom - 1,
+              }
+            : null,
+          horizontalOverflow: card.scrollWidth > card.clientWidth + 1,
+        };
+      });
+    });
+  };
+
+  const editor1280 = await shot('editor', fixture('editor'), 1280);
+  let geometry = await editorGeometry(editorRowLabel.en);
+  assert.ok(geometry.found, 'local application row must render on the editor page');
+  assert.equal(geometry.direction, 'column', 'local application row must stack vertically');
+  assert.ok(geometry.controlsBelowInfo, 'controls row must sit below label/description');
+  const editorWideTops = new Set(geometry.children.map((child) => Math.round(child.top)));
+  assert.equal(editorWideTops.size, 1, 'input, choose app, and remove must share one row at 1280px');
+  assert.ok(geometry.input.width > geometry.rowWidth * 0.4, 'path input must get the row width, not be squeezed beside the label');
+  observations.push({ screenshot: editor1280, geometry });
+
+  const editor375 = await shot('editor', fixture('editor'), 375, '.local-application-controls');
+  geometry = await editorGeometry(editorRowLabel.en);
+  assert.ok(geometry.found && geometry.controlsBelowInfo, 'narrow editor row must keep controls below the label');
+  assert.ok(geometry.children.every((child) => child.width <= geometry.controlsWidth + 1), 'no control may overflow its row at 375px');
+  observations.push({ screenshot: editor375, geometry });
+
+  const desktop1280 = await shot('desktop', fixture('desktop'), 1280);
+  let cards = await desktopGeometry();
+  assert.equal(cards.length, 2, 'desktop page must render app and bridge cards');
+  for (const card of cards) {
+    assert.ok(card.headerAboveVersions, `${card.component}: header must stay the top row`);
+    assert.ok(card.sameRow, `${card.component}: check updates must share the version row`);
+    assert.ok(card.actionsRightOfVersions, `${card.component}: actions must sit right of the version text`);
+    assert.equal(card.summaryButtonCount, 1, `${card.component}: idle summary row must hold only the check button`);
+    assert.equal(card.extraActions, null, `${card.component}: idle phase must not render the extra actions row`);
+    assert.ok(!card.horizontalOverflow, `${card.component}: no horizontal overflow`);
+  }
+  observations.push({ screenshot: desktop1280, cards });
+
+  const desktop768 = await shot('desktop', fixture('desktop'), 768);
+  cards = await desktopGeometry();
+  for (const card of cards) {
+    assert.ok(card.sameRow, `${card.component}: check updates must still share the version row at 768px`);
+    assert.ok(!card.horizontalOverflow, `${card.component}: no horizontal overflow at 768px`);
+  }
+  observations.push({ screenshot: desktop768, cards });
+
+  const desktop375 = await shot('desktop', fixture('desktop'), 375);
+  cards = await desktopGeometry();
+  for (const card of cards) {
+    assert.ok(card.sameRow, `${card.component}: check updates must still share the version row at 375px`);
+    assert.ok(!card.horizontalOverflow, `${card.component}: no horizontal overflow at 375px`);
+  }
+  observations.push({ screenshot: desktop375, cards });
+
+  for (const phase of ['available', 'downloaded', 'error']) {
+    for (const width of [1280, 768, 375]) {
+      const phaseShot = await shot(`desktop-${phase}`, fixture('desktop', { phase }), width);
+      cards = await desktopGeometry();
+      for (const card of cards) {
+        assert.ok(card.sameRow, `${card.component} (${phase}): check must share the version row at ${width}px`);
+        assert.equal(card.summaryButtonCount, 1, `${card.component} (${phase}): summary row must hold only the check button at ${width}px`);
+        assert.ok(card.extraActions, `${card.component} (${phase}): extra actions row must exist`);
+        assert.ok(card.extraActions.belowSummary, `${card.component} (${phase}): extra actions must sit below the summary at ${width}px`);
+        assert.ok(!card.horizontalOverflow, `${card.component} (${phase}): no horizontal overflow at ${width}px`);
+      }
+      observations.push({ screenshot: phaseShot, phase, width, cards });
+    }
+  }
+
+  const editorZh1280 = await shot('editor-zh', fixture('editor', { locale: 'zh-CN', localPath: longWindowsPath }), 1280, '.local-application-controls');
+  geometry = await editorGeometry(editorRowLabel['zh-CN']);
+  assert.ok(geometry.found && geometry.controlsBelowInfo, 'zh-CN editor row must keep controls below the label');
+  assert.ok(geometry.children.every((child) => child.width <= geometry.controlsWidth + 1), 'no control may overflow its row at zh-CN 1280px');
+  observations.push({ screenshot: editorZh1280, geometry });
+
+  const editorZh375 = await shot('editor-zh', fixture('editor', { locale: 'zh-CN', localPath: longWindowsPath }), 375, '.local-application-controls');
+  geometry = await editorGeometry(editorRowLabel['zh-CN']);
+  assert.ok(geometry.found && geometry.controlsBelowInfo, 'zh-CN narrow editor row must keep controls below the label');
+  assert.ok(geometry.children.every((child) => child.width <= geometry.controlsWidth + 1), 'no control may overflow its row at zh-CN 375px');
+  observations.push({ screenshot: editorZh375, geometry });
+
+  const desktopZh1280 = await shot('desktop-zh', fixture('desktop', { locale: 'zh-CN' }), 1280);
+  cards = await desktopGeometry();
+  for (const card of cards) {
+    assert.ok(card.sameRow, `${card.component}: zh-CN check updates must share the version row at 1280px`);
+    assert.ok(!card.horizontalOverflow, `${card.component}: no horizontal overflow at zh-CN 1280px`);
+  }
+  observations.push({ screenshot: desktopZh1280, cards });
+
+  const desktopZh375 = await shot('desktop-zh', fixture('desktop', { locale: 'zh-CN' }), 375);
+  cards = await desktopGeometry();
+  for (const card of cards) {
+    assert.ok(card.sameRow, `${card.component}: zh-CN check updates must still share the version row at 375px`);
+    assert.ok(!card.horizontalOverflow, `${card.component}: no horizontal overflow at zh-CN 375px`);
+  }
+  observations.push({ screenshot: desktopZh375, cards });
+
+  assert.deepEqual(pageErrors, [], 'the fixture page must run without page errors');
+  writeFileSync(path.join(output, 'receipt.json'), JSON.stringify({ pass: true, observations }, null, 2));
+  console.log(JSON.stringify({ pass: true, screenshots: observations.map((entry) => entry.screenshot) }, null, 2));
+} finally {
+  if (browser) await browser.close();
+  if (server) server.kill('SIGTERM');
+}


### PR DESCRIPTION
## 变更
- 文件树保留事件刷新，增加可见、聚焦且连接就绪时的 5 秒串行轮询，自动同步外部文件修改和 Git 提交。
- 重新加载已展开目录的当前内容，保留忽略文件可见性并移除已删除项；用稳定生命周期令牌阻止禁用或切换后端后的重试、排队和延迟刷新。
- 修复首次 PTY 创建时 generation 未初始化导致窗口不出现的问题。
- OpenCode/ACP 命令请求转发附件；斜杠命令不再绕过 Enter 发送设置。
- 扩写中英文 README 的片段、编辑器、Git 操作、Codex 和桌面功能说明，不加入 bug 修复记录。

## 验证
- [x] 回归 RED → GREEN，含忽略目录、受跟踪目录下忽略文件、禁用期间排队请求与重试。
- [x] pnpm lint
- [x] pnpm test：2250 passed，2 skipped
- [x] pnpm build
- [x] pnpm bridge:build
- [x] OpenCode、Codex、ACP 真实 PTY 执行命令。
- [x] 真实浏览器验证外部修改、Git 提交和连续轮询后的展开目录；注销后停止刷新请求。
- [x] 真实 OpenCode 服务端消息包含 auto-slash-command 文本和附件内容；Enter 开关及 Ctrl+Enter 验证。
- [x] 五路初审发现的阻断项已修复，独立增量复审通过。

## 已知基线提示
完整测试仍输出已有 happy-dom AbortError 与 worker teardown 警告；生产构建有已有大分块警告。测试断言和构建均通过。