### PR TITLE
feat(bridge): add terminal updates and RPM releases

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -433,18 +433,70 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install nsis --no-progress --yes
 
+      - name: Install RPM packaging tools
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cpio rpm
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Run RPM packaging inspection test
+        if: runner.os == 'Linux'
+        run: pnpm vitest run bridgeInstallerRpm.integration.test.ts
 
       - name: Verify Windows process-tree cleanup
         if: runner.os == 'Windows'
         run: pnpm vitest run processTree.windows.test.ts acpTerminalManager.test.ts
+
+      - name: Verify terminal updater handoff
+        run: pnpm vitest run bridgeUpdateCli.test.ts bridgeUpdatePlatform.test.ts bridgeUpdateHandoff.test.ts bridgeUpdateCommand.test.ts
+
+      - name: Verify native terminal update transaction
+        if: runner.os == 'Linux'
+        env:
+          VIS_BRIDGE_NATIVE_UPDATE_QA: '1'
+        run: pnpm vitest run bridgeUpdaterTransaction.integration.test.ts
 
       - name: Build vis_bridge binary payload
         run: pnpm bridge:build
 
       - name: Package native vis_bridge installer
         run: pnpm bridge:package-installer
+
+      - name: Package native vis_bridge RPM
+        if: runner.os == 'Linux'
+        run: pnpm bridge:package-installer -- --format rpm
+
+      - name: Inspect Linux RPM payload and lifecycle
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          rpm_installer=(dist-bridge/installers/*.rpm)
+          test "${#rpm_installer[@]}" -eq 1
+          test "$(rpm -qp --qf '%{NAME}' "${rpm_installer[0]}")" = 'vis-bridge'
+          expected_rpm_arch="$([ '${{ matrix.arch }}' = 'x64' ] && printf x86_64 || printf aarch64)"
+          test "$(rpm -qp --qf '%{ARCH}' "${rpm_installer[0]}")" = "$expected_rpm_arch"
+          rpm -qpl "${rpm_installer[0]}" | grep -Fx '/usr/bin/vis_bridge'
+          rpm -qpl "${rpm_installer[0]}" | grep -F '/usr/lib/vis_bridge/node_modules/node-pty/'
+          rpm -qp --scripts "${rpm_installer[0]}" | tee "$RUNNER_TEMP/vis-bridge-rpm-scriptlets.txt"
+          grep -F '/usr/bin/vis_bridge' "$RUNNER_TEMP/vis-bridge-rpm-scriptlets.txt"
+          rpm_extract="$RUNNER_TEMP/vis-bridge-rpm-extract"
+          mkdir -p "$rpm_extract"
+          rpm2cpio "${rpm_installer[0]}" | (cd "$rpm_extract" && cpio --quiet -idmu)
+          cmp dist-bridge/vis_bridge "$rpm_extract/usr/bin/vis_bridge"
+          cmp "node_modules/node-pty/prebuilds/linux-${{ matrix.arch }}/pty.node" "$rpm_extract/usr/lib/vis_bridge/node_modules/node-pty/prebuilds/linux-${{ matrix.arch }}/pty.node"
+          test -x "$rpm_extract/usr/bin/vis_bridge"
+          test -f "$rpm_extract/usr/lib/vis_bridge/node_modules/node-pty/lib/index.js"
+
+      - name: Exercise RPM install, upgrade, and removal lifecycle
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          rpm_installer=(dist-bridge/installers/*.rpm)
+          test "${#rpm_installer[@]}" -eq 1
+          bash scripts/qa/vis-bridge-rpm-lifecycle.sh "${rpm_installer[0]}"
 
       - name: Exercise Linux installer
         if: runner.os == 'Linux'
@@ -539,6 +591,7 @@ jobs:
           name: bridge-${{ matrix.platform }}-${{ matrix.arch }}-artifacts
           path: |
             dist-bridge/installers/*.deb
+            dist-bridge/installers/*.rpm
             dist-bridge/installers/*.pkg
             dist-bridge/installers/*.exe
           retention-days: 7
@@ -599,6 +652,7 @@ jobs:
             artifacts/**/*.exe
             artifacts/**/*.AppImage
             artifacts/**/*.deb
+            artifacts/**/*.rpm
             artifacts/**/*.pkg
             artifacts/**/*.yml
             artifacts/**/*.blockmap

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ codex --version
 
 | 平台 | 安装文件 | 安装结果 |
 |---|---|---|
-| Linux | `VisBridge-<version>-<arch>-Linux.deb` | 安装到 `/usr/bin/vis_bridge` |
+| Linux | `VisBridge-<version>-<arch>-Linux.deb` / `VisBridge-<version>-<arch>-Linux.rpm` | 分别适用于 DEB / RPM 系统，安装到 `/usr/bin/vis_bridge` |
 | macOS | `VisBridge-<version>-<arch>-MacOS.pkg` | 安装到 `/usr/local/bin/vis_bridge` |
 | Windows | `VisBridge-<version>-<arch>-Windows.exe` | 安装到 `%LOCALAPPDATA%\Programs\vis_bridge` 并加入用户 PATH |
 
@@ -159,7 +159,19 @@ vis_bridge stop
 vis_bridge restart
 ```
 
+在 bridge 所在主机的外部终端中手动更新：
+
+```bash
+vis_bridge update --check  # 仅查询最新正式版本，不下载或安装
+vis_bridge update          # 显示更新信息并确认后安装
+vis_bridge upgrade --yes   # update 的别名；非交互使用需显式确认
+```
+
+更新仅适用于原生安装包管理的 `vis_bridge`；源码或自定义位置仍可执行 `--check`。Linux 根据包归属及发行版选择 DEB/RPM，macOS 使用 PKG，Windows 使用每用户 NSIS 安装包；下载须通过大小与 SHA-256 校验。安装会停止 bridge 及其子进程，不自动重启，不能从 bridge 自己托管的终端发起安装。POSIX 终端保留安装器退出状态，非 root 用户需要 `sudo` 权限；Windows 在原命令退出后交接安装，并打印持久结果日志位置，交接成功不等于安装成功。
+
 `start` 会等待 bridge 完成监听和初次服务探测后再返回。OpenCode、Codex 或 ACP Agent 启动失败时，命令行会直接列出对应名称和错误；bridge 本身仍可用时会继续在后台运行，完整错误也会显示在“状态监控”→“ACP”中。配置损坏或端口被占用等 bridge 级错误会让 `start` 以失败退出，不会留下一个表面可用的服务。
+
+Linux 的 `--check` 在有新版时也需要可识别的发行版及包管理工具，无法确定 DEB/RPM 时会明确失败。安装前若祖先进程身份不可读，会在确认后请求仅用于读取进程身份的 `sudo` 权限，不能因此跳过托管终端检查。
 
 源码开发使用相同的守护进程命令：
 
@@ -470,7 +482,7 @@ GitHub Releases publish native installers only, not the intermediate standalone 
 
 | Platform | Installer | Result |
 |---|---|---|
-| Linux | `VisBridge-<version>-<arch>-Linux.deb` | Installs `/usr/bin/vis_bridge` |
+| Linux | `VisBridge-<version>-<arch>-Linux.deb` / `VisBridge-<version>-<arch>-Linux.rpm` | For DEB / RPM systems respectively; installs `/usr/bin/vis_bridge` |
 | macOS | `VisBridge-<version>-<arch>-MacOS.pkg` | Installs `/usr/local/bin/vis_bridge` |
 | Windows | `VisBridge-<version>-<arch>-Windows.exe` | Installs under `%LOCALAPPDATA%\Programs\vis_bridge` and adds it to the user PATH |
 
@@ -489,6 +501,18 @@ vis_bridge restart
 ```
 
 `start` waits until the bridge is listening and the initial service probe has completed. If OpenCode, Codex, or an ACP agent fails to start, the CLI prints the component name and error while keeping the usable bridge online; the full error also appears under **Status Monitor → ACP**. Bridge-level failures such as an invalid config or occupied listen port make `start` fail instead of publishing a superficially healthy service.
+
+Update manually from an external terminal on the bridge host:
+
+```bash
+vis_bridge update --check  # Query the latest stable release without downloading or installing
+vis_bridge update          # Show the offer, then confirm installation
+vis_bridge upgrade --yes   # Alias for update; explicit consent for non-interactive use
+```
+
+Installation requires a native-package-managed `vis_bridge`; source and custom-location builds may still use `--check`. Linux selects DEB/RPM using package ownership and distribution evidence, macOS uses PKG, and Windows uses the per-user NSIS installer. Downloads must pass size and SHA-256 verification. Installation stops the bridge and its children without restarting them; do not install from a bridge-hosted terminal. POSIX preserves the installer exit status and requires `sudo` privileges when non-root. Windows waits for the original command to exit, then runs the installer and records its result at the printed persistent log path; accepted handoff does not mean successful installation.
+
+On Linux, an available update also requires a recognized distribution and package tools for `--check`; ambiguous DEB/RPM selection fails explicitly. After confirmation, installation may request narrowly scoped `sudo` access to inspect otherwise unreadable ancestors rather than bypassing the hosted-terminal guard.
 
 Source development uses the same daemon commands:
 

--- a/app/bridgeInstallerBuild.test.ts
+++ b/app/bridgeInstallerBuild.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createNsiPath,
   createLinuxMaintainerScript,
+  createLinuxRpmSpec,
   createMacPreinstallScript,
   createWindowsStopScript,
   createVisBridgeInstallerAssetName,
@@ -17,11 +18,90 @@ describe('vis_bridge installer packaging', () => {
       createVisBridgeInstallerAssetName({ version: '0.7.0', platform: 'linux', arch: 'x64' }),
     ).toBe('VisBridge-0.7.0-x64-Linux.deb');
     expect(
+      createVisBridgeInstallerAssetName({
+        version: '0.7.0',
+        platform: 'linux',
+        arch: 'x64',
+        format: 'deb',
+      }),
+    ).toBe('VisBridge-0.7.0-x64-Linux.deb');
+    expect(
+      createVisBridgeInstallerAssetName({
+        version: '0.7.0',
+        platform: 'linux',
+        arch: 'x64',
+        format: 'rpm',
+      }),
+    ).toBe('VisBridge-0.7.0-x64-Linux.rpm');
+    expect(
       createVisBridgeInstallerAssetName({ version: 'v0.7.0', platform: 'darwin', arch: 'arm64' }),
     ).toBe('VisBridge-0.7.0-arm64-MacOS.pkg');
     expect(
       createVisBridgeInstallerAssetName({ version: '0.7.0', platform: 'win32', arch: 'x64' }),
     ).toBe('VisBridge-0.7.0-x64-Windows.exe');
+  });
+
+  it('keeps DEB as the Linux default and isolates explicit RPM workspace output', () => {
+    const root = path.resolve('/workspace/vis');
+    expect(
+      createVisBridgeInstallerPaths(root, {
+        version: '0.7.0',
+        platform: 'linux',
+        arch: 'arm64',
+        format: 'rpm',
+      }),
+    ).toEqual({
+      binaryPath: path.join(root, 'dist-bridge', 'vis_bridge'),
+      installerDirectory: path.join(root, 'dist-bridge', 'installers'),
+      installerPath: path.join(
+        root,
+        'dist-bridge',
+        'installers',
+        'VisBridge-0.7.0-arm64-Linux.rpm',
+      ),
+      workspacePath: path.join(root, 'dist-bridge', 'installer-work', 'linux-arm64-rpm'),
+    });
+  });
+
+  it('creates RPM metadata without mutating prebuilt native payloads', () => {
+    const spec = createLinuxRpmSpec({
+      version: '1.2.3',
+      architecture: 'x86_64',
+      payloadPath: '/workspace/payload',
+    });
+    expect(spec).toContain('Name: vis-bridge');
+    expect(spec).toContain('Version: 1.2.3');
+    expect(spec).toContain('BuildArch: x86_64');
+    expect(spec).toContain('%global _enable_debug_packages 0');
+    expect(spec).toContain('%global _build_id_links none');
+    expect(spec).toContain('%global _no_recompute_build_ids 1');
+    expect(spec).toContain('%global __os_install_post %{nil}');
+    expect(spec).toContain('%global __brp_strip %{nil}');
+    expect(spec).toContain('%{?python_disable_dependency_generator}');
+    expect(spec).toContain(
+      'Requires(pre): /bin/sh, /usr/bin/pgrep, /usr/bin/readlink, /usr/bin/kill, /usr/bin/sleep',
+    );
+    expect(spec).toContain(
+      'Requires(preun): /bin/sh, /usr/bin/pgrep, /usr/bin/readlink, /usr/bin/kill, /usr/bin/sleep',
+    );
+    expect(spec).toContain('%attr(0755,root,root) /usr/bin/vis_bridge');
+  });
+
+  it('stops the installed RPM daemon tree before install and only before true uninstall', () => {
+    const spec = createLinuxRpmSpec({
+      version: '1.2.3',
+      architecture: 'aarch64',
+      payloadPath: '/workspace/payload',
+    });
+    const preinstall = spec.slice(spec.indexOf('%pre\n'), spec.indexOf('%preun\n'));
+    const preuninstall = spec.slice(spec.indexOf('%preun\n'), spec.indexOf('%files\n'));
+    expect(preinstall).toContain('/usr/bin/vis_bridge');
+    expect(preinstall).toContain('collect_process_tree');
+    expect(preuninstall).toContain('if [ "$1" -eq 0 ]; then');
+    expect(preuninstall).toContain('/usr/bin/vis_bridge');
+    expect(preuninstall).not.toContain('%postun');
+    expect(spec).not.toContain('%postun');
+    expect(spec).toContain('printf "%%s\\n"');
   });
 
   it('keeps the raw bridge binary outside the publishable installer directory', () => {
@@ -77,7 +157,8 @@ describe('vis_bridge installer packaging', () => {
     expect(linuxScript).not.toContain('/usr/bin/vis_bridge stop');
     expect(linuxScript).toContain('/usr/bin/readlink');
     expect(linuxScript).toContain('/proc/[0-9]*/exe');
-    expect(linuxScript).toContain('/bin/kill -TERM');
+    expect(linuxScript).toContain('/usr/bin/kill -TERM');
+    expect(linuxScript).toContain('/usr/bin/sleep 0.1');
     expect(linuxScript).toContain('collect_process_tree');
     expect(linuxScript).toContain('/usr/bin/pgrep -P');
     expect(linuxScript).toContain('tree_pids');

--- a/app/bridgeInstallerRpm.integration.test.ts
+++ b/app/bridgeInstallerRpm.integration.test.ts
@@ -1,0 +1,95 @@
+import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { packageVisBridgeInstaller } from '../scripts/package-vis-bridge-installer.mjs';
+
+const rpmToolsAvailable =
+  process.platform === 'linux' &&
+  (process.arch === 'x64' || process.arch === 'arm64') &&
+  existsSync('/usr/bin/rpmbuild') &&
+  existsSync('/usr/bin/rpm') &&
+  existsSync('/usr/bin/rpm2cpio') &&
+  existsSync('/usr/bin/cpio');
+
+describe.runIf(rpmToolsAvailable)('vis_bridge RPM package', () => {
+  it('contains the executable runtime payload, metadata, permissions, and lifecycle scriptlets', async () => {
+    const architecture = process.arch as 'x64' | 'arm64';
+    const rpmArchitecture = architecture === 'x64' ? 'x86_64' : 'aarch64';
+    // Given: a minimal native bridge payload with an executable node-pty prebuild.
+    const root = mkdtempSync(path.join(tmpdir(), 'vis-bridge-rpm-test-'));
+    const bridgePath = path.join(root, 'dist-bridge', 'vis_bridge');
+    const nodePtyPath = path.join(root, 'node_modules', 'node-pty');
+    mkdirSync(path.join(nodePtyPath, 'lib'), { recursive: true });
+    mkdirSync(path.join(nodePtyPath, 'prebuilds', `linux-${architecture}`), { recursive: true });
+    mkdirSync(path.dirname(bridgePath), { recursive: true });
+    writeFileSync(bridgePath, '#!/bin/sh\nexit 0\n');
+    writeFileSync(path.join(nodePtyPath, 'lib', 'index.js'), 'export {};\n');
+    const prebuildPath = path.join(nodePtyPath, 'prebuilds', `linux-${architecture}`, 'pty.node');
+    writeFileSync(prebuildPath, 'native-payload\n');
+    writeFileSync(path.join(nodePtyPath, 'package.json'), '{"name":"node-pty"}\n');
+    writeFileSync(path.join(nodePtyPath, 'LICENSE'), 'MIT\n');
+    chmodSync(bridgePath, 0o755);
+    chmodSync(prebuildPath, 0o755);
+
+    // When: the production packager builds a real native-architecture RPM.
+    const rpmPath = await packageVisBridgeInstaller(root, {
+      version: 'v1.2.3',
+      platform: 'linux',
+      arch: architecture,
+      format: 'rpm',
+    });
+
+    // Then: rpm tooling observes the public package contract and extracted bytes.
+    expect(path.basename(rpmPath)).toBe(`VisBridge-1.2.3-${architecture}-Linux.rpm`);
+    expect(
+      execFileSync('rpm', ['-qp', '--qf', '%{NAME} %{VERSION} %{ARCH}', rpmPath], {
+        encoding: 'utf8',
+      }),
+    ).toBe(`vis-bridge 1.2.3 ${rpmArchitecture}`);
+    const files = execFileSync('rpm', ['-qpl', rpmPath], { encoding: 'utf8' });
+    expect(files).toContain('/usr/bin/vis_bridge');
+    expect(files).toContain(
+      `/usr/lib/vis_bridge/node_modules/node-pty/prebuilds/linux-${architecture}/pty.node`,
+    );
+    const scripts = execFileSync('rpm', ['-qp', '--scripts', rpmPath], { encoding: 'utf8' });
+    expect(scripts).toContain('preinstall scriptlet');
+    expect(scripts).toContain('preuninstall scriptlet');
+    expect(scripts).not.toContain('postuninstall scriptlet');
+
+    const extractionPath = path.join(root, 'extracted');
+    mkdirSync(extractionPath);
+    const archive = execFileSync('rpm2cpio', [rpmPath]);
+    execFileSync('cpio', ['-idmu'], {
+      cwd: extractionPath,
+      input: archive,
+      stdio: ['pipe', 'ignore', 'pipe'],
+    });
+    const extractedBridge = path.join(extractionPath, 'usr', 'bin', 'vis_bridge');
+    const extractedPrebuild = path.join(
+      extractionPath,
+      'usr',
+      'lib',
+      'vis_bridge',
+      'node_modules',
+      'node-pty',
+      'prebuilds',
+      `linux-${architecture}`,
+      'pty.node',
+    );
+    expect(readFileSync(extractedBridge, 'utf8')).toBe('#!/bin/sh\nexit 0\n');
+    expect(readFileSync(extractedPrebuild, 'utf8')).toBe('native-payload\n');
+    expect(statSync(extractedBridge).mode & 0o777).toBe(0o755);
+    expect(statSync(extractedPrebuild).mode & 0o777).toBe(0o755);
+  });
+});

--- a/app/bridgeUpdateCli.test.ts
+++ b/app/bridgeUpdateCli.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+import { parseBridgeUpdateArgs, runBridgeUpdate } from '../bridge/updateCli.js';
+
+const RELEASE = {
+  version: '0.8.0',
+  assets: [{
+    name: 'VisBridge-0.8.0-x64-Linux.deb',
+    digest: `sha256:${'a'.repeat(64)}`,
+    size: 12,
+    url: 'https://api.github.com/repos/qiyuanhuakai/opencode-visualizer-cn/releases/assets/1',
+  }],
+};
+
+describe('vis_bridge terminal updater command', () => {
+  it.each(['update', 'upgrade'])('parses the %s alias and updater-only flags', (command) => {
+    expect(parseBridgeUpdateArgs([command, '--check', '-y'])).toEqual({
+      command: 'update', check: true, help: false, yes: true,
+    });
+    expect(parseBridgeUpdateArgs([command, '--help'])).toEqual({
+      command: 'update', check: false, help: true, yes: false,
+    });
+  });
+
+  it('rejects arbitrary updater options before any release request', () => {
+    expect(() => parseBridgeUpdateArgs(['update', '--version', '9.9.9']))
+      .toThrow('Unknown option');
+  });
+
+  it('checks live metadata without staging, prompting, probing ancestors, or handing off', async () => {
+    const dependencies = harness();
+
+    const result = await runBridgeUpdate(
+      { command: 'update', check: true, help: false, yes: false },
+      dependencies,
+    );
+
+    expect(result).toEqual({ kind: 'available', currentVersion: '0.7.13', latestVersion: '0.8.0' });
+    expect(dependencies.presentOffer).toHaveBeenCalledWith({
+      currentVersion: '0.7.13', latestVersion: '0.8.0', asset: RELEASE.assets[0],
+    });
+    expect(dependencies.assertInstallAllowed).not.toHaveBeenCalled();
+    expect(dependencies.transport.downloadAsset).not.toHaveBeenCalled();
+    expect(dependencies.handoff).not.toHaveBeenCalled();
+    expect(dependencies.transport.dispose).toHaveBeenCalledOnce();
+  });
+
+  it('prevents downgrades and exits without requiring --yes in a non-interactive client', async () => {
+    const dependencies = harness({ release: { ...RELEASE, version: '0.7.12' }, interactive: false });
+
+    await expect(runBridgeUpdate(
+      { command: 'update', check: false, help: false, yes: false }, dependencies,
+    )).resolves.toEqual({ kind: 'current', currentVersion: '0.7.13', latestVersion: '0.7.12' });
+
+    expect(dependencies.confirm).not.toHaveBeenCalled();
+    expect(dependencies.transport.downloadAsset).not.toHaveBeenCalled();
+  });
+
+  it('requires --yes for an available update in a non-interactive client before download', async () => {
+    const dependencies = harness({ interactive: false });
+
+    await expect(runBridgeUpdate(
+      { command: 'update', check: false, help: false, yes: false }, dependencies,
+    )).rejects.toThrow('--yes');
+
+    expect(dependencies.assertInstallAllowed).not.toHaveBeenCalled();
+    expect(dependencies.transport.downloadAsset).not.toHaveBeenCalled();
+  });
+
+  it('defaults interactive confirmation to No and warns that all clients and tasks are interrupted', async () => {
+    const dependencies = harness();
+    dependencies.confirm.mockImplementation(async () => {
+      expect(dependencies.presentOffer).toHaveBeenCalledWith({
+        currentVersion: '0.7.13', latestVersion: '0.8.0', asset: RELEASE.assets[0],
+      });
+      return false;
+    });
+
+    await expect(runBridgeUpdate(
+      { command: 'update', check: false, help: false, yes: false }, dependencies,
+    )).resolves.toMatchObject({ kind: 'cancelled' });
+
+    expect(dependencies.confirm).toHaveBeenCalledOnce();
+    expect(dependencies.transport.downloadAsset).not.toHaveBeenCalled();
+  });
+
+  it('checks managed-install and ancestor safety before staging a confirmed update', async () => {
+    const dependencies = harness();
+    dependencies.assertInstallAllowed.mockRejectedValue(new Error('unmanaged installation'));
+
+    await expect(runBridgeUpdate(
+      { command: 'update', check: false, help: false, yes: true }, dependencies,
+    )).rejects.toThrow('unmanaged installation');
+
+    expect(dependencies.transport.downloadAsset).not.toHaveBeenCalled();
+  });
+
+  it('verifies the selected artifact and reports handoff rather than claiming installation', async () => {
+    const dependencies = harness();
+    const resultLogPath = String.raw`C:\Users\me\AppData\Local\vis_bridge\updates\installer.log`;
+    dependencies.handoff.mockImplementation(async (request) => request.onAccepted?.(resultLogPath));
+
+    await expect(runBridgeUpdate(
+      { command: 'update', check: false, help: false, yes: true }, dependencies,
+    )).resolves.toMatchObject({ kind: 'handed-off', latestVersion: '0.8.0' });
+
+    expect(dependencies.transport.verifyAsset).toHaveBeenCalledWith(
+      '/private/staging/update.deb', RELEASE.assets[0], 'a'.repeat(64), 'sha256',
+    );
+    expect(dependencies.handoff).toHaveBeenCalledWith(expect.objectContaining({
+      assetPath: '/private/staging/update.deb', linuxFormat: 'deb', nonInteractiveYes: false,
+    }));
+    expect(dependencies.assertInstallAllowed).toHaveBeenCalledWith({
+      allowPrivilegedInspection: true,
+      nonInteractiveYes: false,
+    });
+    expect(dependencies.output).toHaveBeenLastCalledWith(expect.stringContaining(resultLogPath));
+  });
+});
+
+function harness(options: { release?: typeof RELEASE; interactive?: boolean } = {}) {
+  const release = options.release ?? RELEASE;
+  const transport = {
+    getLatestRelease: vi.fn(async () => release),
+    downloadAsset: vi.fn(async () => '/private/staging/update.deb'),
+    verifyAsset: vi.fn(async () => undefined),
+    dispose: vi.fn(),
+  };
+  return {
+    currentVersion: '0.7.13', platform: 'linux' as const, arch: 'x64' as const,
+    interactive: options.interactive ?? true,
+    output: vi.fn(), presentOffer: vi.fn(), confirm: vi.fn(async () => true),
+    assertInstallAllowed: vi.fn(async () => undefined),
+    resolveLinuxFormat: vi.fn(async () => 'deb' as const),
+    handoff: vi.fn(async (request: { onAccepted?: (resultLogPath?: string) => void }) => request.onAccepted?.()),
+    transport,
+  };
+}

--- a/app/bridgeUpdateCommand.test.ts
+++ b/app/bridgeUpdateCommand.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const temporaryDirectories: string[] = [];
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe('vis_bridge updater process boundary', () => {
+  it.each(['update', 'upgrade'])('prints isolated help for the %s alias without daemon configuration reads', (command) => {
+    const directory = mkdtempSync(path.join(tmpdir(), 'vis-bridge-update-help-'));
+    temporaryDirectories.push(directory);
+    const stateDirectory = path.join(directory, 'daemon-state');
+    const result = spawnSync(process.execPath, [path.resolve(import.meta.dirname, '../vis_bridge.js'), command, '--help'], {
+      encoding: 'utf8',
+      timeout: 5_000,
+      env: {
+        ...process.env,
+        VIS_BRIDGE_PORT: 'invalid',
+        VIS_BRIDGE_CODEX_TOKEN_FILE: '/nonexistent/secret',
+        VIS_BRIDGE_STATE_DIR: stateDirectory,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('vis_bridge update [--check] [--yes|-y]');
+    expect(existsSync(stateDirectory)).toBe(false);
+  });
+
+  it('rejects unsupported updater flags with a nonzero exit and no daemon startup', () => {
+    const result = spawnSync(process.execPath, [
+      path.resolve(import.meta.dirname, '../vis_bridge.js'), 'update', '--url', 'https://example.com',
+    ], { encoding: 'utf8', timeout: 5_000 });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toMatch(/Unknown option '--url'/u);
+  });
+});

--- a/app/bridgeUpdateHandoff.test.ts
+++ b/app/bridgeUpdateHandoff.test.ts
@@ -5,6 +5,7 @@ import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { text } from 'node:stream/consumers';
 import { setTimeout as delay } from 'node:timers/promises';
 import { pathToFileURL } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -18,6 +19,11 @@ import {
 
 const temporaryDirectories: string[] = [];
 const temporaryFiles: string[] = [];
+
+function esmImportSpecifier(filePath: string): string {
+  return pathToFileURL(filePath).href;
+}
+
 afterEach(async () => {
   await Promise.all([
     ...temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
@@ -93,13 +99,30 @@ describe('bridge updater installer handoff', () => {
     expect(accepted).toHaveBeenCalledWith(resultLogPath);
   });
 
+  it('converts Windows drive paths before embedding them in an ESM driver', async () => {
+    const windowsModulePath = String.raw`D:\ci\bridge\updateHandoff.js`;
+    const driverProcess = spawn(process.execPath, [
+      '--input-type=module',
+      '--eval',
+      `import(${JSON.stringify(windowsModulePath)})`,
+    ], { stdio: ['ignore', 'ignore', 'pipe'] });
+    const [[driverExit], driverStderr] = await Promise.all([
+      once(driverProcess, 'exit'),
+      text(driverProcess.stderr),
+    ]);
+
+    expect(driverExit, driverStderr).not.toBe(0);
+    expect(driverStderr).toContain('ERR_UNSUPPORTED_ESM_URL_SCHEME');
+    expect(new URL(esmImportSpecifier(windowsModulePath)).protocol).toBe('file:');
+  });
+
   it('keeps a separate Node protocol driver alive until acknowledgement arrives', async () => {
     const directory = await mkdtemp(path.join(tmpdir(), 'vis-bridge-ack-driver-'));
     temporaryDirectories.push(directory);
     const ackPath = path.join(directory, 'ready');
     const startedPath = path.join(directory, 'started');
     const resultPath = path.join(directory, 'accepted');
-    const moduleUrl = pathToFileURL(path.resolve(import.meta.dirname, '../bridge/updateHandoff.js')).href;
+    const moduleUrl = esmImportSpecifier(path.resolve(import.meta.dirname, '../bridge/updateHandoff.js'));
     const driver = `
       import { EventEmitter } from 'node:events';
       import { writeFile } from 'node:fs/promises';
@@ -173,18 +196,18 @@ C:\Users\me\AppData\Local\Temp\vis_bridge-updates\installer.log`);
   it.runIf(process.platform === 'win32').each([
     ['success', 0],
     ['failure', 7],
-  ])('writes a durable %s result through the real PowerShell helper protocol', async (expectedStatus, installerExit) => {
-    const directory = await mkdtemp(path.join(tmpdir(), 'vis-bridge-powershell-helper-'));
+  ])('writes a durable %s result through the real PowerShell helper protocol with shell-sensitive paths', async (expectedStatus, installerExit) => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'vis bridge & powershell (helper)-'));
     temporaryDirectories.push(directory);
     const stagingDirectory = path.join(directory, 'staging');
     const acceptedPath = path.join(directory, 'accepted-path');
     const helperPath = path.join(stagingDirectory, 'install.ps1');
     const ackPath = path.join(stagingDirectory, 'ready');
-    const installerPath = path.join(stagingDirectory, 'fake-installer.cmd');
+    const installerPath = path.join(stagingDirectory, 'fake installer & handoff.cmd');
     await mkdir(stagingDirectory);
     await writeFile(helperPath, createWindowsUpdateHelper());
     await writeFile(installerPath, `@exit /b ${installerExit}\r\n`);
-    const moduleUrl = pathToFileURL(path.resolve(import.meta.dirname, '../bridge/updateHandoff.js')).href;
+    const moduleUrl = esmImportSpecifier(path.resolve(import.meta.dirname, '../bridge/updateHandoff.js'));
     const powershellPath = path.win32.join(process.env.SystemRoot ?? String.raw`C:\Windows`, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
     const driver = `
       import { spawn } from 'node:child_process';
@@ -198,9 +221,14 @@ C:\Users\me\AppData\Local\Temp\vis_bridge-updates\installer.log`);
         onAccepted: (resultLogPath) => writeFileSync(${JSON.stringify(acceptedPath)}, resultLogPath),
       });
     `;
-    const driverProcess = spawn(process.execPath, ['--input-type=module', '--eval', driver], { stdio: 'ignore' });
-    const [driverExit] = await once(driverProcess, 'exit');
-    expect(driverExit).toBe(0);
+    const driverProcess = spawn(process.execPath, ['--input-type=module', '--eval', driver], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    const [[driverExit, driverSignal], driverStderr] = await Promise.all([
+      once(driverProcess, 'exit'),
+      text(driverProcess.stderr),
+    ]);
+    expect(driverExit, `driver exited with code ${driverExit}, signal ${driverSignal}; stderr:\n${driverStderr}`).toBe(0);
     const resultLogPath = await readFile(acceptedPath, 'utf8');
     temporaryFiles.push(resultLogPath);
     await vi.waitFor(() => expect(existsSync(resultLogPath)).toBe(true), { timeout: 10_000 });

--- a/app/bridgeUpdateHandoff.test.ts
+++ b/app/bridgeUpdateHandoff.test.ts
@@ -1,0 +1,211 @@
+// @vitest-environment node
+import { ChildProcess, spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { pathToFileURL } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createPosixUpdateHelper,
+  createWindowsUpdateHelper,
+  handoffPosixInstaller,
+  handoffWindowsInstaller,
+  waitForAck,
+} from '../bridge/updateHandoff.js';
+
+const temporaryDirectories: string[] = [];
+const temporaryFiles: string[] = [];
+afterEach(async () => {
+  await Promise.all([
+    ...temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+    ...temporaryFiles.splice(0).map((file) => rm(file, { force: true })),
+  ]);
+});
+
+describe('bridge updater installer handoff', () => {
+  it('refuses POSIX installation when execve is unavailable instead of spawning a child', async () => {
+    await expect(handoffPosixInstaller({
+      assetPath: '/private/staging/update.deb', platform: 'linux', linuxFormat: 'deb',
+      nonInteractiveYes: false, uid: 1000, execve: null,
+      writeHelper: vi.fn(async () => '/private/staging/install.sh'),
+    })).rejects.toThrow('process.execve is unavailable');
+  });
+
+  it('exec-replaces the updater on POSIX and never falls back to a killable child process', async () => {
+    const execve = vi.fn();
+    const helperPath = '/private/staging/install.sh';
+    await handoffPosixInstaller({
+      assetPath: '/private/staging/update.deb', platform: 'linux', linuxFormat: 'deb',
+      nonInteractiveYes: true, uid: 1000, execve,
+      writeHelper: vi.fn(async () => helperPath),
+    });
+
+    expect(execve).toHaveBeenCalledWith('/bin/sh', [
+      '/bin/sh', helperPath, '/private/staging/update.deb', 'sudo-noninteractive',
+    ], expect.any(Object));
+  });
+
+  it('uses only fixed absolute installer commands and cleans staging after the POSIX result', () => {
+    const deb = createPosixUpdateHelper('linux', 'deb');
+    const rpm = createPosixUpdateHelper('linux', 'rpm');
+    const mac = createPosixUpdateHelper('darwin', null);
+    expect(deb).toContain('/usr/bin/dpkg -i -- "$installer"');
+    expect(rpm).toContain('/usr/bin/rpm -U -- "$installer"');
+    expect(mac).toContain('/usr/sbin/installer -pkg "$installer" -target /');
+    expect(deb).toContain('/bin/rm -rf -- "$staging_dir"');
+    expect(deb).not.toContain('eval');
+  });
+
+  it('makes the Windows helper open and await the parent process handle before NSIS /S', () => {
+    const helper = createWindowsUpdateHelper();
+    expect(helper).toContain('OpenProcess');
+    expect(helper).toContain('WaitForSingleObject');
+    expect(helper).toContain("[IO.File]::WriteAllText($AckPath, ('ready' + [Environment]::NewLine + $resultLogPath))");
+    expect(helper.indexOf('WaitForSingleObject')).toBeLessThan(helper.indexOf("ArgumentList '/S'"));
+    expect(helper).toContain("[IO.File]::WriteAllText($resultLogPath, ('status=success'");
+    expect(helper).toContain("[IO.File]::WriteAllText($resultLogPath, ('status=failure'");
+    expect(helper.indexOf('$resultLogPath')).toBeLessThan(helper.indexOf('Remove-Item -LiteralPath $StagingDirectory'));
+  });
+
+  it('waits for the Windows handle-ready acknowledgement before accepting handoff', async () => {
+    const child = new ChildProcess();
+    const resultLogPath = String.raw`C:\Users\me\AppData\Local\Temp\vis_bridge-updates\installer-42.log`;
+    const waitForAck = vi.fn(async () => resultLogPath);
+    const spawnProcess = vi.fn(() => child);
+    const accepted = vi.fn();
+
+    await handoffWindowsInstaller({
+      assetPath: String.raw`C:\private\update.exe`, parentPid: 42,
+      powershellPath: String.raw`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`,
+      spawnProcess, waitForAck, onAccepted: accepted,
+      writeHelper: vi.fn(async () => ({
+        helperPath: String.raw`C:\private\install.ps1`, ackPath: String.raw`C:\private\ready`,
+      })),
+    });
+
+    expect(waitForAck).toHaveBeenCalledWith(String.raw`C:\private\ready`, child);
+    expect(spawnProcess).toHaveBeenCalledWith(expect.stringContaining('System32'), expect.arrayContaining([
+      '-File', String.raw`C:\private\install.ps1`, '-ParentPid', '42',
+    ]), expect.objectContaining({ detached: true, stdio: 'ignore', windowsHide: true }));
+    expect(accepted).toHaveBeenCalledWith(resultLogPath);
+  });
+
+  it('keeps a separate Node protocol driver alive until acknowledgement arrives', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'vis-bridge-ack-driver-'));
+    temporaryDirectories.push(directory);
+    const ackPath = path.join(directory, 'ready');
+    const startedPath = path.join(directory, 'started');
+    const resultPath = path.join(directory, 'accepted');
+    const moduleUrl = pathToFileURL(path.resolve(import.meta.dirname, '../bridge/updateHandoff.js')).href;
+    const driver = `
+      import { EventEmitter } from 'node:events';
+      import { writeFile } from 'node:fs/promises';
+      import { waitForAck } from ${JSON.stringify(moduleUrl)};
+      await writeFile(${JSON.stringify(startedPath)}, 'started');
+      const helper = new EventEmitter();
+      helper.pid = undefined;
+      helper.kill = () => false;
+      helper.unref = () => undefined;
+      waitForAck(${JSON.stringify(ackPath)}, helper, { timeoutMs: 1000, pollIntervalMs: 10 })
+        .then(() => writeFile(${JSON.stringify(resultPath)}, 'accepted'));
+    `;
+    const driverProcess = spawn(process.execPath, ['--input-type=module', '--eval', driver], {
+      stdio: 'ignore',
+    });
+    const exitPromise = once(driverProcess, 'exit');
+    await vi.waitFor(() => expect(existsSync(startedPath)).toBe(true));
+
+    const exitedBeforeAck = await Promise.race([
+      exitPromise.then(() => true),
+      delay(100, false),
+    ]);
+    if (!exitedBeforeAck) await writeFile(ackPath, String.raw`ready
+C:\Users\me\AppData\Local\Temp\vis_bridge-updates\installer.log`);
+    if (!exitedBeforeAck) await exitPromise;
+
+    expect(exitedBeforeAck).toBe(false);
+    expect(await readFile(resultPath, 'utf8')).toBe('accepted');
+  }, 7_000);
+
+  it('rejects a readable malformed acknowledgement within the configured deadline', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'vis-bridge-malformed-ack-'));
+    temporaryDirectories.push(directory);
+    const ackPath = path.join(directory, 'ready');
+    await writeFile(ackPath, 'not-ready');
+    const helper = spawn(process.execPath, ['--eval', 'setInterval(() => undefined, 1_000)'], {
+      stdio: 'ignore',
+    });
+    const helperExit = once(helper, 'exit');
+    const pending = waitForAck(ackPath, helper, { timeoutMs: 50, pollIntervalMs: 5 });
+
+    const outcome = await Promise.race([
+      pending.then(() => 'resolved', () => 'rejected'),
+      delay(150, 'still-pending'),
+    ]);
+    if (outcome === 'still-pending') helper.kill();
+    await helperExit;
+    await pending.catch(() => undefined);
+
+    expect(outcome).toBe('rejected');
+    expect(helper.killed).toBe(true);
+  });
+
+  it('does not schedule another acknowledgement poll after the helper settles', async () => {
+    const helper = new ChildProcess();
+    let completeRead: ((value: string) => void) | undefined;
+    const readAck = vi.fn(() => new Promise<string>((resolve) => { completeRead = resolve; }));
+    const schedule = vi.fn(() => setTimeout(() => undefined, 1_000));
+    const pending = waitForAck('/unused', helper, { readAck, schedule, timeoutMs: 1_000 });
+    await vi.waitFor(() => expect(readAck).toHaveBeenCalledOnce());
+    expect(schedule).toHaveBeenCalledOnce();
+
+    helper.emit('exit', 1);
+    await expect(pending).rejects.toThrow('before readiness');
+    completeRead?.('not-ready');
+    await Promise.resolve();
+
+    expect(schedule).toHaveBeenCalledOnce();
+  });
+
+  it.runIf(process.platform === 'win32').each([
+    ['success', 0],
+    ['failure', 7],
+  ])('writes a durable %s result through the real PowerShell helper protocol', async (expectedStatus, installerExit) => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'vis-bridge-powershell-helper-'));
+    temporaryDirectories.push(directory);
+    const stagingDirectory = path.join(directory, 'staging');
+    const acceptedPath = path.join(directory, 'accepted-path');
+    const helperPath = path.join(stagingDirectory, 'install.ps1');
+    const ackPath = path.join(stagingDirectory, 'ready');
+    const installerPath = path.join(stagingDirectory, 'fake-installer.cmd');
+    await mkdir(stagingDirectory);
+    await writeFile(helperPath, createWindowsUpdateHelper());
+    await writeFile(installerPath, `@exit /b ${installerExit}\r\n`);
+    const moduleUrl = pathToFileURL(path.resolve(import.meta.dirname, '../bridge/updateHandoff.js')).href;
+    const powershellPath = path.win32.join(process.env.SystemRoot ?? String.raw`C:\Windows`, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+    const driver = `
+      import { spawn } from 'node:child_process';
+      import { writeFileSync } from 'node:fs';
+      import { handoffWindowsInstaller, waitForAck } from ${JSON.stringify(moduleUrl)};
+      await handoffWindowsInstaller({
+        assetPath: ${JSON.stringify(installerPath)}, parentPid: process.pid,
+        powershellPath: ${JSON.stringify(powershellPath)},
+        spawnProcess: spawn, waitForAck,
+        writeHelper: async () => ({ helperPath: ${JSON.stringify(helperPath)}, ackPath: ${JSON.stringify(ackPath)} }),
+        onAccepted: (resultLogPath) => writeFileSync(${JSON.stringify(acceptedPath)}, resultLogPath),
+      });
+    `;
+    const driverProcess = spawn(process.execPath, ['--input-type=module', '--eval', driver], { stdio: 'ignore' });
+    const [driverExit] = await once(driverProcess, 'exit');
+    expect(driverExit).toBe(0);
+    const resultLogPath = await readFile(acceptedPath, 'utf8');
+    temporaryFiles.push(resultLogPath);
+    await vi.waitFor(() => expect(existsSync(resultLogPath)).toBe(true), { timeout: 10_000 });
+
+    expect(await readFile(resultLogPath, 'utf8')).toContain(`status=${expectedStatus}`);
+    expect(existsSync(stagingDirectory)).toBe(false);
+  }, 20_000);
+});

--- a/app/bridgeUpdateHandoff.test.ts
+++ b/app/bridgeUpdateHandoff.test.ts
@@ -11,6 +11,7 @@ import { pathToFileURL } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createPosixUpdateHelper,
+  createWindowsUpdateBootstrap,
   createWindowsUpdateHelper,
   handoffPosixInstaller,
   handoffWindowsInstaller,
@@ -69,6 +70,7 @@ describe('bridge updater installer handoff', () => {
     const helper = createWindowsUpdateHelper();
     expect(helper).toContain('OpenProcess');
     expect(helper).toContain('WaitForSingleObject');
+    expect(helper).toContain('WaitForSingleObject($parentHandle, [uint32]::MaxValue)');
     expect(helper).toContain("[IO.File]::WriteAllText($AckPath, ('ready' + [Environment]::NewLine + $resultLogPath))");
     expect(helper.indexOf('WaitForSingleObject')).toBeLessThan(helper.indexOf("ArgumentList '/S'"));
     expect(helper).toContain("[IO.File]::WriteAllText($resultLogPath, ('status=success'");
@@ -76,8 +78,26 @@ describe('bridge updater installer handoff', () => {
     expect(helper.indexOf('$resultLogPath')).toBeLessThan(helper.indexOf('Remove-Item -LiteralPath $StagingDirectory'));
   });
 
+  it('encodes a hidden PowerShell bootstrap that waits for the real helper process', () => {
+    const command = createWindowsUpdateBootstrap({
+      powershellPath: String.raw`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`,
+      helperPath: String.raw`C:\private & staging\install helper.ps1`,
+      parentPid: 42,
+      ackPath: String.raw`C:\private & staging\ready`,
+      installerPath: String.raw`C:\private & staging\update package.exe`,
+      stagingDirectory: String.raw`C:\private & staging`,
+    });
+    const bootstrap = Buffer.from(command, 'base64').toString('utf16le');
+
+    expect(bootstrap).toContain('Start-Process');
+    expect(bootstrap).toContain('-WindowStyle Hidden');
+    expect(bootstrap).toContain('$helper.WaitForExit()');
+    expect(bootstrap).not.toContain(String.raw`C:\private & staging`);
+  });
+
   it('waits for the Windows handle-ready acknowledgement before accepting handoff', async () => {
     const child = new ChildProcess();
+    const unref = vi.spyOn(child, 'unref');
     const resultLogPath = String.raw`C:\Users\me\AppData\Local\Temp\vis_bridge-updates\installer-42.log`;
     const waitForAck = vi.fn(async () => resultLogPath);
     const spawnProcess = vi.fn(() => child);
@@ -94,8 +114,9 @@ describe('bridge updater installer handoff', () => {
 
     expect(waitForAck).toHaveBeenCalledWith(String.raw`C:\private\ready`, child);
     expect(spawnProcess).toHaveBeenCalledWith(expect.stringContaining('System32'), expect.arrayContaining([
-      '-File', String.raw`C:\private\install.ps1`, '-ParentPid', '42',
-    ]), expect.objectContaining({ detached: true, stdio: 'ignore', windowsHide: true }));
+      '-EncodedCommand', expect.any(String),
+    ]), expect.objectContaining({ detached: false, stdio: 'ignore', windowsHide: true }));
+    expect(unref).toHaveBeenCalledOnce();
     expect(accepted).toHaveBeenCalledWith(resultLogPath);
   });
 

--- a/app/bridgeUpdatePlatform.test.ts
+++ b/app/bridgeUpdatePlatform.test.ts
@@ -1,0 +1,171 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+import {
+  assertBridgeInstallAllowed,
+  assertManagedInstallation,
+  collectDarwinAncestors,
+  collectLinuxAncestors,
+  collectWindowsAncestors,
+  hasBridgeHostedAncestor,
+  readLinuxExecutableWithSudo,
+  selectLinuxPackageFormat,
+} from '../bridge/updatePlatform.js';
+
+describe('bridge updater platform admission', () => {
+  it('requires the updater to run from the platform-managed executable', () => {
+    expect(() => assertManagedInstallation('/tmp/vis_bridge', 'linux', {})).toThrow('installed');
+    expect(() => assertManagedInstallation('/usr/bin/vis_bridge', 'linux', {})).not.toThrow();
+    expect(() => assertManagedInstallation('/usr/local/bin/vis_bridge', 'darwin', {})).not.toThrow();
+    expect(() => assertManagedInstallation(
+      String.raw`C:\Users\me\AppData\Local\Programs\vis_bridge\VIS_BRIDGE.EXE`,
+      'win32', { LOCALAPPDATA: String.raw`C:\Users\me\AppData\Local` },
+    )).not.toThrow();
+  });
+
+  it('identifies an installed bridge executable anywhere in the ancestor chain', () => {
+    expect(hasBridgeHostedAncestor([
+      { pid: 20, executable: '/bin/bash' },
+      { pid: 10, executable: '/usr/bin/vis_bridge' },
+    ], '/usr/bin/vis_bridge', 'linux')).toBe(true);
+    expect(hasBridgeHostedAncestor([
+      { pid: 20, executable: '/bin/bash' },
+      { pid: 10, executable: '/usr/bin/node' },
+    ], '/usr/bin/vis_bridge', 'linux')).toBe(false);
+    expect(hasBridgeHostedAncestor([
+      { pid: 10, executable: 'vis_bridge' },
+    ], '/usr/local/bin/vis_bridge', 'darwin')).toBe(true);
+  });
+
+  it('refuses installation from a bridge-hosted terminal ancestor', async () => {
+    await expect(assertBridgeInstallAllowed({
+      platform: 'linux', execPath: '/usr/bin/vis_bridge', pid: 20,
+      collectAncestors: async () => [{ pid: 10, executable: '/usr/bin/vis_bridge' }],
+    })).rejects.toThrow('bridge-hosted terminal');
+  });
+
+  it('selects DEB or RPM only when ownership, distro family, and installed tooling agree', async () => {
+    const probe = vi.fn(async (command: string) => ({
+      '/usr/bin/dpkg-query': { code: 1, stdout: '' },
+      '/usr/bin/rpm': { code: 0, stdout: 'vis-bridge-0.7.13' },
+    }[command] ?? { code: 1, stdout: '' }));
+
+    await expect(selectLinuxPackageFormat({
+      osRelease: 'ID=fedora\nID_LIKE="rhel centos"\n',
+      installedPath: '/usr/bin/vis_bridge',
+      requireOwnership: true,
+      toolExists: (tool) => tool === '/usr/bin/rpm',
+      probe,
+    })).resolves.toBe('rpm');
+  });
+
+  it('fails closed when Linux package ownership evidence is ambiguous', async () => {
+    await expect(selectLinuxPackageFormat({
+      osRelease: 'ID=ubuntu\nID_LIKE=debian\n',
+      installedPath: '/usr/bin/vis_bridge',
+      requireOwnership: true,
+      toolExists: () => true,
+      probe: async () => ({ code: 0, stdout: 'owned' }),
+    })).rejects.toThrow('unambiguously');
+  });
+
+  it('fails closed when a live Linux ancestor executable cannot be inspected', async () => {
+    const permissionError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    await expect(collectLinuxAncestors(42, {
+      readFile: async () => '42 (node) S 1 0 0 0',
+      readlink: async () => { throw permissionError; },
+    })).rejects.toThrow('Unable to inspect live process ancestry');
+  });
+
+  it('tolerates a Linux ancestor that genuinely exits during inspection', async () => {
+    const goneError = Object.assign(new Error('gone'), { code: 'ENOENT' });
+    await expect(collectLinuxAncestors(42, {
+      readFile: async () => { throw goneError; },
+      readlink: async () => '/usr/bin/node',
+    })).resolves.toEqual([]);
+  });
+
+  it.each(['EACCES', 'EPERM'])('uses a privileged executable lookup only for %s and preserves process identity', async (code) => {
+    const permissionError = Object.assign(new Error('permission denied'), { code });
+    const privilegedReadlink = vi.fn(async () => '/init');
+    let statReads = 0;
+    await expect(collectLinuxAncestors(42, {
+      readFile: async () => {
+        statReads += 1;
+        return linuxProcessStat(42, 0, 100);
+      },
+      readlink: async () => { throw permissionError; },
+      privilegedReadlink,
+    })).resolves.toEqual([{ pid: 42, executable: '/init' }]);
+
+    expect(privilegedReadlink).toHaveBeenCalledWith(42);
+    expect(statReads).toBe(2);
+  });
+
+  it('does not escalate a non-permission Linux executable lookup failure', async () => {
+    const privilegedReadlink = vi.fn(async () => '/init');
+    await expect(collectLinuxAncestors(42, {
+      readFile: async () => linuxProcessStat(42, 0, 100),
+      readlink: async () => { throw Object.assign(new Error('I/O failure'), { code: 'EIO' }); },
+      privilegedReadlink,
+    })).rejects.toThrow('Unable to inspect live process ancestry');
+    expect(privilegedReadlink).not.toHaveBeenCalled();
+  });
+
+  it('rejects a reused PID after privileged Linux executable inspection', async () => {
+    const permissionError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    let statReads = 0;
+    await expect(collectLinuxAncestors(42, {
+      readFile: async () => linuxProcessStat(42, 0, statReads++ < 1 ? 100 : 101),
+      readlink: async () => { throw permissionError; },
+      privilegedReadlink: async () => '/init',
+    })).rejects.toThrow('changed during privileged inspection');
+  });
+
+  it.each([
+    [false, ['/usr/bin/readlink', '--', '/proc/42/exe']],
+    [true, ['-n', '/usr/bin/readlink', '--', '/proc/42/exe']],
+  ])('uses fixed sudo argv for privileged Linux identity lookup (noninteractive=%s)', async (nonInteractiveYes, expectedArgs) => {
+    const probe = vi.fn(async () => ({ code: 0, stdout: '/init\n' }));
+
+    await expect(readLinuxExecutableWithSudo(42, { nonInteractiveYes, probe })).resolves.toBe('/init');
+    expect(probe).toHaveBeenCalledWith('/usr/bin/sudo', expectedArgs);
+  });
+
+  it('fails closed when ps cannot inspect a live macOS ancestor', async () => {
+    await expect(collectDarwinAncestors(42, {
+      probe: async () => ({ code: 1, stdout: '' }),
+      isAlive: () => true,
+    })).rejects.toThrow('Unable to inspect live process ancestry');
+  });
+
+  it('tolerates a macOS ancestor that exits before ps observes it', async () => {
+    await expect(collectDarwinAncestors(42, {
+      probe: async () => ({ code: 1, stdout: '' }),
+      isAlive: () => false,
+    })).resolves.toEqual([]);
+  });
+
+  it('fails closed when PowerShell cannot inspect a live Windows ancestor', async () => {
+    await expect(collectWindowsAncestors(42, { SystemRoot: String.raw`C:\Windows` }, {
+      probe: async () => ({ code: 1, stdout: '' }),
+      isAlive: () => true,
+    })).rejects.toThrow('Unable to inspect live process ancestry');
+  });
+
+  it('uses the protected system PowerShell path instead of a caller-controlled environment path', async () => {
+    const probe = vi.fn(async () => ({ code: 1, stdout: '' }));
+    await collectWindowsAncestors(42, { SystemRoot: String.raw`C:\attacker` }, {
+      probe,
+      isAlive: () => false,
+    });
+
+    expect(probe).toHaveBeenCalledWith(
+      String.raw`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`,
+      expect.any(Array),
+    );
+  });
+});
+
+function linuxProcessStat(pid: number, parentPid: number, startTime: number): string {
+  return `${pid} (process) ${['S', String(parentPid), ...Array(17).fill('0'), String(startTime)].join(' ')}`;
+}

--- a/app/bridgeUpdaterTransaction.integration.test.ts
+++ b/app/bridgeUpdaterTransaction.integration.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment node
+import { execFileSync, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { buildVisBridgeBinary } from '../scripts/build-vis-bridge.mjs';
+import { packageVisBridgeInstaller } from '../scripts/package-vis-bridge-installer.mjs';
+
+const projectRoot = path.resolve(import.meta.dirname, '..');
+const nativeQaEnabled = process.env.VIS_BRIDGE_NATIVE_UPDATE_QA === '1'
+  && process.platform === 'linux'
+  && (process.arch === 'x64' || process.arch === 'arm64')
+  && existsSync('/usr/bin/docker')
+  && existsSync('/usr/bin/dpkg-deb');
+
+describe.runIf(nativeQaEnabled)('vis_bridge native updater transaction', () => {
+  it('upgrades an older SEA package while stopping its daemon tree without restart', async () => {
+    const fixtureRoot = mkdtempSync(path.join(tmpdir(), 'vis-bridge-native-update-'));
+    const containerName = `vis-bridge-updater-transaction-${process.pid}`;
+    try {
+      stageFixtureDependencies(fixtureRoot);
+      const oldInstaller = await buildFixtureInstaller(fixtureRoot, '0.7.12');
+      const newInstaller = await buildFixtureInstaller(fixtureRoot, '0.8.0');
+      const digest = createHash('sha256').update(readFileSync(newInstaller)).digest('hex');
+      const output = execFileSync('docker', [
+        'run', '--rm', '--init', '--name', containerName,
+        '--volume', `${fixtureRoot}:/fixtures:ro`,
+        'debian:bookworm-slim',
+        '/bin/bash', '-euxo', 'pipefail', '-c',
+        containerTransaction({
+          oldInstaller: `/fixtures/${path.relative(fixtureRoot, oldInstaller)}`,
+          newInstaller: `/fixtures/${path.relative(fixtureRoot, newInstaller)}`,
+          digest,
+        }),
+      ], { encoding: 'utf8', timeout: 220_000, maxBuffer: 4 * 1024 * 1024 });
+
+      for (const evidence of [
+        'OLD_VERSION=0.7.12',
+        'UNREADABLE_ROOT_ANCESTOR=1',
+        'HOSTED_REJECTED=1',
+        'NEW_VERSION=0.8.0',
+        'PACKAGE_VERSION=0.8.0',
+        'DAEMON_STOPPED=1',
+        'NO_RESTART=1',
+      ]) expect(output).toContain(evidence);
+    } finally {
+      spawnSync('docker', ['rm', '--force', containerName], { stdio: 'ignore' });
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  }, 280_000);
+});
+
+function stageFixtureDependencies(fixtureRoot: string): void {
+  const nodeModules = path.join(fixtureRoot, 'node_modules');
+  mkdirSync(nodeModules, { recursive: true });
+  symlinkSync(path.join(projectRoot, 'node_modules', 'node-pty'), path.join(nodeModules, 'node-pty'));
+  mkdirSync(path.join(fixtureRoot, 'bridge'), { recursive: true });
+}
+
+async function buildFixtureInstaller(fixtureRoot: string, version: string): Promise<string> {
+  writeFileSync(
+    path.join(fixtureRoot, 'bridge', 'binaryEntry.js'),
+    fixtureEntry(version),
+    'utf8',
+  );
+  await buildVisBridgeBinary(fixtureRoot);
+  return packageVisBridgeInstaller(fixtureRoot, {
+    version,
+    platform: 'linux',
+    arch: process.arch,
+    format: 'deb',
+  });
+}
+
+function fixtureEntry(version: string): string {
+  const updateCliPath = path.join(projectRoot, 'bridge', 'updateCli.js');
+  const transportPath = path.join(projectRoot, 'electron', 'updateTransport.js');
+  return `
+import { spawn, spawnSync } from 'node:child_process';
+import { chmod, copyFile, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { runBridgeUpdate } from ${JSON.stringify(updateCliPath)};
+import { verifyAsset } from ${JSON.stringify(transportPath)};
+const version = ${JSON.stringify(version)};
+async function main() {
+  const [command] = process.argv.slice(2);
+  if (command === '--version') return process.stdout.write(version + '\\n');
+  if (command === 'child') return setInterval(() => undefined, 1000);
+  if (command === 'daemon') {
+    const child = spawn(process.execPath, ['child'], { stdio: 'ignore' });
+    await writeFile(process.argv[3], process.pid + ' ' + child.pid + '\\n');
+    return setInterval(() => undefined, 1000);
+  }
+  if (command === 'hosted-update') {
+    const child = spawnSync(process.execPath, ['update', '--yes'], { env: process.env, stdio: 'inherit' });
+    process.exitCode = child.status ?? 1;
+    return;
+  }
+  if (command !== 'update') throw new Error('Unknown fixture command.');
+  const assetPath = process.env.VIS_BRIDGE_FIXTURE_ASSET;
+  const digest = process.env.VIS_BRIDGE_FIXTURE_SHA256;
+  if (!assetPath || !digest) throw new Error('Missing fixture release metadata.');
+  const assetStat = await stat(assetPath);
+  const asset = {
+    name: path.basename(assetPath),
+    size: assetStat.size,
+    digest: 'sha256:' + digest,
+    url: 'https://api.github.com/repos/qiyuanhuakai/opencode-visualizer-cn/releases/assets/1',
+  };
+  const transport = {
+    getLatestRelease: async () => ({ version: '0.8.0', tag: 'v0.8.0', assets: [asset] }),
+    downloadAsset: async () => {
+      const directory = await mkdtemp('/tmp/vis-update-');
+      await chmod(directory, 0o700);
+      const destination = path.join(directory, asset.name);
+      await copyFile(assetPath, destination);
+      await chmod(destination, 0o600);
+      return destination;
+    },
+    verifyAsset,
+    removeFile: async (filePath) => rm(path.dirname(filePath), { recursive: true, force: true }),
+    dispose: () => undefined,
+  };
+  await runBridgeUpdate({ check: false, yes: true }, { currentVersion: version, transport });
+}
+void main().catch((error) => {
+  process.stderr.write((error instanceof Error ? error.message : String(error)) + '\\n');
+  process.exitCode = 1;
+});
+`;
+}
+
+function containerTransaction(paths: {
+  oldInstaller: string;
+  newInstaller: string;
+  digest: string;
+}): string {
+  return `
+apt-get update >/dev/null
+apt-get install -y --no-install-recommends procps sudo >/dev/null
+useradd --create-home updater
+printf 'updater ALL=(root) NOPASSWD: /usr/bin/readlink, /usr/bin/dpkg\\n' >/etc/sudoers.d/updater
+chmod 0440 /etc/sudoers.d/updater
+dpkg -i ${paths.oldInstaller} >/dev/null
+printf 'OLD_VERSION=%s\\n' "$(/usr/bin/vis_bridge --version)"
+if runuser -u updater -- /usr/bin/readlink -- /proc/$$/exe >/dev/null 2>&1; then exit 20; fi
+printf 'UNREADABLE_ROOT_ANCESTOR=1\\n'
+export VIS_BRIDGE_FIXTURE_ASSET=${paths.newInstaller}
+export VIS_BRIDGE_FIXTURE_SHA256=${paths.digest}
+if runuser -u updater --preserve-environment -- /usr/bin/vis_bridge hosted-update >/tmp/hosted.log 2>&1; then exit 21; fi
+test "$(/usr/bin/vis_bridge --version)" = '0.7.12'
+printf 'HOSTED_REJECTED=1\\n'
+runuser -u updater -- /usr/bin/vis_bridge daemon /tmp/daemon-pids >/tmp/daemon.log 2>&1 &
+launcher=$!
+for attempt in $(seq 1 100); do test -s /tmp/daemon-pids && break; sleep 0.05; done
+test -s /tmp/daemon-pids
+runuser -u updater --preserve-environment -- /usr/bin/vis_bridge update --yes >/tmp/update.log 2>&1
+read -r daemon_pid child_pid </tmp/daemon-pids
+for attempt in $(seq 1 100); do
+  test ! -e "/proc/$daemon_pid/exe" && test ! -e "/proc/$child_pid/exe" && break
+  sleep 0.05
+done
+test ! -e "/proc/$daemon_pid/exe"
+test ! -e "/proc/$child_pid/exe"
+kill "$launcher" 2>/dev/null || true
+wait "$launcher" || true
+printf 'DAEMON_STOPPED=1\\n'
+printf 'NEW_VERSION=%s\\n' "$(/usr/bin/vis_bridge --version)"
+printf 'PACKAGE_VERSION=%s\\n' "$(dpkg-query -W -f='\${Version}' vis-bridge)"
+for executable in /proc/[0-9]*/exe; do
+  test "$(readlink "$executable" 2>/dev/null || true)" != '/usr/bin/vis_bridge'
+done
+printf 'NO_RESTART=1\\n'
+! compgen -G '/tmp/vis-update-*' >/dev/null
+cat /tmp/update.log
+`;
+}

--- a/app/bridgeUpdaterTransaction.integration.test.ts
+++ b/app/bridgeUpdaterTransaction.integration.test.ts
@@ -2,6 +2,7 @@
 import { execFileSync, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -32,6 +33,7 @@ describe.runIf(nativeQaEnabled)('vis_bridge native updater transaction', () => {
       stageFixtureDependencies(fixtureRoot);
       const oldInstaller = await buildFixtureInstaller(fixtureRoot, '0.7.12');
       const newInstaller = await buildFixtureInstaller(fixtureRoot, '0.8.0');
+      chmodSync(fixtureRoot, 0o755);
       const digest = createHash('sha256').update(readFileSync(newInstaller)).digest('hex');
       const output = execFileSync('docker', [
         'run', '--rm', '--init', '--name', containerName,
@@ -47,6 +49,7 @@ describe.runIf(nativeQaEnabled)('vis_bridge native updater transaction', () => {
 
       for (const evidence of [
         'OLD_VERSION=0.7.12',
+        'UID_MISMATCH=1',
         'UNREADABLE_ROOT_ANCESTOR=1',
         'HOSTED_REJECTED=1',
         'NEW_VERSION=0.8.0',
@@ -147,9 +150,27 @@ function containerTransaction(paths: {
   digest: string;
 }): string {
   return `
+dump_logs() {
+  status=$?
+  trap - EXIT
+  if test "$status" -ne 0; then
+    for log in /tmp/hosted.log /tmp/daemon.log /tmp/update.log; do
+      if test -f "$log"; then
+        printf '\\n=== %s ===\\n' "$log" >&2
+        cat "$log" >&2 || true
+      fi
+    done
+  fi
+  exit "$status"
+}
+trap dump_logs EXIT
 apt-get update >/dev/null
 apt-get install -y --no-install-recommends procps sudo >/dev/null
-useradd --create-home updater
+fixture_uid=$(stat -c %u /fixtures)
+if test "$fixture_uid" = '1000'; then updater_uid=1001; else updater_uid=1000; fi
+useradd --uid "$updater_uid" --create-home updater
+test "$fixture_uid" != "$updater_uid"
+printf 'UID_MISMATCH=1\n'
 printf 'updater ALL=(root) NOPASSWD: /usr/bin/readlink, /usr/bin/dpkg\\n' >/etc/sudoers.d/updater
 chmod 0440 /etc/sudoers.d/updater
 dpkg -i ${paths.oldInstaller} >/dev/null

--- a/app/ciWorkflow.test.ts
+++ b/app/ciWorkflow.test.ts
@@ -152,14 +152,35 @@ describe('complete CI workflow', () => {
   });
 
   it('publishes only native bridge installers with VIS releases', () => {
+    const bridgeJob = workflow.slice(
+      workflow.indexOf('\n  bridge-installers:'),
+      workflow.indexOf('\n  complete-ci:'),
+    );
+    const buildIndex = bridgeJob.indexOf('run: pnpm bridge:build');
+    const rpmPackageIndex = bridgeJob.indexOf(
+      'run: pnpm bridge:package-installer -- --format rpm',
+    );
+    const rpmLifecycleIndex = bridgeJob.indexOf(
+      'bash scripts/qa/vis-bridge-rpm-lifecycle.sh',
+    );
+
     expect(workflow).toContain('run: pnpm bridge:package-installer');
+    expect(workflow).toContain('run: pnpm bridge:package-installer -- --format rpm');
+    expect(workflow).toContain('run: pnpm vitest run bridgeInstallerRpm.integration.test.ts');
+    expect(workflow).toContain('sudo apt-get install -y cpio rpm');
+    expect(workflow).toContain('bash scripts/qa/vis-bridge-rpm-lifecycle.sh');
     expect(workflow).toContain('dist-bridge/installers/*.deb');
+    expect(workflow).toContain('dist-bridge/installers/*.rpm');
     expect(workflow).toContain('dist-bridge/installers/*.pkg');
     expect(workflow).toContain('dist-bridge/installers/*.exe');
     expect(workflow).not.toContain('dist-bridge/vis_bridge*');
     expect(workflow).toContain('runner: ubuntu-24.04-arm');
     expect(workflow).toContain('runner: windows-11-arm');
     expect(workflow).toContain('runner: macos-15-intel');
+    expect(workflow).toContain('artifacts/**/*.rpm');
+    expect(buildIndex).toBeGreaterThanOrEqual(0);
+    expect(rpmPackageIndex).toBeGreaterThan(buildIndex);
+    expect(rpmLifecycleIndex).toBeGreaterThan(rpmPackageIndex);
   });
 
   it('exercises each native bridge installer through the installed PATH command', () => {
@@ -167,6 +188,9 @@ describe('complete CI workflow', () => {
     expect(workflow).toContain('name: Exercise macOS installer');
     expect(workflow).toContain('name: Exercise Windows installer');
     expect(workflow).toContain('vis_bridge --help');
+    expect(workflow).toContain('rpm -qpl');
+    expect(workflow).toContain('rpm -qp --scripts');
+    expect(workflow).toContain('rpm2cpio');
   });
 
   it('builds the electron app on five native architecture lanes, one per platform/arch pair', () => {

--- a/app/desktopUpdateLifecycle.test.ts
+++ b/app/desktopUpdateLifecycle.test.ts
@@ -358,6 +358,30 @@ describe('desktop update lifecycle', () => {
     expect(fixture.service.getState().bridge.phase).toBe('unsupported');
   });
 
+  it('does not offer a local installer when package detection completes after the bridge becomes remote', async () => {
+    // Given: Linux package detection is still pending during a local bridge check.
+    const fixture = createFixture();
+    const detection = deferred<'deb'>();
+    fixture.runtime.resolveBridgeLinuxFormat.mockReturnValueOnce(detection.promise);
+    const checking = fixture.service.check('bridge');
+    await vi.waitFor(() => expect(fixture.runtime.resolveBridgeLinuxFormat).toHaveBeenCalledOnce());
+
+    // When: the connection becomes remote before package detection finishes.
+    fixture.service.reportBridgeVersion({
+      connectionId: 'connection-1',
+      endpointLocality: 'remote',
+      version: '1.0.0',
+    });
+    detection.resolve('deb');
+    await checking;
+
+    // Then: stale local package metadata cannot replace the remote-only state.
+    expect(fixture.service.getState().bridge).toMatchObject({
+      installKind: 'remote',
+      assetName: null,
+    });
+  });
+
   it('drains a pending metadata auto-check after stale bridge work settles', async () => {
     const fixture = createFixture();
     const staleRelease = deferred<typeof RELEASE>();
@@ -434,6 +458,7 @@ function createFixture(options: { readonly automaticAppUpdates?: boolean } = {})
     updater,
     getLatestRelease: vi.fn(async () => RELEASE),
     getBridgeVersion: vi.fn(async () => '1.0.0'),
+    resolveBridgeLinuxFormat: vi.fn(async () => 'deb' as const),
     downloadAppUpdate: vi.fn(async () => [] as string[]),
     downloadAsset: vi.fn(
       async (_asset, _onProgress: (percent: number) => void) => '/private/update/bridge.deb',

--- a/app/desktopUpdateMetadata.test.ts
+++ b/app/desktopUpdateMetadata.test.ts
@@ -8,10 +8,53 @@ const workflow = readFileSync(path.join(root, '.github/workflows/build-electron.
 const packageJson = JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf8')) as {
   dependencies?: Record<string, string>;
 };
+const localImportPattern =
+  /^\s*(?:import|export)\s+(?:[^'"]+\s+from\s+)?['"](\.[^'"]+)['"];?\s*$/gmu;
+
+function localModuleClosure(entryPath: string) {
+  const pending = [entryPath];
+  const closure = new Set<string>();
+  while (pending.length > 0) {
+    const modulePath = pending.pop();
+    if (!modulePath || closure.has(modulePath)) continue;
+    closure.add(modulePath);
+    const source = readFileSync(path.join(root, modulePath), 'utf8');
+    for (const match of source.matchAll(localImportPattern)) {
+      const specifier = match[1];
+      if (!specifier) continue;
+      const resolved = path.posix.normalize(
+        path.posix.join(path.posix.dirname(modulePath), specifier),
+      );
+      pending.push(path.posix.extname(resolved) ? resolved : `${resolved}.js`);
+    }
+  }
+  return [...closure];
+}
+
+function packagedByBuilder(modulePath: string) {
+  const filePatterns = builder
+    .slice(builder.indexOf('files:'), builder.indexOf('\nasar:'))
+    .matchAll(/^\s*-\s*["']([^"']+)["']\s*$/gmu);
+  return [...filePatterns].some(([, pattern]) => {
+    if (!pattern || pattern.startsWith('!')) return false;
+    if (pattern.endsWith('/**/*')) return modulePath.startsWith(pattern.slice(0, -4));
+    if (pattern.endsWith('*.js')) {
+      return modulePath.startsWith(pattern.slice(0, -4)) && modulePath.endsWith('.js');
+    }
+    return modulePath === pattern;
+  });
+}
 
 describe('desktop update metadata pipeline', () => {
   it('does not exclude production modules needed by the packaged main process', () => {
     expect(builder).not.toMatch(/^\s*-\s*["']?!node_modules(?:\/\*\*\/\*)?["']?\s*$/mu);
+  });
+
+  it('packages the local module closure of the Electron entry point', () => {
+    const unpackagedModules = localModuleClosure('electron/main.js').filter(
+      (modulePath) => !packagedByBuilder(modulePath),
+    );
+    expect(unpackagedModules).toEqual([]);
   });
   it('keeps the updater at runtime and pins the official GitHub provider', () => {
     // Given the packaged main process needs electron-updater at runtime
@@ -41,7 +84,7 @@ describe('desktop update metadata pipeline', () => {
     expect(workflow).toContain('artifacts/**/*.yml');
     expect(workflow).toContain('artifacts/**/*.blockmap');
     expect(workflow).toContain("Test-Path 'dist-electron/latest.yml'");
-    expect(workflow).toContain("test -f dist-electron/latest-linux.yml");
+    expect(workflow).toContain('test -f dist-electron/latest-linux.yml');
     expect(windowsJobs).toContain('dist-electron/*.blockmap');
     expect(linuxJob).not.toContain('dist-electron/*.blockmap');
   });

--- a/app/desktopUpdatePolicy.test.ts
+++ b/app/desktopUpdatePolicy.test.ts
@@ -3,6 +3,7 @@ import {
   automaticAppUpdateSupported,
   parseStableRelease,
   selectAutomaticAppFile,
+  selectBridgeAsset,
   selectManualAsset,
   sha256FromDigest,
 } from '../electron/updatePolicy.js';
@@ -26,6 +27,27 @@ describe('desktop update release policy', () => {
 
     // Then: selection is an exact filename match rather than a fuzzy platform match.
     expect(selected.name).toBe('VisBridge-1.2.3-x64-Linux.deb');
+  });
+
+  it('selects the requested Linux bridge package while retaining the DEB default', () => {
+    // Given: the release ships both supported Linux package formats.
+    const release = parseStableRelease({
+      tag_name: 'v1.2.3',
+      draft: false,
+      prerelease: false,
+      assets: [asset('VisBridge-1.2.3-x64-Linux.deb'), asset('VisBridge-1.2.3-x64-Linux.rpm')],
+    });
+
+    // When/Then: callers can request RPM while an omitted format still selects DEB.
+    expect(selectBridgeAsset(release, 'linux', 'x64', 'rpm').name).toBe(
+      'VisBridge-1.2.3-x64-Linux.rpm',
+    );
+    expect(selectManualAsset(release, 'bridge', 'linux', 'x64', 'rpm').name).toBe(
+      'VisBridge-1.2.3-x64-Linux.rpm',
+    );
+    expect(selectManualAsset(release, 'bridge', 'linux', 'x64').name).toBe(
+      'VisBridge-1.2.3-x64-Linux.deb',
+    );
   });
 
   it('rejects draft and prerelease responses even when the endpoint returns them', () => {
@@ -60,7 +82,9 @@ describe('desktop update release policy', () => {
       tag_name: 'v1.2.3',
       draft: false,
       prerelease: false,
-      assets: [{ ...asset('VisBridge-1.2.3-x64-Linux.deb'), url: `${asset('unused').url}/payload` }],
+      assets: [
+        { ...asset('VisBridge-1.2.3-x64-Linux.deb'), url: `${asset('unused').url}/payload` },
+      ],
     };
 
     // When/Then: the URL cannot escape the exact repository asset endpoint shape.
@@ -72,7 +96,9 @@ describe('desktop update release policy', () => {
     const identities = [null, 'deb', 'rpm', 'pacman'] as const;
 
     // When: runtime capability is derived for the configured distribution targets.
-    const supported = identities.map((packageType) => automaticAppUpdateSupported('linux', false, packageType));
+    const supported = identities.map((packageType) =>
+      automaticAppUpdateSupported('linux', false, packageType),
+    );
 
     // Then: only the shipped DEB package is automatic without an AppImage identity.
     expect(supported).toEqual([false, true, false, false]);
@@ -87,16 +113,19 @@ describe('desktop update release policy', () => {
     ['linux', 'x64', 'deb', 'Vis-1.2.3-amd64-Linux.deb'],
     ['linux', 'arm64', 'appimage', 'Vis-1.2.3-arm64-Linux.AppImage'],
     ['linux', 'arm64', 'deb', 'Vis-1.2.3-arm64-Linux.deb'],
-  ] as const)('selects the generated automatic artifact for %s %s %s', (platform, arch, target, name) => {
-    // Given: updater metadata produced from the configured targets and artifactName templates.
-    const info = automaticInfo(platform === 'linux' ? linuxNames(arch) : [name]);
+  ] as const)(
+    'selects the generated automatic artifact for %s %s %s',
+    (platform, arch, target, name) => {
+      // Given: updater metadata produced from the configured targets and artifactName templates.
+      const info = automaticInfo(platform === 'linux' ? linuxNames(arch) : [name]);
 
-    // When: the offer crosses the app-update policy boundary.
-    const selected = selectAutomaticAppFile(info, platform, arch, target);
+      // When: the offer crosses the app-update policy boundary.
+      const selected = selectAutomaticAppFile(info, platform, arch, target);
 
-    // Then: the exact Vis installer and its integrity metadata are retained.
-    expect(selected).toEqual({ name, size: 12, sha512: `${'A'.repeat(86)}==`, url: name });
-  });
+      // Then: the exact Vis installer and its integrity metadata are retained.
+      expect(selected).toEqual({ name, size: 12, sha512: `${'A'.repeat(86)}==`, url: name });
+    },
+  );
 
   it.each([
     'VisBridge-1.2.3-x64-Windows.exe',
@@ -108,7 +137,9 @@ describe('desktop update release policy', () => {
     const info = automaticInfo([name]);
 
     // When/Then: Windows x64 selection rejects it instead of using a fuzzy Vis prefix.
-    expect(() => selectAutomaticAppFile(info, 'win32', 'x64', 'nsis')).toThrow(/automatic update artifact/iu);
+    expect(() => selectAutomaticAppFile(info, 'win32', 'x64', 'nsis')).toThrow(
+      /automatic update artifact/iu,
+    );
   });
 
   it('rejects prerelease versions and ambiguous automatic file lists', () => {
@@ -116,9 +147,17 @@ describe('desktop update release policy', () => {
     const exact = automaticInfo(['Vis-1.2.3-x64-Windows.exe']);
 
     // When/Then: neither a prerelease version nor an adjacent bridge file is accepted.
-    expect(() => selectAutomaticAppFile({ ...exact, version: '1.2.3-rc.1' }, 'win32', 'x64', 'nsis')).toThrow('stable');
-    expect(() => selectAutomaticAppFile({ ...exact, files: [...exact.files, exact.files[0]] }, 'win32', 'x64', 'nsis'))
-      .toThrow(/automatic update artifact list/iu);
+    expect(() =>
+      selectAutomaticAppFile({ ...exact, version: '1.2.3-rc.1' }, 'win32', 'x64', 'nsis'),
+    ).toThrow('stable');
+    expect(() =>
+      selectAutomaticAppFile(
+        { ...exact, files: [...exact.files, exact.files[0]] },
+        'win32',
+        'x64',
+        'nsis',
+      ),
+    ).toThrow(/automatic update artifact list/iu);
   });
 });
 

--- a/app/desktopUpdateRuntimeAdapter.test.ts
+++ b/app/desktopUpdateRuntimeAdapter.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+
+const harness = vi.hoisted(() => ({
+  getLatestRelease: vi.fn(async () => ({ version: '1.2.3', assets: [] })),
+  downloadAsset: vi.fn(async () => '/private/update.deb'),
+  verifyAsset: vi.fn(async () => undefined),
+  removeFile: vi.fn(async () => undefined),
+  dispose: vi.fn(),
+  onBeforeRequest: vi.fn(),
+  detectLinuxPackageFormat: vi.fn(async () => 'rpm' as const),
+}));
+
+vi.mock('../bridge/updatePlatform.js', () => ({
+  detectLinuxPackageFormat: harness.detectLinuxPackageFormat,
+}));
+
+vi.mock('../electron/updateTransport.js', () => ({
+  createUpdateTransport: () => ({
+    getLatestRelease: harness.getLatestRelease,
+    downloadAsset: harness.downloadAsset,
+    verifyAsset: harness.verifyAsset,
+    removeFile: harness.removeFile,
+    dispose: harness.dispose,
+  }),
+  isAllowedUpdateUrl: () => true,
+}));
+
+vi.mock('electron-updater', () => ({
+  default: {
+    autoUpdater: {
+      netSession: { webRequest: { onBeforeRequest: harness.onBeforeRequest } },
+    },
+    CancellationToken: class {},
+  },
+}));
+
+import { createUpdateRuntime } from '../electron/updateRuntime.js';
+
+describe('desktop update runtime adapter', () => {
+  it('delegates Node-only release transport while retaining Electron session lifecycle', async () => {
+    const runtime = createUpdateRuntime();
+    const asset = {
+      name: 'update.deb',
+      digest: `sha256:${'a'.repeat(64)}`,
+      size: 12,
+      url: 'https://api.github.com/repos/qiyuanhuakai/opencode-visualizer-cn/releases/assets/1',
+    };
+
+    await expect(runtime.getLatestRelease()).resolves.toEqual({ version: '1.2.3', assets: [] });
+    await expect(runtime.downloadAsset(asset, vi.fn())).resolves.toBe('/private/update.deb');
+    await runtime.verifyAsset('/private/update.deb', asset, 'a'.repeat(64));
+    await runtime.removeFile('/private/update.deb');
+    runtime.dispose();
+
+    expect(harness.getLatestRelease).toHaveBeenCalledOnce();
+    expect(harness.downloadAsset).toHaveBeenCalledWith(asset, expect.any(Function));
+    expect(harness.verifyAsset).toHaveBeenCalledWith('/private/update.deb', asset, 'a'.repeat(64));
+    expect(harness.removeFile).toHaveBeenCalledWith('/private/update.deb');
+    expect(harness.dispose).toHaveBeenCalledOnce();
+    expect(harness.onBeforeRequest).toHaveBeenLastCalledWith(null);
+  });
+
+  it('requires package ownership when resolving the desktop bridge Linux format', async () => {
+    // Given: the production runtime is active on the desktop host.
+    const runtime = createUpdateRuntime();
+
+    // When: a Linux bridge check resolves its native package family.
+    await expect(runtime.resolveBridgeLinuxFormat()).resolves.toBe('rpm');
+
+    // Then: detection requires ownership of the installed bridge package.
+    expect(harness.detectLinuxPackageFormat).toHaveBeenCalledWith({ requireOwnership: true });
+    runtime.dispose();
+  });
+});

--- a/app/desktopUpdateSecurity.test.ts
+++ b/app/desktopUpdateSecurity.test.ts
@@ -30,7 +30,9 @@ describe('automatic desktop update security', () => {
       fixture.updater.emit('update-available', info);
       return { updateInfo: info };
     });
-    fixture.runtime.downloadAppUpdate.mockResolvedValueOnce(['/private/update/Vis-1.2.3-x86_64-Linux.AppImage']);
+    fixture.runtime.downloadAppUpdate.mockResolvedValueOnce([
+      '/private/update/Vis-1.2.3-x86_64-Linux.AppImage',
+    ]);
     await fixture.service.check('app');
     await fixture.service.download('app');
 
@@ -40,7 +42,12 @@ describe('automatic desktop update security', () => {
     // Then: the returned path is checked against retained manifest evidence before quitAndInstall.
     expect(fixture.runtime.verifyAsset).toHaveBeenCalledWith(
       '/private/update/Vis-1.2.3-x86_64-Linux.AppImage',
-      { name: 'Vis-1.2.3-x86_64-Linux.AppImage', size: 12, sha512: `${'A'.repeat(86)}==`, url: 'Vis-1.2.3-x86_64-Linux.AppImage' },
+      {
+        name: 'Vis-1.2.3-x86_64-Linux.AppImage',
+        size: 12,
+        sha512: `${'A'.repeat(86)}==`,
+        url: 'Vis-1.2.3-x86_64-Linux.AppImage',
+      },
       `${'A'.repeat(86)}==`,
       'sha512',
     );
@@ -54,7 +61,9 @@ describe('automatic desktop update security', () => {
     const fixture = createFixture();
     const info = updateInfo('Vis-1.2.3-x86_64-Linux.AppImage');
     fixture.updater.checkForUpdates.mockResolvedValueOnce({ updateInfo: info });
-    fixture.runtime.downloadAppUpdate.mockResolvedValueOnce(['/private/update/Vis-1.2.3-arm64-Linux.AppImage']);
+    fixture.runtime.downloadAppUpdate.mockResolvedValueOnce([
+      '/private/update/Vis-1.2.3-arm64-Linux.AppImage',
+    ]);
     await fixture.service.check('app');
 
     // When: the update download is recorded.
@@ -70,7 +79,9 @@ describe('automatic desktop update security', () => {
     const fixture = createFixture();
     const info = updateInfo('Vis-1.2.3-x86_64-Linux.AppImage');
     fixture.updater.checkForUpdates.mockResolvedValueOnce({ updateInfo: info });
-    fixture.runtime.downloadAppUpdate.mockResolvedValueOnce(['/private/update/Vis-1.2.3-x86_64-Linux.AppImage']);
+    fixture.runtime.downloadAppUpdate.mockResolvedValueOnce([
+      '/private/update/Vis-1.2.3-x86_64-Linux.AppImage',
+    ]);
     fixture.runtime.verifyAsset.mockRejectedValueOnce(new Error('SHA512 mismatch'));
     await fixture.service.check('app');
     await fixture.service.download('app');
@@ -79,13 +90,18 @@ describe('automatic desktop update security', () => {
     await fixture.service.install('app');
 
     // Then: the mismatch becomes renderer-safe error state without handing off to the updater.
-    expect(fixture.service.getState().app).toMatchObject({ phase: 'error', error: 'SHA512 mismatch' });
+    expect(fixture.service.getState().app).toMatchObject({
+      phase: 'error',
+      error: 'SHA512 mismatch',
+    });
     expect(fixture.updater.quitAndInstall).not.toHaveBeenCalled();
   });
 
   it('removes URL credentials, query, and fragment from bounded renderer errors', () => {
     // Given: a provider error containing secrets in a URL and an oversized suffix.
-    const secret = new Error(`failed https://user:password@github.com/release/file?token=secret#fragment ${'x'.repeat(700)}`);
+    const secret = new Error(
+      `failed https://user:password@github.com/release/file?token=secret#fragment ${'x'.repeat(700)}`,
+    );
 
     // When: the error is prepared for renderer state.
     const message = errorMessage(secret);
@@ -116,18 +132,22 @@ function createFixture() {
     updater,
     getLatestRelease: vi.fn(),
     getBridgeVersion: vi.fn(),
+    resolveBridgeLinuxFormat: vi.fn(async () => 'deb' as const),
     downloadAppUpdate: vi.fn(async () => [] as string[]),
     downloadAsset: vi.fn(),
     verifyAsset: vi.fn(async () => undefined),
     removeFile: vi.fn(async () => undefined),
     dispose: vi.fn(),
   };
-  const service = createDesktopUpdates({
-    app: { isPackaged: true, getVersion: () => '1.0.0' },
-    shell: { openPath: vi.fn(async () => '') },
-    onChange: () => undefined,
-    beforeInstall: vi.fn(async () => true),
-  }, runtime);
+  const service = createDesktopUpdates(
+    {
+      app: { isPackaged: true, getVersion: () => '1.0.0' },
+      shell: { openPath: vi.fn(async () => '') },
+      onChange: () => undefined,
+      beforeInstall: vi.fn(async () => true),
+    },
+    runtime,
+  );
   return { runtime, service, updater };
 }
 

--- a/app/desktopUpdateService.test.ts
+++ b/app/desktopUpdateService.test.ts
@@ -14,6 +14,13 @@ const RELEASE = {
       size: 12,
       url: 'https://api.github.com/repos/qiyuanhuakai/opencode-visualizer-cn/releases/assets/1',
     },
+    {
+      name: 'VisBridge-1.2.3-x64-Linux.rpm',
+      digest: `sha256:${'b'.repeat(64)}`,
+      sha256: 'b'.repeat(64),
+      size: 12,
+      url: 'https://api.github.com/repos/qiyuanhuakai/opencode-visualizer-cn/releases/assets/2',
+    },
   ],
 };
 
@@ -80,6 +87,21 @@ describe('desktop update service', () => {
     });
   });
 
+  it('selects the installed RPM package family for a local Linux bridge update', async () => {
+    // Given: the desktop runtime detected an RPM-managed local bridge.
+    const fixture = createFixture({ bridgeLinuxFormat: 'rpm' });
+
+    // When: the local bridge checks the shared release.
+    await fixture.service.check('bridge');
+
+    // Then: the offer uses the RPM asset instead of the desktop DEB fallback.
+    expect(fixture.runtime.resolveBridgeLinuxFormat).toHaveBeenCalledOnce();
+    expect(fixture.service.getState().bridge).toMatchObject({
+      phase: 'available',
+      assetName: 'VisBridge-1.2.3-x64-Linux.rpm',
+    });
+  });
+
   it('uses electron-updater for packaged Linux app updates and quits only on explicit install', async () => {
     // Given: electron-updater has announced and downloaded an app update.
     const fixture = createFixture();
@@ -100,6 +122,7 @@ describe('desktop update service', () => {
 
     // Then: the confirmation hook precedes the updater-owned quit/install action.
     expect(fixture.runtime.downloadAppUpdate).toHaveBeenCalledOnce();
+    expect(fixture.runtime.resolveBridgeLinuxFormat).not.toHaveBeenCalled();
     expect(fixture.beforeInstall).toHaveBeenCalledWith('app', expect.any(AbortSignal));
     expect(fixture.updater.quitAndInstall).toHaveBeenCalledWith(false, true);
   });
@@ -400,6 +423,7 @@ function createFixture(
     readonly packaged?: boolean;
     readonly automaticAppUpdates?: boolean;
     readonly bridgeVersion?: string | null;
+    readonly bridgeLinuxFormat?: 'deb' | 'rpm';
   } = {},
 ) {
   const updater = Object.assign(new EventEmitter(), {
@@ -420,6 +444,7 @@ function createFixture(
     updater,
     getLatestRelease: vi.fn(async () => RELEASE),
     getBridgeVersion: vi.fn(async () => '1.0.0'),
+    resolveBridgeLinuxFormat: vi.fn(async () => options.bridgeLinuxFormat ?? 'deb'),
     downloadAppUpdate: vi.fn(async () => [] as string[]),
     downloadAsset: vi.fn(
       async (_asset, _onProgress: (percent: number) => void) => '/private/update/bridge.deb',
@@ -511,6 +536,7 @@ function createRuntime(
     updater,
     getLatestRelease: vi.fn(async () => RELEASE),
     getBridgeVersion: vi.fn(async () => '1.0.0'),
+    resolveBridgeLinuxFormat: vi.fn(async () => 'deb' as const),
     downloadAppUpdate: vi.fn(async () => [] as string[]),
     downloadAsset: vi.fn(async () => '/private/update/bridge.deb'),
     verifyAsset: vi.fn(async () => undefined),

--- a/app/sharedUpdateTransport.test.ts
+++ b/app/sharedUpdateTransport.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import http from 'node:http';
+import https from 'node:https';
+import { rm, stat } from 'node:fs/promises';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createUpdateTransport, isAllowedUpdateUrl } from '../electron/updateTransport.js';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('shared Node update transport policy', () => {
+  it('allows only HTTPS GitHub transport on the default TLS port', () => {
+    expect(isAllowedUpdateUrl('https://api.github.com/releases/latest')).toBe(true);
+    expect(isAllowedUpdateUrl('https://release-assets.githubusercontent.com/file')).toBe(true);
+    expect(isAllowedUpdateUrl('https://api.github.com:444/releases/latest')).toBe(false);
+    expect(isAllowedUpdateUrl('http://api.github.com/releases/latest')).toBe(false);
+    expect(isAllowedUpdateUrl('https://user:secret@api.github.com/releases/latest')).toBe(false);
+  });
+
+  it('stages downloads in a private directory with a private exclusive file', async () => {
+    const server = http.createServer((_request, response) => {
+      response.writeHead(200, { 'Content-Length': '4' });
+      response.end('data');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Expected TCP listener');
+    vi.spyOn(https, 'get').mockImplementation((_input, options, callback) =>
+      http.get(`http://127.0.0.1:${address.port}`, typeof options === 'function' ? options : callback),
+    );
+    const transport = createUpdateTransport();
+    let filePath: string | null = null;
+    try {
+      filePath = await transport.downloadAsset({
+        name: 'VisBridge-1.2.3-x64-Linux.deb', digest: null, size: 4,
+        url: 'https://api.github.com/repos/qiyuanhuakai/opencode-visualizer-cn/releases/assets/1',
+      });
+      expect((await stat(filePath)).mode & 0o777).toBe(0o600);
+      expect((await stat(new URL('.', `file://${filePath}`))).mode & 0o777).toBe(0o700);
+    } finally {
+      transport.dispose();
+      if (filePath) await rm(new URL('.', `file://${filePath}`), { recursive: true, force: true });
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('rejects release metadata beyond the two MiB boundary', async () => {
+    const server = http.createServer((_request, response) => response.end('x'.repeat((2 * 1024 * 1024) + 1)));
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Expected TCP listener');
+    vi.spyOn(https, 'get').mockImplementation((_input, options, callback) =>
+      http.get(`http://127.0.0.1:${address.port}`, typeof options === 'function' ? options : callback),
+    );
+    const transport = createUpdateTransport();
+    try {
+      await expect(transport.getLatestRelease()).rejects.toThrow('size limit');
+    } finally {
+      transport.dispose();
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/app/sharedUpdateTransportCleanup.test.ts
+++ b/app/sharedUpdateTransportCleanup.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+
+const fsMocks = vi.hoisted(() => ({
+  chmod: vi.fn(),
+  mkdtemp: vi.fn(),
+  rm: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:fs/promises')>()),
+  chmod: fsMocks.chmod,
+  mkdtemp: fsMocks.mkdtemp,
+  rm: fsMocks.rm,
+}));
+
+import { createUpdateTransport } from '../electron/updateTransport.js';
+
+describe('shared update transport staging cleanup', () => {
+  it('removes a newly-created staging directory when private permission setup fails', async () => {
+    fsMocks.mkdtemp.mockResolvedValue('/tmp/vis-update-private');
+    fsMocks.chmod.mockRejectedValue(new Error('chmod failed'));
+    fsMocks.rm.mockResolvedValue(undefined);
+    const transport = createUpdateTransport();
+
+    await expect(transport.downloadAsset({
+      name: 'VisBridge-1.2.3-x64-Linux.deb',
+      digest: `sha256:${'a'.repeat(64)}`,
+      size: 4,
+      url: 'https://api.github.com/repos/qiyuanhuakai/opencode-visualizer-cn/releases/assets/1',
+    })).rejects.toThrow('chmod failed');
+
+    expect(fsMocks.rm).toHaveBeenCalledWith('/tmp/vis-update-private', {
+      recursive: true,
+      force: true,
+    });
+    transport.dispose();
+  });
+});

--- a/bridge/updateCli.d.ts
+++ b/bridge/updateCli.d.ts
@@ -1,0 +1,57 @@
+import type { ReleaseAsset, StableRelease, UpdateArchitecture, UpdatePlatform } from '../electron/updatePolicy.js';
+
+export interface BridgeUpdateOptions {
+  readonly command: 'update';
+  readonly check: boolean;
+  readonly help: boolean;
+  readonly yes: boolean;
+}
+
+export interface BridgeUpdateHandoffRequest {
+  readonly assetPath: string;
+  readonly linuxFormat: 'deb' | 'rpm' | null;
+  readonly nonInteractiveYes: boolean;
+  readonly onAccepted: (resultLogPath?: string) => void;
+}
+
+export interface BridgeUpdateOffer {
+  readonly currentVersion: string;
+  readonly latestVersion: string;
+  readonly asset: ReleaseAsset;
+}
+
+export interface BridgeUpdateDependencies {
+  readonly currentVersion: string;
+  readonly platform: UpdatePlatform;
+  readonly arch: UpdateArchitecture;
+  readonly interactive: boolean;
+  readonly output: (message: string) => void;
+  readonly presentOffer: (offer: BridgeUpdateOffer) => void;
+  readonly confirm: (question: string) => Promise<boolean>;
+  readonly assertInstallAllowed: (options: {
+    readonly allowPrivilegedInspection: true;
+    readonly nonInteractiveYes: boolean;
+  }) => Promise<void>;
+  readonly resolveLinuxFormat: (options: { readonly requireOwnership: boolean }) => Promise<'deb' | 'rpm'>;
+  readonly handoff: (request: BridgeUpdateHandoffRequest) => Promise<void>;
+  readonly transport: {
+    getLatestRelease(): Promise<StableRelease>;
+    downloadAsset(asset: ReleaseAsset, onProgress: (percent: number) => void): Promise<string>;
+    verifyAsset(filePath: string, asset: ReleaseAsset, digest: string, algorithm: 'sha256'): Promise<void>;
+    removeFile?(filePath: string): Promise<void>;
+    dispose(): void;
+  };
+}
+
+export type BridgeUpdateResult = {
+  readonly kind: 'available' | 'cancelled' | 'current' | 'handed-off';
+  readonly currentVersion: string;
+  readonly latestVersion: string;
+};
+
+export declare function parseBridgeUpdateArgs(argv?: readonly string[]): BridgeUpdateOptions | null;
+export declare function updateUsage(): string;
+export declare function runBridgeUpdate(
+  options: BridgeUpdateOptions,
+  dependencies: Partial<BridgeUpdateDependencies> & Pick<BridgeUpdateDependencies, 'currentVersion'>,
+): Promise<BridgeUpdateResult>;

--- a/bridge/updateCli.js
+++ b/bridge/updateCli.js
@@ -1,0 +1,145 @@
+import { createInterface } from 'node:readline/promises';
+import { parseArgs } from 'node:util';
+import { isNewerVersion, selectBridgeAsset, sha256FromDigest } from '../electron/updatePolicy.js';
+import { createUpdateTransport } from '../electron/updateTransport.js';
+import { createInstallerHandoff } from './updateHandoff.js';
+import { assertBridgeInstallAllowed, detectLinuxPackageFormat } from './updatePlatform.js';
+
+export function parseBridgeUpdateArgs(argv = process.argv.slice(2)) {
+  if (argv[0] !== 'update' && argv[0] !== 'upgrade') return null;
+  const { values } = parseArgs({
+    args: argv.slice(1),
+    options: {
+      check: { type: 'boolean' },
+      help: { type: 'boolean', short: 'h' },
+      yes: { type: 'boolean', short: 'y' },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  return {
+    command: 'update',
+    check: Boolean(values.check),
+    help: Boolean(values.help),
+    yes: Boolean(values.yes),
+  };
+}
+
+export function updateUsage() {
+  return `Usage:
+  vis_bridge update [--check] [--yes|-y]
+  vis_bridge upgrade [--check] [--yes|-y]
+
+Options:
+  --check              Check the latest stable release without downloading or installing.
+  --yes, -y            Confirm an available update without prompting.
+  --help, -h           Show this help.`;
+}
+
+export async function runBridgeUpdate(options, injected = {}) {
+  const dependencies = createDependencies(injected);
+  let stagedPath = null;
+  let handedOff = false;
+  try {
+    dependencies.output('Checking the latest stable vis_bridge release...');
+    const release = await dependencies.transport.getLatestRelease();
+    const result = {
+      currentVersion: dependencies.currentVersion,
+      latestVersion: release.version,
+    };
+    if (!isNewerVersion(release.version, dependencies.currentVersion)) {
+      dependencies.output(`vis_bridge ${dependencies.currentVersion} is current; latest stable is ${release.version}.`);
+      return { kind: 'current', ...result };
+    }
+    const previewLinuxFormat = await resolveLinuxFormat(dependencies, false);
+    const previewAsset = selectBridgeAsset(
+      release,
+      dependencies.platform,
+      dependencies.arch,
+      previewLinuxFormat,
+    );
+    sha256FromDigest(previewAsset);
+    dependencies.presentOffer({
+      currentVersion: dependencies.currentVersion,
+      latestVersion: release.version,
+      asset: previewAsset,
+    });
+    if (options.check) {
+      return { kind: 'available', ...result };
+    }
+    if (!options.yes) {
+      if (!dependencies.interactive) {
+        throw new Error('An update is available; rerun with --yes in a non-interactive terminal.');
+      }
+      const approved = await dependencies.confirm(
+        `Updating interrupts all connected clients and running tasks. Continue? [y/N] `,
+      );
+      if (!approved) {
+        dependencies.output('Update cancelled.');
+        return { kind: 'cancelled', ...result };
+      }
+    }
+
+    await dependencies.assertInstallAllowed({
+      allowPrivilegedInspection: true,
+      nonInteractiveYes: options.yes && !dependencies.interactive,
+    });
+    const linuxFormat = await resolveLinuxFormat(dependencies, true);
+    const asset = selectBridgeAsset(release, dependencies.platform, dependencies.arch, linuxFormat);
+    const digest = sha256FromDigest(asset);
+    dependencies.output(`Downloading ${asset.name} (${asset.size} bytes)...`);
+    stagedPath = await dependencies.transport.downloadAsset(asset, () => undefined);
+    await dependencies.transport.verifyAsset(stagedPath, asset, digest, 'sha256');
+    await dependencies.handoff({
+      assetPath: stagedPath,
+      linuxFormat,
+      nonInteractiveYes: options.yes && !dependencies.interactive,
+      onAccepted: (resultLogPath) => dependencies.output(resultLogPath
+        ? `Installer handoff accepted; the installer result will be written to ${resultLogPath}.`
+        : 'Installer handoff accepted; installation continues after vis_bridge exits.'),
+    });
+    handedOff = true;
+    return { kind: 'handed-off', ...result };
+  } catch (error) {
+    if (stagedPath && !handedOff) await dependencies.transport.removeFile?.(stagedPath);
+    throw error;
+  } finally {
+    dependencies.transport.dispose();
+  }
+}
+
+function createDependencies(injected) {
+  const transport = injected.transport ?? createUpdateTransport();
+  const output = injected.output ?? ((message) => console.log(message));
+  return {
+    currentVersion: injected.currentVersion,
+    platform: injected.platform ?? process.platform,
+    arch: injected.arch ?? process.arch,
+    interactive: injected.interactive ?? Boolean(process.stdin.isTTY && process.stdout.isTTY),
+    output,
+    presentOffer: injected.presentOffer ?? ((offer) => output(
+      `Update available: ${offer.currentVersion} -> ${offer.latestVersion} (${offer.asset.name}, ${offer.asset.size} bytes).`,
+    )),
+    confirm: injected.confirm ?? confirmUpdate,
+    assertInstallAllowed: injected.assertInstallAllowed ?? ((options) => assertBridgeInstallAllowed(options)),
+    resolveLinuxFormat: injected.resolveLinuxFormat ?? detectLinuxPackageFormat,
+    handoff: injected.handoff ?? createInstallerHandoff(),
+    transport,
+  };
+}
+
+function resolveLinuxFormat(dependencies, requireOwnership) {
+  return dependencies.platform === 'linux'
+    ? dependencies.resolveLinuxFormat({ requireOwnership })
+    : Promise.resolve(null);
+}
+
+async function confirmUpdate(question) {
+  const prompt = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await prompt.question(question)).trim().toLowerCase();
+    return answer === 'y' || answer === 'yes';
+  } finally {
+    prompt.close();
+  }
+}

--- a/bridge/updateHandoff.d.ts
+++ b/bridge/updateHandoff.d.ts
@@ -1,0 +1,50 @@
+import type { ChildProcess } from 'node:child_process';
+
+export type UpdateHelperProcess = Pick<ChildProcess, 'kill' | 'off' | 'once' | 'pid' | 'unref'>;
+
+export interface InstallerHandoffRequest {
+  readonly assetPath: string;
+  readonly linuxFormat: 'deb' | 'rpm' | null;
+  readonly nonInteractiveYes: boolean;
+  readonly onAccepted?: (resultLogPath?: string) => void;
+}
+
+export declare function createPosixUpdateHelper(platform: string, linuxFormat: 'deb' | 'rpm' | null): string;
+export declare function createWindowsUpdateHelper(): string;
+export declare function waitForAck(
+  ackPath: string,
+  child: UpdateHelperProcess,
+  options?: {
+    readonly timeoutMs?: number;
+    readonly pollIntervalMs?: number;
+    readonly readAck?: (path: string, encoding: BufferEncoding) => Promise<string>;
+    readonly schedule?: (callback: () => void, delay: number) => NodeJS.Timeout;
+    readonly clearSchedule?: (handle: NodeJS.Timeout) => void;
+  },
+): Promise<string>;
+export declare function handoffPosixInstaller(options: InstallerHandoffRequest & {
+  readonly platform: string;
+  readonly uid: number | null;
+  readonly execve: ((file: string, args: string[], env: NodeJS.ProcessEnv) => void) | null;
+  readonly writeHelper: (assetPath: string, contents: string) => Promise<string>;
+}): Promise<void>;
+export declare function handoffWindowsInstaller(options: {
+  readonly assetPath: string;
+  readonly parentPid: number;
+  readonly powershellPath: string;
+  readonly spawnProcess: (
+    command: string,
+    args: readonly string[],
+    options: import('node:child_process').SpawnOptions,
+  ) => UpdateHelperProcess;
+  readonly waitForAck: (ackPath: string, child: UpdateHelperProcess) => Promise<string>;
+  readonly writeHelper: (
+    assetPath: string,
+    contents: string,
+  ) => Promise<{ readonly helperPath: string; readonly ackPath: string }>;
+  readonly onAccepted?: (resultLogPath: string) => void;
+}): Promise<void>;
+export declare function handoffBridgeInstaller(options: InstallerHandoffRequest & Record<string, unknown>): Promise<void>;
+export declare function createInstallerHandoff(options?: {
+  readonly platform?: string;
+}): (request: InstallerHandoffRequest) => Promise<void>;

--- a/bridge/updateHandoff.d.ts
+++ b/bridge/updateHandoff.d.ts
@@ -11,6 +11,14 @@ export interface InstallerHandoffRequest {
 
 export declare function createPosixUpdateHelper(platform: string, linuxFormat: 'deb' | 'rpm' | null): string;
 export declare function createWindowsUpdateHelper(): string;
+export declare function createWindowsUpdateBootstrap(options: {
+  readonly powershellPath: string;
+  readonly helperPath: string;
+  readonly parentPid: number;
+  readonly ackPath: string;
+  readonly installerPath: string;
+  readonly stagingDirectory: string;
+}): string;
 export declare function waitForAck(
   ackPath: string,
   child: UpdateHelperProcess,

--- a/bridge/updateHandoff.js
+++ b/bridge/updateHandoff.js
@@ -1,0 +1,221 @@
+import { spawn } from 'node:child_process';
+import { chmod, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export async function handoffBridgeInstaller(options) {
+  if (options.platform === 'win32') return handoffWindowsInstaller(options);
+  return handoffPosixInstaller(options);
+}
+
+export async function handoffPosixInstaller(options) {
+  if (typeof options.execve !== 'function') {
+    throw new Error('This vis_bridge runtime cannot safely hand off an installer because process.execve is unavailable.');
+  }
+  const helperPath = await options.writeHelper(
+    options.assetPath,
+    createPosixUpdateHelper(options.platform, options.linuxFormat),
+  );
+  const privilege = options.uid === 0
+    ? 'root'
+    : options.nonInteractiveYes ? 'sudo-noninteractive' : 'sudo';
+  options.onAccepted?.();
+  options.execve('/bin/sh', ['/bin/sh', helperPath, options.assetPath, privilege], { ...process.env });
+}
+
+export async function handoffWindowsInstaller(options) {
+  const { helperPath, ackPath } = await options.writeHelper(
+    options.assetPath,
+    createWindowsUpdateHelper(),
+  );
+  const stagingDirectory = path.win32.dirname(options.assetPath);
+  const child = options.spawnProcess(options.powershellPath, [
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-File',
+    helperPath,
+    '-ParentPid',
+    String(options.parentPid),
+    '-AckPath',
+    ackPath,
+    '-InstallerPath',
+    options.assetPath,
+    '-StagingDirectory',
+    stagingDirectory,
+  ], {
+    detached: true,
+    env: { ...process.env },
+    stdio: 'ignore',
+    windowsHide: true,
+  });
+  if (typeof child.unref === 'function') child.unref();
+  const resultLogPath = await options.waitForAck(ackPath, child);
+  options.onAccepted?.(resultLogPath);
+}
+
+export function createPosixUpdateHelper(platform, linuxFormat) {
+  const installerCommand = platform === 'darwin'
+    ? '/usr/sbin/installer -pkg "$installer" -target /'
+    : linuxFormat === 'rpm'
+      ? '/usr/bin/rpm -U -- "$installer"'
+      : '/usr/bin/dpkg -i -- "$installer"';
+  return `#!/bin/sh
+set -u
+installer="$1"
+privilege="$2"
+staging_dir="\${installer%/*}"
+cleanup() { /bin/rm -rf -- "$staging_dir"; }
+trap cleanup EXIT
+case "$privilege" in
+  root) ${installerCommand} ;;
+  sudo) /usr/bin/sudo ${installerCommand} ;;
+  sudo-noninteractive) /usr/bin/sudo -n ${installerCommand} ;;
+  *) /bin/printf '%s\n' 'Invalid updater privilege mode.' >&2; exit 2 ;;
+esac
+result=$?
+if [ "$result" -eq 0 ]; then
+  /bin/printf '%s\n' 'vis_bridge installer completed successfully.'
+else
+  /bin/printf 'vis_bridge installer failed with exit code %s.\n' "$result" >&2
+fi
+exit "$result"
+`;
+}
+
+export function createWindowsUpdateHelper() {
+  return String.raw`param(
+  [Parameter(Mandatory = $true)][uint32]$ParentPid,
+  [Parameter(Mandatory = $true)][string]$AckPath,
+  [Parameter(Mandatory = $true)][string]$InstallerPath,
+  [Parameter(Mandatory = $true)][string]$StagingDirectory
+)
+$ErrorActionPreference = 'Stop'
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class VisBridgeUpdateNative {
+  [DllImport("kernel32.dll", SetLastError = true)]
+  public static extern IntPtr OpenProcess(uint access, bool inheritHandle, uint processId);
+  [DllImport("kernel32.dll", SetLastError = true)]
+  public static extern uint WaitForSingleObject(IntPtr handle, uint milliseconds);
+  [DllImport("kernel32.dll")]
+  public static extern bool CloseHandle(IntPtr handle);
+}
+'@
+$parentHandle = [IntPtr]::Zero
+$exitCode = 1
+$resultDirectory = Join-Path ([Environment]::GetFolderPath([Environment+SpecialFolder]::LocalApplicationData)) 'vis_bridge\updates'
+$resultLogPath = Join-Path $resultDirectory ("installer-{0}-{1}.log" -f $ParentPid, [Guid]::NewGuid())
+try {
+  [IO.Directory]::CreateDirectory($resultDirectory) | Out-Null
+  $parentHandle = [VisBridgeUpdateNative]::OpenProcess(0x00100000, $false, $ParentPid)
+  if ($parentHandle -eq [IntPtr]::Zero) { throw 'Unable to acquire the vis_bridge parent process handle.' }
+  [IO.File]::WriteAllText($AckPath, ('ready' + [Environment]::NewLine + $resultLogPath))
+  $waitResult = [VisBridgeUpdateNative]::WaitForSingleObject($parentHandle, 0xFFFFFFFF)
+  if ($waitResult -ne 0) { throw "Waiting for vis_bridge exit failed: $waitResult" }
+  $process = Start-Process -FilePath $InstallerPath -ArgumentList '/S' -Wait -PassThru
+  if ($process.ExitCode -ne 0) { throw "vis_bridge installer failed with exit code $($process.ExitCode)." }
+  [IO.File]::WriteAllText($resultLogPath, ('status=success' + [Environment]::NewLine + 'exit_code=0'))
+  $exitCode = 0
+} catch {
+  $message = $_.Exception.Message
+  [IO.File]::WriteAllText($resultLogPath, ('status=failure' + [Environment]::NewLine + "error=$message"))
+} finally {
+  if ($parentHandle -ne [IntPtr]::Zero) { [VisBridgeUpdateNative]::CloseHandle($parentHandle) | Out-Null }
+  Remove-Item -LiteralPath $StagingDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}
+exit $exitCode
+`;
+}
+
+export function createInstallerHandoff(options = {}) {
+  const platform = options.platform ?? process.platform;
+  const powershellPath = platform === 'win32'
+    ? String.raw`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`
+    : null;
+  return (request) => handoffBridgeInstaller({
+    ...request,
+    platform,
+    uid: typeof process.getuid === 'function' ? process.getuid() : null,
+    parentPid: process.pid,
+    powershellPath,
+    execve: typeof process.execve === 'function' ? (...args) => process.execve(...args) : null,
+    spawnProcess: spawn,
+    waitForAck,
+    writeHelper: platform === 'win32' ? writeWindowsHelper : writePosixHelper,
+  });
+}
+
+async function writePosixHelper(assetPath, contents) {
+  const helperPath = path.join(path.dirname(assetPath), 'install-vis-bridge.sh');
+  await writeFile(helperPath, contents, { encoding: 'utf8', flag: 'wx', mode: 0o700 });
+  await chmod(helperPath, 0o700);
+  return helperPath;
+}
+
+async function writeWindowsHelper(assetPath, contents) {
+  const directory = path.win32.dirname(assetPath);
+  const helperPath = path.win32.join(directory, 'install-vis-bridge.ps1');
+  const ackPath = path.win32.join(directory, 'parent-handle-ready');
+  await writeFile(helperPath, contents, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+  return { helperPath, ackPath };
+}
+
+export function waitForAck(ackPath, child, options = {}) {
+  const readAck = options.readAck ?? readFile;
+  const schedule = options.schedule ?? setTimeout;
+  const clearSchedule = options.clearSchedule ?? clearTimeout;
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const pollIntervalMs = options.pollIntervalMs ?? 25;
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let pollHandle;
+    let timeoutHandle;
+    const finish = (error, terminateHelper = true, resultLogPath) => {
+      if (settled) return;
+      settled = true;
+      if (pollHandle) clearSchedule(pollHandle);
+      if (timeoutHandle) clearSchedule(timeoutHandle);
+      child.off?.('error', onError);
+      child.off?.('exit', onExit);
+      if (error) {
+        if (terminateHelper && child.pid) {
+          try {
+            child.kill?.();
+          } catch (terminationError) {
+            reject(new AggregateError([error, terminationError], 'Windows update helper termination failed.'));
+            return;
+          }
+        }
+        reject(error);
+      }
+      else resolve(resultLogPath);
+    };
+    const onError = (error) => finish(error);
+    const onExit = (code) => finish(
+      new Error(`Windows update helper exited before readiness acknowledgement (${code ?? 'unknown'}).`),
+      false,
+    );
+    const poll = async () => {
+      try {
+        const value = await readAck(ackPath, 'utf8');
+        if (settled) return;
+        const [status, resultLogPath] = value.split(/\r?\n/u, 2);
+        if (status === 'ready' && resultLogPath && path.win32.isAbsolute(resultLogPath)) {
+          return finish(undefined, false, resultLogPath);
+        }
+      } catch (error) {
+        if (settled) return;
+        if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') return finish(error);
+      }
+      if (!settled) pollHandle = schedule(() => { void poll(); }, pollIntervalMs);
+    };
+    child.once('error', onError);
+    child.once('exit', onExit);
+    timeoutHandle = schedule(() => {
+      finish(new Error('Windows update helper did not acknowledge its parent process handle.'));
+    }, timeoutMs);
+    void poll();
+  });
+}

--- a/bridge/updateHandoff.js
+++ b/bridge/updateHandoff.js
@@ -1,6 +1,9 @@
 import { spawn } from 'node:child_process';
 import { chmod, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { createWindowsUpdateBootstrap } from './updateHandoffWindows.js';
+
+export { createWindowsUpdateBootstrap } from './updateHandoffWindows.js';
 
 export async function handoffBridgeInstaller(options) {
   if (options.platform === 'win32') return handoffWindowsInstaller(options);
@@ -28,23 +31,23 @@ export async function handoffWindowsInstaller(options) {
     createWindowsUpdateHelper(),
   );
   const stagingDirectory = path.win32.dirname(options.assetPath);
+  const bootstrapCommand = createWindowsUpdateBootstrap({
+    powershellPath: options.powershellPath,
+    helperPath,
+    parentPid: options.parentPid,
+    ackPath,
+    installerPath: options.assetPath,
+    stagingDirectory,
+  });
   const child = options.spawnProcess(options.powershellPath, [
     '-NoProfile',
     '-NonInteractive',
     '-ExecutionPolicy',
     'Bypass',
-    '-File',
-    helperPath,
-    '-ParentPid',
-    String(options.parentPid),
-    '-AckPath',
-    ackPath,
-    '-InstallerPath',
-    options.assetPath,
-    '-StagingDirectory',
-    stagingDirectory,
+    '-EncodedCommand',
+    bootstrapCommand,
   ], {
-    detached: true,
+    detached: false,
     env: { ...process.env },
     stdio: 'ignore',
     windowsHide: true,
@@ -112,7 +115,7 @@ try {
   $parentHandle = [VisBridgeUpdateNative]::OpenProcess(0x00100000, $false, $ParentPid)
   if ($parentHandle -eq [IntPtr]::Zero) { throw 'Unable to acquire the vis_bridge parent process handle.' }
   [IO.File]::WriteAllText($AckPath, ('ready' + [Environment]::NewLine + $resultLogPath))
-  $waitResult = [VisBridgeUpdateNative]::WaitForSingleObject($parentHandle, 0xFFFFFFFF)
+  $waitResult = [VisBridgeUpdateNative]::WaitForSingleObject($parentHandle, [uint32]::MaxValue)
   if ($waitResult -ne 0) { throw "Waiting for vis_bridge exit failed: $waitResult" }
   $process = Start-Process -FilePath $InstallerPath -ArgumentList '/S' -Wait -PassThru
   if ($process.ExitCode -ne 0) { throw "vis_bridge installer failed with exit code $($process.ExitCode)." }

--- a/bridge/updateHandoffWindows.js
+++ b/bridge/updateHandoffWindows.js
@@ -1,0 +1,25 @@
+function encodePowerShellCommand(command) {
+  return Buffer.from(command, 'utf16le').toString('base64');
+}
+
+function decodeUtf8Expression(value) {
+  const encoded = Buffer.from(value, 'utf8').toString('base64');
+  return `[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${encoded}'))`;
+}
+
+export function createWindowsUpdateBootstrap(options) {
+  const helperCommand = String.raw`$ErrorActionPreference = 'Stop'
+$helperPath = ${decodeUtf8Expression(options.helperPath)}
+$ackPath = ${decodeUtf8Expression(options.ackPath)}
+$installerPath = ${decodeUtf8Expression(options.installerPath)}
+$stagingDirectory = ${decodeUtf8Expression(options.stagingDirectory)}
+& $helperPath -ParentPid ${options.parentPid} -AckPath $ackPath -InstallerPath $installerPath -StagingDirectory $stagingDirectory
+exit $LASTEXITCODE`;
+  const bootstrap = String.raw`$ErrorActionPreference = 'Stop'
+$powershellPath = ${decodeUtf8Expression(options.powershellPath)}
+$helperCommand = '${encodePowerShellCommand(helperCommand)}'
+$helper = Start-Process -FilePath $powershellPath -ArgumentList @('-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-EncodedCommand', $helperCommand) -WindowStyle Hidden -PassThru
+$helper.WaitForExit()
+exit $helper.ExitCode`;
+  return encodePowerShellCommand(bootstrap);
+}

--- a/bridge/updateLinuxAncestry.d.ts
+++ b/bridge/updateLinuxAncestry.d.ts
@@ -1,0 +1,32 @@
+export interface LinuxAncestryProbeResult {
+  readonly code: number;
+  readonly stdout: string;
+}
+
+export interface LinuxAncestor {
+  readonly pid: number;
+  readonly executable: string;
+}
+
+export declare function collectLinuxAncestors(
+  pid: number,
+  options?: {
+    readonly readFile?: (path: string, encoding: BufferEncoding) => Promise<string>;
+    readonly readlink?: (path: string) => Promise<string>;
+    readonly privilegedReadlink?: (pid: number) => Promise<string>;
+  },
+): Promise<readonly LinuxAncestor[]>;
+export declare function privilegedLinuxReadlinkCommand(
+  pid: number,
+  nonInteractiveYes: boolean,
+): { readonly command: '/usr/bin/sudo'; readonly args: readonly string[] };
+export declare function readLinuxExecutableWithSudo(
+  pid: number,
+  options?: {
+    readonly nonInteractiveYes?: boolean;
+    readonly probe?: (
+      command: string,
+      args: readonly string[],
+    ) => Promise<LinuxAncestryProbeResult>;
+  },
+): Promise<string>;

--- a/bridge/updateLinuxAncestry.js
+++ b/bridge/updateLinuxAncestry.js
@@ -1,0 +1,128 @@
+import { execFile } from 'node:child_process';
+import { readFile, readlink } from 'node:fs/promises';
+import path from 'node:path';
+
+export async function collectLinuxAncestors(firstPid, options = {}) {
+  const readStat = options.readFile ?? readFile;
+  const readExecutable = options.readlink ?? readlink;
+  const ancestors = [];
+  const visited = new Set();
+  let pid = firstPid;
+  while (pid > 0 && !visited.has(pid)) {
+    visited.add(pid);
+    const stat = await readProcessStat(readStat, pid);
+    if (!stat) break;
+    const identity = parseProcessIdentity(stat, pid);
+    const executable = await resolveExecutable({
+      pid,
+      identity,
+      readExecutable,
+      readStat,
+      privilegedReadlink: options.privilegedReadlink,
+    });
+    if (executable === null) break;
+    ancestors.push({ pid, executable });
+    pid = identity.parentPid;
+  }
+  return ancestors;
+}
+
+export function privilegedLinuxReadlinkCommand(pid, nonInteractiveYes) {
+  if (!Number.isSafeInteger(pid) || pid <= 0) throw new Error('Invalid Linux ancestor PID.');
+  return {
+    command: '/usr/bin/sudo',
+    args: [
+      ...(nonInteractiveYes ? ['-n'] : []),
+      '/usr/bin/readlink',
+      '--',
+      `/proc/${pid}/exe`,
+    ],
+  };
+}
+
+export async function readLinuxExecutableWithSudo(pid, options = {}) {
+  const invocation = privilegedLinuxReadlinkCommand(pid, options.nonInteractiveYes ?? false);
+  const result = await (options.probe ?? execFileResult)(invocation.command, invocation.args);
+  const executable = result.stdout.trim();
+  if (result.code !== 0 || !path.isAbsolute(executable)) {
+    throw new Error(`Unable to inspect Linux ancestor PID ${pid} with sudo.`);
+  }
+  return executable;
+}
+
+async function resolveExecutable(options) {
+  try {
+    return await options.readExecutable(`/proc/${options.pid}/exe`);
+  } catch (error) {
+    if (isGoneProcessError(error)) return null;
+    if (!isPermissionError(error) || !options.privilegedReadlink) {
+      throw processInspectionError(options.pid, error);
+    }
+    return resolvePrivilegedExecutable(options);
+  }
+}
+
+async function resolvePrivilegedExecutable(options) {
+  let executable;
+  let privilegedError;
+  try {
+    executable = await options.privilegedReadlink(options.pid);
+  } catch (error) {
+    privilegedError = error;
+  }
+  const currentStat = await readProcessStat(options.readStat, options.pid);
+  if (!currentStat) return null;
+  const currentIdentity = parseProcessIdentity(currentStat, options.pid);
+  if (currentIdentity.startTime !== options.identity.startTime
+    || currentIdentity.parentPid !== options.identity.parentPid) {
+    throw new Error(`Linux ancestor PID ${options.pid} changed during privileged inspection.`);
+  }
+  if (privilegedError) throw processInspectionError(options.pid, privilegedError);
+  return executable;
+}
+
+async function readProcessStat(readStat, pid) {
+  try {
+    return await readStat(`/proc/${pid}/stat`, 'utf8');
+  } catch (error) {
+    if (isGoneProcessError(error)) return null;
+    throw processInspectionError(pid, error);
+  }
+}
+
+function parseProcessIdentity(stat, expectedPid) {
+  const nameEnd = stat.lastIndexOf(')');
+  const statPid = Number.parseInt(stat.slice(0, stat.indexOf('(')).trim(), 10);
+  const fields = stat.slice(nameEnd + 2).trim().split(/\s+/u);
+  const parentPid = Number.parseInt(fields[1] ?? '', 10);
+  const startTime = fields[19];
+  if (nameEnd < 0 || statPid !== expectedPid || !Number.isSafeInteger(parentPid) || !startTime) {
+    throw processInspectionError(expectedPid);
+  }
+  return { parentPid, startTime };
+}
+
+function isGoneProcessError(error) {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}
+
+function isPermissionError(error) {
+  return error instanceof Error
+    && 'code' in error
+    && (error.code === 'EACCES' || error.code === 'EPERM');
+}
+
+function processInspectionError(pid, cause) {
+  return new Error(
+    `Unable to inspect live process ancestry on Linux at PID ${pid}.`,
+    cause ? { cause } : undefined,
+  );
+}
+
+function execFileResult(command, args) {
+  return new Promise((resolve) => {
+    execFile(command, args, { encoding: 'utf8', timeout: 15_000, windowsHide: true }, (error, stdout) => {
+      resolve({ code: error ? 1 : 0, stdout: typeof stdout === 'string' ? stdout : '' });
+    });
+  });
+}

--- a/bridge/updatePlatform.d.ts
+++ b/bridge/updatePlatform.d.ts
@@ -1,0 +1,86 @@
+export interface ProcessAncestor {
+  readonly pid: number;
+  readonly executable: string;
+}
+
+export interface LinuxPackageProbeResult {
+  readonly code: number;
+  readonly stdout: string;
+}
+
+export declare function managedBridgePath(platform: string, env?: NodeJS.ProcessEnv): string;
+export declare function assertManagedInstallation(
+  execPath: string,
+  platform: string,
+  env?: NodeJS.ProcessEnv,
+): string;
+export declare function hasBridgeHostedAncestor(
+  ancestors: readonly ProcessAncestor[],
+  installedPath: string,
+  platform: string,
+): boolean;
+export declare function assertBridgeInstallAllowed(options?: {
+  readonly platform?: string;
+  readonly execPath?: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly pid?: number;
+  readonly allowPrivilegedInspection?: boolean;
+  readonly nonInteractiveYes?: boolean;
+  readonly collectAncestors?: (
+    pid: number,
+    platform: string,
+    env: NodeJS.ProcessEnv,
+  ) => Promise<readonly ProcessAncestor[]>;
+}): Promise<void>;
+export declare function detectLinuxPackageFormat(options?: {
+  readonly requireOwnership?: boolean;
+}): Promise<'deb' | 'rpm'>;
+export declare function selectLinuxPackageFormat(options: {
+  readonly osRelease: string;
+  readonly installedPath: string;
+  readonly requireOwnership: boolean;
+  readonly toolExists: (tool: string) => boolean;
+  readonly probe: (command: string, args: readonly string[]) => Promise<LinuxPackageProbeResult>;
+}): Promise<'deb' | 'rpm'>;
+export declare function collectProcessAncestors(
+  pid: number,
+  platform: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<readonly ProcessAncestor[]>;
+export declare function collectLinuxAncestors(
+  pid: number,
+  options?: {
+    readonly readFile?: (path: string, encoding: BufferEncoding) => Promise<string>;
+    readonly readlink?: (path: string) => Promise<string>;
+    readonly privilegedReadlink?: (pid: number) => Promise<string>;
+  },
+): Promise<readonly ProcessAncestor[]>;
+export declare function privilegedLinuxReadlinkCommand(
+  pid: number,
+  nonInteractiveYes: boolean,
+): { readonly command: '/usr/bin/sudo'; readonly args: readonly string[] };
+export declare function readLinuxExecutableWithSudo(
+  pid: number,
+  options?: {
+    readonly nonInteractiveYes?: boolean;
+    readonly probe?: (
+      command: string,
+      args: readonly string[],
+    ) => Promise<LinuxPackageProbeResult>;
+  },
+): Promise<string>;
+export declare function collectDarwinAncestors(
+  pid: number,
+  runtime?: {
+    readonly probe: (command: string, args: readonly string[]) => Promise<LinuxPackageProbeResult>;
+    readonly isAlive: (pid: number) => boolean;
+  },
+): Promise<readonly ProcessAncestor[]>;
+export declare function collectWindowsAncestors(
+  pid: number,
+  env: NodeJS.ProcessEnv,
+  runtime?: {
+    readonly probe: (command: string, args: readonly string[]) => Promise<LinuxPackageProbeResult>;
+    readonly isAlive: (pid: number) => boolean;
+  },
+): Promise<readonly ProcessAncestor[]>;

--- a/bridge/updatePlatform.js
+++ b/bridge/updatePlatform.js
@@ -1,0 +1,230 @@
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import {
+  collectLinuxAncestors,
+  readLinuxExecutableWithSudo,
+} from './updateLinuxAncestry.js';
+
+export {
+  collectLinuxAncestors,
+  privilegedLinuxReadlinkCommand,
+  readLinuxExecutableWithSudo,
+} from './updateLinuxAncestry.js';
+
+const DEB_FAMILIES = new Set(['debian', 'linuxmint', 'pop', 'ubuntu']);
+const RPM_FAMILIES = new Set(['almalinux', 'amzn', 'centos', 'fedora', 'opensuse', 'rhel', 'rocky', 'sles', 'suse']);
+
+export function managedBridgePath(platform, env = process.env) {
+  if (platform === 'linux') return '/usr/bin/vis_bridge';
+  if (platform === 'darwin') return '/usr/local/bin/vis_bridge';
+  if (platform === 'win32' && env.LOCALAPPDATA) {
+    return path.win32.join(env.LOCALAPPDATA, 'Programs', 'vis_bridge', 'vis_bridge.exe');
+  }
+  throw new Error(`vis_bridge updates are unsupported on ${platform}`);
+}
+
+export function assertManagedInstallation(execPath, platform, env = process.env) {
+  const installedPath = managedBridgePath(platform, env);
+  if (!sameExecutable(execPath, installedPath, platform)) {
+    throw new Error(`Run the update command from the installed vis_bridge executable at ${installedPath}.`);
+  }
+  return installedPath;
+}
+
+export function hasBridgeHostedAncestor(ancestors, installedPath, platform) {
+  return ancestors.some(({ executable }) => sameExecutable(executable, installedPath, platform)
+    || (platform === 'darwin'
+      && path.posix.basename(executable) === path.posix.basename(installedPath)));
+}
+
+export async function assertBridgeInstallAllowed(options = {}) {
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+  const installedPath = assertManagedInstallation(options.execPath ?? process.execPath, platform, env);
+  const pid = options.pid ?? process.ppid;
+  const ancestors = options.collectAncestors
+    ? await options.collectAncestors(pid, platform, env)
+    : await collectProcessAncestorsWithOptions({
+      pid,
+      platform,
+      env,
+      allowPrivilegedInspection: options.allowPrivilegedInspection ?? false,
+      nonInteractiveYes: options.nonInteractiveYes ?? false,
+    });
+  if (hasBridgeHostedAncestor(ancestors, installedPath, platform)) {
+    throw new Error('Refusing to update from a bridge-hosted terminal because installation stops its ancestor process tree.');
+  }
+}
+
+export async function detectLinuxPackageFormat(options = {}) {
+  let osRelease = '';
+  try {
+    osRelease = await readFile('/etc/os-release', 'utf8');
+  } catch {
+    throw new Error('Cannot determine the Linux distribution package format.');
+  }
+  return selectLinuxPackageFormat({
+    osRelease,
+    installedPath: '/usr/bin/vis_bridge',
+    requireOwnership: options.requireOwnership ?? false,
+    toolExists: existsSync,
+    probe: execFileResult,
+  });
+}
+
+export async function selectLinuxPackageFormat(options) {
+  const debTool = options.toolExists('/usr/bin/dpkg-query');
+  const rpmTool = options.toolExists('/usr/bin/rpm');
+  const [debOwner, rpmOwner] = await Promise.all([
+    debTool
+      ? options.probe('/usr/bin/dpkg-query', ['--search', options.installedPath])
+      : { code: 1, stdout: '' },
+    rpmTool
+      ? options.probe('/usr/bin/rpm', ['-qf', '--queryformat', '%{NAME}', options.installedPath])
+      : { code: 1, stdout: '' },
+  ]);
+  const ownedFormats = [
+    ...(debOwner.code === 0 ? ['deb'] : []),
+    ...(rpmOwner.code === 0 ? ['rpm'] : []),
+  ];
+  if (ownedFormats.length > 1) throw ambiguousLinuxPackageError();
+
+  const distroFormats = linuxDistroFormats(options.osRelease);
+  if (ownedFormats.length === 1) {
+    const owned = ownedFormats[0];
+    if (distroFormats.length !== 1 || distroFormats[0] !== owned) throw ambiguousLinuxPackageError();
+    return owned;
+  }
+  if (options.requireOwnership) throw ambiguousLinuxPackageError();
+
+  const available = distroFormats.filter((format) => format === 'deb' ? debTool : rpmTool);
+  if (available.length !== 1) throw ambiguousLinuxPackageError();
+  return available[0];
+}
+
+export async function collectProcessAncestors(pid, platform, env = process.env) {
+  return collectProcessAncestorsWithOptions({ pid, platform, env });
+}
+
+async function collectProcessAncestorsWithOptions(options) {
+  if (options.platform === 'linux') return collectLinuxAncestors(options.pid, {
+    privilegedReadlink: options.allowPrivilegedInspection
+      ? (ancestorPid) => readLinuxExecutableWithSudo(ancestorPid, {
+        nonInteractiveYes: options.nonInteractiveYes,
+      })
+      : undefined,
+  });
+  if (options.platform === 'darwin') return collectDarwinAncestors(options.pid);
+  if (options.platform === 'win32') return collectWindowsAncestors(options.pid, options.env);
+  return [];
+}
+
+export async function collectDarwinAncestors(firstPid, runtime = {
+  probe: execFileResult,
+  isAlive: processIsAlive,
+}) {
+  const ancestors = [];
+  const visited = new Set();
+  let pid = firstPid;
+  while (pid > 1 && !visited.has(pid)) {
+    visited.add(pid);
+    const result = await runtime.probe('/bin/ps', ['-p', String(pid), '-o', 'ppid=', '-o', 'comm=']);
+    if (result.code !== 0) {
+      if (runtime.isAlive(pid)) throw processInspectionError('macOS', pid);
+      break;
+    }
+    const match = /^\s*(\d+)\s+(.+)$/u.exec(result.stdout.trim());
+    if (!match) {
+      if (runtime.isAlive(pid)) throw processInspectionError('macOS', pid);
+      break;
+    }
+    ancestors.push({ pid, executable: match[2] });
+    pid = Number.parseInt(match[1], 10);
+  }
+  return ancestors;
+}
+
+export async function collectWindowsAncestors(firstPid, _env, runtime = {
+  probe: execFileResult,
+  isAlive: processIsAlive,
+}) {
+  const powershell = String.raw`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`;
+  const script = 'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,ExecutablePath | ConvertTo-Json -Compress';
+  const result = await runtime.probe(powershell, ['-NoProfile', '-NonInteractive', '-Command', script]);
+  if (result.code !== 0) {
+    if (runtime.isAlive(firstPid)) throw processInspectionError('Windows', firstPid);
+    return [];
+  }
+  const parsed = JSON.parse(result.stdout);
+  const rows = Array.isArray(parsed) ? parsed : [parsed];
+  const byPid = new Map(rows.map((row) => [Number(row.ProcessId), row]));
+  const ancestors = [];
+  const visited = new Set();
+  let pid = firstPid;
+  while (pid > 0 && !visited.has(pid)) {
+    visited.add(pid);
+    const row = byPid.get(pid);
+    if (!row) {
+      if (runtime.isAlive(pid)) throw processInspectionError('Windows', pid);
+      break;
+    }
+    if (typeof row.ExecutablePath !== 'string' || row.ExecutablePath.length === 0) {
+      if (Number(row.ParentProcessId) === 0) break;
+      throw processInspectionError('Windows', pid);
+    }
+    ancestors.push({ pid, executable: row.ExecutablePath });
+    pid = Number(row.ParentProcessId);
+  }
+  return ancestors;
+}
+
+function linuxDistroFormats(osRelease) {
+  const values = new Set();
+  for (const line of osRelease.split('\n')) {
+    const match = /^(?:ID|ID_LIKE)=(.*)$/u.exec(line.trim());
+    if (!match) continue;
+    for (const value of match[1].replace(/^['"]|['"]$/gu, '').toLowerCase().split(/\s+/u)) values.add(value);
+  }
+  return [
+    ...([...values].some((value) => DEB_FAMILIES.has(value)) ? ['deb'] : []),
+    ...([...values].some((value) => RPM_FAMILIES.has(value)) ? ['rpm'] : []),
+  ];
+}
+
+function sameExecutable(left, right, platform) {
+  const normalize = platform === 'win32'
+    ? (value) => path.win32.normalize(value).toLowerCase()
+    : (value) => path.normalize(value);
+  return normalize(left) === normalize(right);
+}
+
+function ambiguousLinuxPackageError() {
+  return new Error('Cannot unambiguously select a DEB or RPM package from ownership, distribution, and tooling evidence.');
+}
+
+function processIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error) {
+      if (error.code === 'ESRCH') return false;
+      if (error.code === 'EPERM') return true;
+    }
+    throw error;
+  }
+}
+
+function processInspectionError(platform, pid, cause) {
+  return new Error(`Unable to inspect live process ancestry on ${platform} at PID ${pid}.`, cause ? { cause } : undefined);
+}
+
+function execFileResult(command, args) {
+  return new Promise((resolve) => {
+    execFile(command, args, { encoding: 'utf8', timeout: 15_000, windowsHide: true }, (error, stdout) => {
+      resolve({ code: error ? 1 : 0, stdout: typeof stdout === 'string' ? stdout : '' });
+    });
+  });
+}

--- a/bridge/visBridgeCli.js
+++ b/bridge/visBridgeCli.js
@@ -20,6 +20,8 @@ Usage:
   vis_bridge start [options]
   vis_bridge stop
   vis_bridge restart [options]
+  vis_bridge update [--check] [--yes|-y]
+  vis_bridge upgrade [--check] [--yes|-y]
   vis_bridge --version
 
 Options:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -11,6 +11,7 @@ directories:
 files:
   - "dist/**/*"
   - "electron/**/*"
+  - "bridge/update*.js"
   - "package.json"
   - "!**/*.{iml,o,hprof,orig,pyc,pyo,rbc,swp,csproj,sln,xproj}"
   - "!.editorconfig"

--- a/electron/updateManual.js
+++ b/electron/updateManual.js
@@ -44,7 +44,18 @@ export function createManualUpdate({
       });
       return;
     }
-    const asset = selectManualAsset(release, component, runtime.platform, runtime.arch);
+    const linuxFormat =
+      component === 'bridge' && runtime.platform === 'linux'
+        ? await runtime.resolveBridgeLinuxFormat()
+        : 'deb';
+    if (!isUsable(component, revision)) return;
+    const asset = selectManualAsset(
+      release,
+      component,
+      runtime.platform,
+      runtime.arch,
+      linuxFormat,
+    );
     sha256FromDigest(asset);
     assets.set(component, asset);
     publish(component, {

--- a/electron/updatePolicy.d.ts
+++ b/electron/updatePolicy.d.ts
@@ -2,6 +2,7 @@ export type UpdateComponent = 'app' | 'bridge';
 export type UpdatePlatform = 'darwin' | 'linux' | 'win32';
 export type UpdateArchitecture = 'x64' | 'arm64';
 export type AutomaticUpdateTarget = 'appimage' | 'deb' | 'nsis';
+export type BridgeLinuxFormat = 'deb' | 'rpm';
 
 export interface ReleaseAsset {
   readonly name: string;
@@ -28,6 +29,13 @@ export declare function selectManualAsset(
   component: UpdateComponent,
   platform: UpdatePlatform,
   arch: UpdateArchitecture,
+  linuxFormat?: BridgeLinuxFormat,
+): ReleaseAsset;
+export declare function selectBridgeAsset(
+  release: StableRelease,
+  platform: UpdatePlatform,
+  arch: UpdateArchitecture,
+  linuxFormat?: BridgeLinuxFormat,
 ): ReleaseAsset;
 export declare function selectAutomaticAppFile(
   info: unknown,

--- a/electron/updatePolicy.js
+++ b/electron/updatePolicy.js
@@ -27,9 +27,25 @@ export function parseStableRelease(value) {
   };
 }
 
-export function selectManualAsset(release, component, platform, arch) {
+export function selectManualAsset(release, component, platform, arch, linuxFormat = 'deb') {
+  if (component === 'bridge') {
+    return selectBridgeAsset(release, platform, arch, linuxFormat);
+  }
   assertSupportedTarget(platform, arch);
-  const expectedName = assetName(release.version, component, platform, arch);
+  const expectedName = assetName(release.version, component, platform, arch, linuxFormat);
+  return exactlyOneAsset(release, expectedName);
+}
+
+export function selectBridgeAsset(release, platform, arch, linuxFormat = 'deb') {
+  assertSupportedTarget(platform, arch);
+  if (platform === 'linux' && linuxFormat !== 'deb' && linuxFormat !== 'rpm') {
+    throw new DesktopUpdatePolicyError(`Unsupported Linux bridge package format: ${linuxFormat}`);
+  }
+  const expectedName = assetName(release.version, 'bridge', platform, arch, linuxFormat ?? 'deb');
+  return exactlyOneAsset(release, expectedName);
+}
+
+function exactlyOneAsset(release, expectedName) {
   const matches = release.assets.filter((asset) => asset.name === expectedName);
   if (matches.length !== 1) {
     throw new DesktopUpdatePolicyError(
@@ -41,12 +57,18 @@ export function selectManualAsset(release, component, platform, arch) {
 
 export function selectAutomaticAppFile(info, platform, arch, target) {
   assertSupportedTarget(platform, arch);
-  if (!isRecord(info) || typeof info.version !== 'string' || !AUTOMATIC_VERSION_PATTERN.test(info.version)) {
+  if (
+    !isRecord(info) ||
+    typeof info.version !== 'string' ||
+    !AUTOMATIC_VERSION_PATTERN.test(info.version)
+  ) {
     throw new DesktopUpdatePolicyError('Automatic update metadata has no stable version');
   }
   const expected = automaticAppNames(info.version, platform, arch, target);
   if (!Array.isArray(info.files) || info.files.length !== expected.names.size) {
-    throw new DesktopUpdatePolicyError('Automatic update artifact list does not match generated Vis targets');
+    throw new DesktopUpdatePolicyError(
+      'Automatic update artifact list does not match generated Vis targets',
+    );
   }
   const files = new Map();
   for (const file of info.files) {
@@ -61,12 +83,17 @@ export function selectAutomaticAppFile(info, platform, arch, target) {
       !Number.isSafeInteger(file.size) ||
       file.size <= 0
     ) {
-      throw new DesktopUpdatePolicyError('Automatic update artifact does not match the Vis release target');
+      throw new DesktopUpdatePolicyError(
+        'Automatic update artifact does not match the Vis release target',
+      );
     }
     files.set(file.url, file);
   }
   const file = files.get(expected.selected);
-  if (!file) throw new DesktopUpdatePolicyError('Automatic update manifest omits the installed Vis package target');
+  if (!file)
+    throw new DesktopUpdatePolicyError(
+      'Automatic update manifest omits the installed Vis package target',
+    );
   return { name: file.url, size: file.size, sha512: file.sha512, url: file.url };
 }
 
@@ -139,12 +166,14 @@ function checkedAssetApiUrl(rawUrl) {
     url.search ||
     url.hash
   ) {
-    throw new DesktopUpdatePolicyError('GitHub returned a release asset URL outside the official repository');
+    throw new DesktopUpdatePolicyError(
+      'GitHub returned a release asset URL outside the official repository',
+    );
   }
   return url.toString();
 }
 
-function assetName(version, component, platform, arch) {
+function assetName(version, component, platform, arch, linuxFormat) {
   if (component === 'app') {
     if (platform !== 'darwin') {
       throw new DesktopUpdatePolicyError('Manual app installers are supported only on macOS');
@@ -152,7 +181,7 @@ function assetName(version, component, platform, arch) {
     return `Vis-${version}-${arch}-MacOS.dmg`;
   }
   const platformName = { darwin: 'MacOS', linux: 'Linux', win32: 'Windows' }[platform];
-  const extension = { darwin: 'pkg', linux: 'deb', win32: 'exe' }[platform];
+  const extension = { darwin: 'pkg', linux: linuxFormat, win32: 'exe' }[platform];
   return `VisBridge-${version}-${arch}-${platformName}.${extension}`;
 }
 
@@ -176,7 +205,9 @@ function automaticAppNames(version, platform, arch, target) {
     const appImage = `Vis-${version}-${appImageArch}-Linux.AppImage`;
     const deb = `Vis-${version}-${debArch}-Linux.deb`;
     if (target !== 'appimage' && target !== 'deb') {
-      throw new DesktopUpdatePolicyError('Automatic app update target does not match the Linux package');
+      throw new DesktopUpdatePolicyError(
+        'Automatic app update target does not match the Linux package',
+      );
     }
     return { names: new Set([appImage, deb]), selected: target === 'appimage' ? appImage : deb };
   }

--- a/electron/updateRuntime.d.ts
+++ b/electron/updateRuntime.d.ts
@@ -1,9 +1,21 @@
 import type { EventEmitter } from 'node:events';
-import type { AutomaticUpdateFile, AutomaticUpdateTarget, ReleaseAsset, StableRelease, UpdateArchitecture, UpdatePlatform } from './updatePolicy.js';
+import type {
+  AutomaticUpdateFile,
+  AutomaticUpdateTarget,
+  BridgeLinuxFormat,
+  ReleaseAsset,
+  StableRelease,
+  UpdateArchitecture,
+  UpdatePlatform,
+} from './updatePolicy.js';
 
 export interface UpdateInfo {
   readonly version: string;
-  readonly files: readonly { readonly url: string; readonly size?: number; readonly sha512: string }[];
+  readonly files: readonly {
+    readonly url: string;
+    readonly size?: number;
+    readonly sha512: string;
+  }[];
 }
 
 export interface DesktopAutoUpdater extends EventEmitter {
@@ -25,6 +37,7 @@ export interface UpdateRuntime {
   readonly updater: DesktopAutoUpdater;
   getLatestRelease(): Promise<StableRelease>;
   getBridgeVersion(): Promise<string | null>;
+  resolveBridgeLinuxFormat(): Promise<BridgeLinuxFormat>;
   downloadAppUpdate(): Promise<readonly string[]>;
   downloadAsset(asset: ReleaseAsset, onProgress: (percent: number) => void): Promise<string>;
   verifyAsset(

--- a/electron/updateRuntime.js
+++ b/electron/updateRuntime.js
@@ -1,35 +1,20 @@
 import { execFile } from 'node:child_process';
-import { createHash } from 'node:crypto';
-import { createReadStream, createWriteStream, existsSync, readFileSync } from 'node:fs';
-import { chmod, mkdtemp, rm, stat } from 'node:fs/promises';
-import https from 'node:https';
-import os from 'node:os';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
-import { pipeline } from 'node:stream/promises';
 import { promisify } from 'node:util';
 import electronUpdater from 'electron-updater';
+import { detectLinuxPackageFormat } from '../bridge/updatePlatform.js';
 import { bridgeVersionPaths } from './bridgeVersionPaths.js';
-import { automaticAppUpdateTarget, parseInstalledVersion, parseStableRelease } from './updatePolicy.js';
+import { automaticAppUpdateTarget, parseInstalledVersion } from './updatePolicy.js';
+import { createUpdateTransport, isAllowedUpdateUrl } from './updateTransport.js';
 
 const execFileAsync = promisify(execFile);
-const API_URL = 'https://api.github.com/repos/qiyuanhuakai/opencode-visualizer-cn/releases/latest';
 const REQUEST_TIMEOUT_MS = 15_000;
-const DOWNLOAD_TIMEOUT_MS = 10 * 60_000;
-const MAX_METADATA_BYTES = 2 * 1024 * 1024;
-const MAX_ASSET_BYTES = 1024 * 1024 * 1024;
-const MAX_REDIRECTS = 4;
-const updateAgent = new https.Agent({ proxyEnv: process.env });
-const DOWNLOAD_HOSTS = new Set([
-  'api.github.com',
-  'github.com',
-  'objects.githubusercontent.com',
-  'release-assets.githubusercontent.com',
-]);
 const { CancellationToken } = electronUpdater;
 
 export function createUpdateRuntime() {
   const { autoUpdater } = electronUpdater;
-  const activeRequests = new Set();
+  const transport = createUpdateTransport();
   const activeDownloads = new Set();
   const versionProbe = new AbortController();
   const removeUpdaterRequestPolicy = installUpdaterRequestPolicy(autoUpdater);
@@ -39,7 +24,6 @@ export function createUpdateRuntime() {
   const assertActive = () => {
     if (disposed) throw new Error('Desktop update runtime is disposed');
   };
-
   const downloadAppUpdate = async () => {
     assertActive();
     const token = new CancellationToken();
@@ -51,13 +35,12 @@ export function createUpdateRuntime() {
       token.dispose();
     }
   };
-
   const dispose = () => {
     if (disposed) return;
     disposed = true;
     versionProbe.abort();
     for (const token of activeDownloads) token.cancel();
-    for (const requestHandle of activeRequests) requestHandle.destroy(new Error('Desktop update runtime disposed'));
+    transport.dispose();
     removeUpdaterRequestPolicy();
   };
 
@@ -69,39 +52,35 @@ export function createUpdateRuntime() {
     updater: autoUpdater,
     getLatestRelease: () => {
       assertActive();
-      return getLatestRelease(activeRequests);
+      return transport.getLatestRelease();
     },
     getBridgeVersion: () => {
       assertActive();
       return getBridgeVersion(versionProbe.signal);
     },
+    resolveBridgeLinuxFormat: () => {
+      assertActive();
+      return detectLinuxPackageFormat({ requireOwnership: true });
+    },
     downloadAsset: (asset, onProgress) => {
       assertActive();
-      return downloadAsset(asset, onProgress, activeRequests);
+      return transport.downloadAsset(asset, onProgress);
     },
     downloadAppUpdate,
-    verifyAsset,
-    removeFile: (filePath) => rm(path.dirname(filePath), { recursive: true, force: true }),
+    verifyAsset: transport.verifyAsset,
+    removeFile: transport.removeFile,
     dispose,
   };
-}
-
-async function getLatestRelease(activeRequests) {
-  const body = await requestBuffer(new URL(API_URL), 'application/vnd.github+json', MAX_METADATA_BYTES, activeRequests);
-  let payload;
-  try {
-    payload = JSON.parse(body.toString('utf8'));
-  } catch {
-    throw new Error('GitHub returned malformed release metadata');
-  }
-  return parseStableRelease(payload);
 }
 
 async function getBridgeVersion(signal) {
   for (const command of bridgeVersionPaths(process.platform, process.env.LOCALAPPDATA)) {
     try {
       const { stdout } = await execFileAsync(command, ['--version'], {
-        encoding: 'utf8', timeout: REQUEST_TIMEOUT_MS, windowsHide: true, signal,
+        encoding: 'utf8',
+        timeout: REQUEST_TIMEOUT_MS,
+        windowsHide: true,
+        signal,
       });
       const version = parseInstalledVersion(stdout);
       if (version) return version;
@@ -112,148 +91,12 @@ async function getBridgeVersion(signal) {
   return null;
 }
 
-async function downloadAsset(asset, onProgress, activeRequests) {
-  if (asset.size > MAX_ASSET_BYTES) throw new Error(`Release asset ${asset.name} exceeds the download limit`);
-  const directory = await mkdtemp(path.join(os.tmpdir(), 'vis-update-'));
-  const filePath = path.join(directory, path.basename(asset.name));
-  try {
-    await downloadToFile(new URL(asset.url), filePath, asset.size, onProgress, activeRequests);
-    await chmod(filePath, 0o600);
-    return filePath;
-  } catch (error) {
-    await rm(directory, { recursive: true, force: true });
-    throw error;
-  }
-}
-
-async function verifyAsset(filePath, asset, expectedDigest, algorithm = 'sha256') {
-  const fileStat = await stat(filePath);
-  if (!fileStat.isFile() || fileStat.size !== asset.size) {
-    throw new Error(`Downloaded asset ${asset.name} has an unexpected size`);
-  }
-  const hash = createHash(algorithm);
-  await new Promise((resolve, reject) => {
-    const stream = createReadStream(filePath);
-    stream.on('data', (chunk) => hash.update(chunk));
-    stream.on('error', reject);
-    stream.on('end', resolve);
-  });
-  const encoding = algorithm === 'sha512' ? 'base64' : 'hex';
-  if (hash.digest(encoding) !== expectedDigest) {
-    throw new Error(`Downloaded asset ${asset.name} failed ${algorithm.toUpperCase()} verification`);
-  }
-}
-
-async function requestBuffer(url, accept, maximumBytes, activeRequests, redirects = 0) {
-  const response = await request(url, accept, activeRequests);
-  if (isRedirect(response.statusCode)) {
-    response.resume();
-    return requestBuffer(redirectUrl(response, url, redirects), accept, maximumBytes, activeRequests, redirects + 1);
-  }
-  if (response.statusCode !== 200) {
-    response.resume();
-    throw new Error(`Update request failed with HTTP ${response.statusCode ?? 'unknown'}`);
-  }
-  const chunks = [];
-  let received = 0;
-  for await (const chunk of response) {
-    received += chunk.length;
-    if (received > maximumBytes) {
-      response.destroy();
-      throw new Error('Update response exceeded the size limit');
-    }
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks);
-}
-
-async function downloadToFile(url, filePath, expectedSize, onProgress, activeRequests, redirects = 0) {
-  const response = await request(url, 'application/octet-stream', activeRequests);
-  if (isRedirect(response.statusCode)) {
-    response.resume();
-    return downloadToFile(redirectUrl(response, url, redirects), filePath, expectedSize, onProgress, activeRequests, redirects + 1);
-  }
-  if (response.statusCode !== 200) {
-    response.resume();
-    throw new Error(`Asset download failed with HTTP ${response.statusCode ?? 'unknown'}`);
-  }
-  const advertisedSize = Number(response.headers['content-length']);
-  if (Number.isFinite(advertisedSize) && advertisedSize !== expectedSize) {
-    response.resume();
-    throw new Error('Asset download Content-Length does not match release metadata');
-  }
-  let received = 0;
-  await pipeline(response, async function* (source) {
-    for await (const chunk of source) {
-      received += chunk.length;
-      if (received > expectedSize || received > MAX_ASSET_BYTES) {
-        throw new Error('Asset download exceeded the declared size');
-      }
-      onProgress(Math.min(100, (received / expectedSize) * 100));
-      yield chunk;
-    }
-  }, createWriteStream(filePath, { flags: 'wx', mode: 0o600 }), {
-    signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
-  });
-  if (received !== expectedSize) throw new Error('Asset download ended before the declared size');
-}
-
-function request(url, accept, activeRequests) {
-  assertAllowedDownloadUrl(url);
-  return new Promise((resolve, reject) => {
-    const requestHandle = https.get(
-      url,
-      {
-        agent: updateAgent,
-        headers: {
-          Accept: accept,
-          'User-Agent': 'Vis-Desktop-Updater',
-          'X-GitHub-Api-Version': '2022-11-28',
-        },
-      },
-      resolve,
-    );
-    activeRequests.add(requestHandle);
-    requestHandle.once('close', () => activeRequests.delete(requestHandle));
-    requestHandle.setTimeout(REQUEST_TIMEOUT_MS, () => requestHandle.destroy(new Error('Update request timed out')));
-    requestHandle.on('error', reject);
-  });
-}
-
-function redirectUrl(response, currentUrl, redirects) {
-  if (redirects >= MAX_REDIRECTS) throw new Error('Update request exceeded the redirect limit');
-  const location = response.headers.location;
-  if (!location) throw new Error('Update redirect had no Location header');
-  const nextUrl = new URL(location, currentUrl);
-  assertAllowedDownloadUrl(nextUrl);
-  return nextUrl;
-}
-
-function assertAllowedDownloadUrl(url) {
-  if (url.protocol !== 'https:' || !DOWNLOAD_HOSTS.has(url.hostname) || url.username || url.password) {
-    throw new Error('Update URL is outside the GitHub download allowlist');
-  }
-}
-
 function installUpdaterRequestPolicy(autoUpdater) {
   const webRequest = autoUpdater.netSession.webRequest;
   webRequest.onBeforeRequest({ urls: ['<all_urls>'] }, (details, callback) => {
-    callback({ cancel: !isAllowedUpdaterUrl(details.url) });
+    callback({ cancel: !isAllowedUpdateUrl(details.url) });
   });
   return () => webRequest.onBeforeRequest(null);
-}
-
-function isAllowedUpdaterUrl(rawUrl) {
-  try {
-    const url = new URL(rawUrl);
-    return url.protocol === 'https:' && DOWNLOAD_HOSTS.has(url.hostname) && !url.username && !url.password;
-  } catch {
-    return false;
-  }
-}
-
-function isRedirect(statusCode) {
-  return statusCode === 301 || statusCode === 302 || statusCode === 303 || statusCode === 307 || statusCode === 308;
 }
 
 function detectAutomaticAppUpdateTarget() {

--- a/electron/updateTransport.d.ts
+++ b/electron/updateTransport.d.ts
@@ -1,0 +1,21 @@
+import type { Agent } from 'node:https';
+
+import type { AutomaticUpdateFile, ReleaseAsset, StableRelease } from './updatePolicy.js';
+
+export interface UpdateTransport {
+  getLatestRelease(): Promise<StableRelease>;
+  downloadAsset(asset: ReleaseAsset, onProgress?: (percent: number) => void): Promise<string>;
+  verifyAsset(
+    filePath: string,
+    asset: ReleaseAsset | AutomaticUpdateFile,
+    expectedDigest: string,
+    algorithm?: 'sha256' | 'sha512',
+  ): Promise<void>;
+  removeFile(filePath: string): Promise<void>;
+  dispose(): void;
+}
+
+export declare function createUpdateTransport(options?: {
+  readonly agent?: Agent;
+}): UpdateTransport;
+export declare function isAllowedUpdateUrl(rawUrl: string | URL): boolean;

--- a/electron/updateTransport.js
+++ b/electron/updateTransport.js
@@ -1,0 +1,186 @@
+import { createHash } from 'node:crypto';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { chmod, mkdtemp, rm, stat } from 'node:fs/promises';
+import https from 'node:https';
+import os from 'node:os';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { parseStableRelease } from './updatePolicy.js';
+
+const API_URL = 'https://api.github.com/repos/qiyuanhuakai/opencode-visualizer-cn/releases/latest';
+const REQUEST_TIMEOUT_MS = 15_000;
+const DOWNLOAD_TIMEOUT_MS = 10 * 60_000;
+const MAX_METADATA_BYTES = 2 * 1024 * 1024;
+const MAX_ASSET_BYTES = 1024 * 1024 * 1024;
+const MAX_REDIRECTS = 4;
+const DOWNLOAD_HOSTS = new Set([
+  'api.github.com',
+  'github.com',
+  'objects.githubusercontent.com',
+  'release-assets.githubusercontent.com',
+]);
+
+export function createUpdateTransport(options = {}) {
+  const agent = options.agent ?? new https.Agent({ proxyEnv: process.env });
+  const activeRequests = new Set();
+  let disposed = false;
+
+  const assertActive = () => {
+    if (disposed) throw new Error('Update transport is disposed');
+  };
+  const request = (url, accept) => {
+    assertActive();
+    assertAllowedUpdateUrl(url);
+    return new Promise((resolve, reject) => {
+      const requestHandle = https.get(url, {
+        agent,
+        headers: {
+          Accept: accept,
+          'User-Agent': 'Vis-Desktop-Updater',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      }, resolve);
+      activeRequests.add(requestHandle);
+      requestHandle.once('close', () => activeRequests.delete(requestHandle));
+      requestHandle.setTimeout(REQUEST_TIMEOUT_MS, () => requestHandle.destroy(new Error('Update request timed out')));
+      requestHandle.on('error', reject);
+    });
+  };
+  const requestBuffer = async (url, accept, maximumBytes, redirects = 0) => {
+    const response = await request(url, accept);
+    if (isRedirect(response.statusCode)) {
+      response.resume();
+      return requestBuffer(redirectUrl(response, url, redirects), accept, maximumBytes, redirects + 1);
+    }
+    if (response.statusCode !== 200) {
+      response.resume();
+      throw new Error(`Update request failed with HTTP ${response.statusCode ?? 'unknown'}`);
+    }
+    const chunks = [];
+    let received = 0;
+    for await (const chunk of response) {
+      received += chunk.length;
+      if (received > maximumBytes) {
+        response.destroy();
+        throw new Error('Update response exceeded the size limit');
+      }
+      chunks.push(chunk);
+    }
+    return Buffer.concat(chunks);
+  };
+  const getLatestRelease = async () => {
+    const body = await requestBuffer(new URL(API_URL), 'application/vnd.github+json', MAX_METADATA_BYTES);
+    try {
+      return parseStableRelease(JSON.parse(body.toString('utf8')));
+    } catch (error) {
+      if (error instanceof SyntaxError) throw new Error('GitHub returned malformed release metadata');
+      throw error;
+    }
+  };
+  const downloadAsset = async (asset, onProgress = () => undefined) => {
+    assertActive();
+    if (asset.size > MAX_ASSET_BYTES) throw new Error(`Release asset ${asset.name} exceeds the download limit`);
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'vis-update-'));
+    try {
+      await chmod(directory, 0o700);
+      const filePath = path.join(directory, path.basename(asset.name));
+      await downloadToFile(request, new URL(asset.url), filePath, asset.size, onProgress);
+      await chmod(filePath, 0o600);
+      return filePath;
+    } catch (error) {
+      await rm(directory, { recursive: true, force: true });
+      throw error;
+    }
+  };
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    for (const requestHandle of activeRequests) requestHandle.destroy(new Error('Update transport disposed'));
+  };
+  return {
+    getLatestRelease,
+    downloadAsset,
+    verifyAsset,
+    removeFile: (filePath) => rm(path.dirname(filePath), { recursive: true, force: true }),
+    dispose,
+  };
+}
+
+export function isAllowedUpdateUrl(rawUrl) {
+  try {
+    const url = rawUrl instanceof URL ? rawUrl : new URL(rawUrl);
+    return url.protocol === 'https:'
+      && DOWNLOAD_HOSTS.has(url.hostname)
+      && (url.port === '' || url.port === '443')
+      && !url.username
+      && !url.password;
+  } catch {
+    return false;
+  }
+}
+
+export async function verifyAsset(filePath, asset, expectedDigest, algorithm = 'sha256') {
+  const fileStat = await stat(filePath);
+  if (!fileStat.isFile() || fileStat.size !== asset.size) {
+    throw new Error(`Downloaded asset ${asset.name} has an unexpected size`);
+  }
+  const hash = createHash(algorithm);
+  await new Promise((resolve, reject) => {
+    const stream = createReadStream(filePath);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('error', reject);
+    stream.on('end', resolve);
+  });
+  const encoding = algorithm === 'sha512' ? 'base64' : 'hex';
+  if (hash.digest(encoding) !== expectedDigest) {
+    throw new Error(`Downloaded asset ${asset.name} failed ${algorithm.toUpperCase()} verification`);
+  }
+}
+
+async function downloadToFile(request, url, filePath, expectedSize, onProgress, redirects = 0) {
+  const response = await request(url, 'application/octet-stream');
+  if (isRedirect(response.statusCode)) {
+    response.resume();
+    return downloadToFile(request, redirectUrl(response, url, redirects), filePath, expectedSize, onProgress, redirects + 1);
+  }
+  if (response.statusCode !== 200) {
+    response.resume();
+    throw new Error(`Asset download failed with HTTP ${response.statusCode ?? 'unknown'}`);
+  }
+  const advertisedSize = Number(response.headers['content-length']);
+  if (Number.isFinite(advertisedSize) && advertisedSize !== expectedSize) {
+    response.resume();
+    throw new Error('Asset download Content-Length does not match release metadata');
+  }
+  let received = 0;
+  await pipeline(response, async function* (source) {
+    for await (const chunk of source) {
+      received += chunk.length;
+      if (received > expectedSize || received > MAX_ASSET_BYTES) {
+        throw new Error('Asset download exceeded the declared size');
+      }
+      onProgress(Math.min(100, (received / expectedSize) * 100));
+      yield chunk;
+    }
+  }, createWriteStream(filePath, { flags: 'wx', mode: 0o600 }), {
+    signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+  });
+  if (received !== expectedSize) throw new Error('Asset download ended before the declared size');
+}
+
+function redirectUrl(response, currentUrl, redirects) {
+  if (redirects >= MAX_REDIRECTS) throw new Error('Update request exceeded the redirect limit');
+  const location = response.headers.location;
+  if (!location) throw new Error('Update redirect had no Location header');
+  const nextUrl = new URL(location, currentUrl);
+  assertAllowedUpdateUrl(nextUrl);
+  return nextUrl;
+}
+
+function assertAllowedUpdateUrl(url) {
+  if (!isAllowedUpdateUrl(url)) throw new Error('Update URL is outside the GitHub download allowlist');
+}
+
+function isRedirect(statusCode) {
+  return statusCode === 301 || statusCode === 302 || statusCode === 303 || statusCode === 307 || statusCode === 308;
+}

--- a/scripts/package-vis-bridge-installer.d.mts
+++ b/scripts/package-vis-bridge-installer.d.mts
@@ -2,6 +2,13 @@ export type VisBridgeInstallerTarget = {
   readonly version: string;
   readonly platform: NodeJS.Platform;
   readonly arch: NodeJS.Architecture;
+  readonly format?: 'deb' | 'rpm';
+};
+
+export type LinuxRpmSpecOptions = {
+  readonly version: string;
+  readonly architecture: 'x86_64' | 'aarch64';
+  readonly payloadPath: string;
 };
 
 export type VisBridgeInstallerPaths = {
@@ -15,6 +22,7 @@ export class VisBridgeInstallerTargetError extends Error {}
 
 export function createNsiPath(filePath: string): string;
 export function createLinuxMaintainerScript(): string;
+export function createLinuxRpmSpec(options: LinuxRpmSpecOptions): string;
 export function createMacPreinstallScript(): string;
 export function createWindowsStopScript(): string;
 export function createWindowsInstallerScript(paths: VisBridgeInstallerPaths): string;

--- a/scripts/package-vis-bridge-installer.mjs
+++ b/scripts/package-vis-bridge-installer.mjs
@@ -7,10 +7,8 @@ import {
   createWindowsStopScript,
   windowsStopDaemonLines,
 } from './vis-bridge-installer-lifecycle.mjs';
-import {
-  packageLinuxInstaller,
-  packageMacInstaller,
-} from './vis-bridge-installer-posix.mjs';
+import { packageLinuxInstaller, packageMacInstaller } from './vis-bridge-installer-posix.mjs';
+import { createLinuxRpmSpec, packageLinuxRpmInstaller } from './vis-bridge-installer-rpm.mjs';
 import { stageNodePtyRuntime } from './vis-bridge-node-pty.mjs';
 
 export {
@@ -18,6 +16,7 @@ export {
   createMacPreinstallScript,
 } from './vis-bridge-installer-lifecycle.mjs';
 export { createWindowsStopScript };
+export { createLinuxRpmSpec };
 
 const execFileAsync = promisify(execFile);
 
@@ -45,12 +44,21 @@ function checkedArchitecture(arch) {
   return arch;
 }
 
+function checkedLinuxFormat(format) {
+  if (format !== undefined && format !== 'deb' && format !== 'rpm') {
+    throw new VisBridgeInstallerTargetError(
+      `Unsupported vis_bridge Linux installer format: ${format}`,
+    );
+  }
+  return format ?? 'deb';
+}
+
 export function createVisBridgeInstallerAssetName(target) {
   const version = normalizedVersion(target.version);
   const arch = checkedArchitecture(target.arch);
   switch (target.platform) {
     case 'linux':
-      return `VisBridge-${version}-${arch}-Linux.deb`;
+      return `VisBridge-${version}-${arch}-Linux.${checkedLinuxFormat(target.format)}`;
     case 'darwin':
       return `VisBridge-${version}-${arch}-MacOS.pkg`;
     case 'win32':
@@ -64,6 +72,12 @@ export function createVisBridgeInstallerAssetName(target) {
 
 export function createVisBridgeInstallerPaths(rootDirectory, target) {
   const installerDirectory = path.join(rootDirectory, 'dist-bridge', 'installers');
+  const linuxFormat = target.platform === 'linux' ? checkedLinuxFormat(target.format) : undefined;
+  if (target.platform !== 'linux' && target.format !== undefined) {
+    throw new VisBridgeInstallerTargetError(
+      `Unsupported vis_bridge installer format for ${target.platform}: ${target.format}`,
+    );
+  }
   return {
     binaryPath: path.join(
       rootDirectory,
@@ -76,7 +90,7 @@ export function createVisBridgeInstallerPaths(rootDirectory, target) {
       rootDirectory,
       'dist-bridge',
       'installer-work',
-      `${target.platform}-${checkedArchitecture(target.arch)}`,
+      `${target.platform}-${checkedArchitecture(target.arch)}${linuxFormat === 'rpm' ? '-rpm' : ''}`,
     ),
   };
 }
@@ -181,7 +195,11 @@ export async function packageVisBridgeInstaller(rootDirectory, target) {
   await mkdir(paths.installerDirectory, { recursive: true });
   switch (target.platform) {
     case 'linux':
-      await packageLinuxInstaller(paths, target, rootDirectory, normalizedVersion);
+      if (checkedLinuxFormat(target.format) === 'rpm') {
+        await packageLinuxRpmInstaller(paths, target, rootDirectory, normalizedVersion);
+      } else {
+        await packageLinuxInstaller(paths, target, rootDirectory, normalizedVersion);
+      }
       break;
     case 'darwin':
       await packageMacInstaller(paths, target, rootDirectory, normalizedVersion);
@@ -208,10 +226,17 @@ if (directRun) {
   if (typeof packageVersion !== 'string') {
     throw new VisBridgeInstallerTargetError('Unable to resolve the vis_bridge installer version');
   }
+  const formatArgumentIndex = process.argv.findIndex((argument) => argument === '--format');
+  const formatValue =
+    formatArgumentIndex === -1 ? undefined : process.argv[formatArgumentIndex + 1];
+  if (formatArgumentIndex !== -1 && formatValue === undefined) {
+    throw new VisBridgeInstallerTargetError('Missing value for --format');
+  }
   const installerPath = await packageVisBridgeInstaller(rootDirectory, {
     version: packageVersion,
     platform: process.platform,
     arch: process.arch,
+    format: formatValue,
   });
   process.stdout.write(`${installerPath}\n`);
 }

--- a/scripts/qa/vis-bridge-rpm-lifecycle.sh
+++ b/scripts/qa/vis-bridge-rpm-lifecycle.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+set -eu
+
+if [ "${1:-}" = '--container' ]; then
+  if [ "$#" -ne 2 ]; then
+    printf 'container usage: %s --container <release-rpm>\n' "$0" >&2
+    exit 2
+  fi
+
+  release_rpm="$2"
+  helper='/workspace/scripts/qa/vis-bridge-installer-daemon-qa.mjs'
+
+  start_process_tree() {
+    state_directory="$1"
+    port="$2"
+    evidence_path="$3"
+    VIS_BRIDGE_STATE_DIR="$state_directory" /usr/bin/vis_bridge start --port "$port"
+    node "$helper" spawn "$state_directory" "$port" "$evidence_path"
+  }
+
+  dnf install -y nodejs "$release_rpm"
+  rpm -q vis-bridge
+  /usr/bin/vis_bridge --version
+  printf 'RPM_NORMAL_INSTALL_OK\n'
+
+  dnf install -y rpm-build
+  qa_root="$(mktemp -d)"
+  trap 'rm -rf "$qa_root"' EXIT INT TERM
+  mkdir -p "$qa_root/dist-bridge" "$qa_root/node_modules"
+  cp /usr/bin/vis_bridge "$qa_root/dist-bridge/vis_bridge"
+  cp -a /usr/lib/vis_bridge/node_modules/node-pty "$qa_root/node_modules/node-pty"
+  upgrade_rpm="$(
+    node --input-type=module - "$qa_root" <<'NODE'
+import { packageVisBridgeInstaller } from '/workspace/scripts/package-vis-bridge-installer.mjs';
+
+const rootDirectory = process.argv[2];
+const installerPath = await packageVisBridgeInstaller(rootDirectory, {
+  platform: 'linux',
+  arch: process.arch,
+  format: 'rpm',
+  version: '9999.0.0',
+});
+process.stdout.write(installerPath);
+NODE
+  )"
+
+  start_process_tree /tmp/vis-bridge-rpm-install-state 23199 /tmp/vis-bridge-rpm-upgrade.json
+  dnf upgrade -y "$upgrade_rpm"
+  node "$helper" assert-stopped /tmp/vis-bridge-rpm-install-state 23199 /tmp/vis-bridge-rpm-upgrade.json
+  test "$(rpm -q --qf '%{VERSION}' vis-bridge)" = '9999.0.0'
+  printf 'RPM_UPGRADE_LIFECYCLE_OK\n'
+
+  start_process_tree /tmp/vis-bridge-rpm-remove-state 23200 /tmp/vis-bridge-rpm-remove.json
+  dnf remove -y vis-bridge
+  node "$helper" assert-stopped /tmp/vis-bridge-rpm-remove-state 23200 /tmp/vis-bridge-rpm-remove.json
+  printf 'RPM_REMOVE_LIFECYCLE_OK\n'
+  exit 0
+fi
+
+if [ "$#" -ne 1 ] || [ ! -f "$1" ]; then
+  printf 'usage: %s <release-rpm>\n' "$0" >&2
+  exit 2
+fi
+
+root_directory="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+release_rpm="$(readlink -f "$1")"
+case "$release_rpm" in
+  "$root_directory"/*) ;;
+  *)
+    printf 'release RPM must be inside %s\n' "$root_directory" >&2
+    exit 2
+    ;;
+esac
+
+docker run --rm --init \
+  -v "$root_directory:/workspace:ro" \
+  fedora:42 \
+  bash /workspace/scripts/qa/vis-bridge-rpm-lifecycle.sh \
+  --container "/workspace/${release_rpm#"$root_directory"/}"

--- a/scripts/vis-bridge-installer-lifecycle.mjs
+++ b/scripts/vis-bridge-installer-lifecycle.mjs
@@ -1,4 +1,4 @@
-function stopProcessLines(matchingCommand) {
+function stopProcessLines(matchingCommand, commandPaths) {
   return [
     'matching_vis_bridge_pids() {',
     ...matchingCommand.map((line) => `  ${line}`),
@@ -6,20 +6,20 @@ function stopProcessLines(matchingCommand) {
     'pids="$(matching_vis_bridge_pids)"',
     'if [ -n "$pids" ]; then',
     '  collect_process_tree() {',
-    '    for child in $(/usr/bin/pgrep -P "$1" 2>/dev/null || true); do collect_process_tree "$child"; done',
+    `    for child in $(${commandPaths.pgrep} -P "$1" 2>/dev/null || true); do collect_process_tree "$child"; done`,
     '    printf "%s\\n" "$1"',
     '  }',
     '  tree_pids=""',
     '  for pid in $pids; do tree_pids="$tree_pids $(collect_process_tree "$pid")"; done',
-    '  for pid in $tree_pids; do /bin/kill -TERM "$pid" 2>/dev/null || true; done',
+    `  for pid in $tree_pids; do ${commandPaths.kill} -TERM "$pid" 2>/dev/null || true; done`,
     '  # Startup readiness may still be unwinding; allow its signal cleanup to finish.',
     '  attempt=0',
-    '  tree_alive() { for pid in $tree_pids; do /bin/kill -0 "$pid" 2>/dev/null && return 0; done; return 1; }',
+    `  tree_alive() { for pid in $tree_pids; do ${commandPaths.kill} -0 "$pid" 2>/dev/null && return 0; done; return 1; }`,
     '  while [ "$attempt" -lt 350 ] && tree_alive; do',
-    '    /bin/sleep 0.1',
+    `    ${commandPaths.sleep} 0.1`,
     '    attempt=$((attempt + 1))',
     '  done',
-    '  for pid in $tree_pids; do /bin/kill -KILL "$pid" 2>/dev/null || true; done',
+    `  for pid in $tree_pids; do ${commandPaths.kill} -KILL "$pid" 2>/dev/null || true; done`,
     'fi',
   ];
 }
@@ -28,14 +28,17 @@ export function createLinuxMaintainerScript() {
   return [
     '#!/bin/sh',
     'set -e',
-    ...stopProcessLines([
-      'for executable in /proc/[0-9]*/exe; do',
-      '  [ -e "$executable" ] || continue',
-      '  [ "$(/usr/bin/readlink "$executable" 2>/dev/null || true)" = "/usr/bin/vis_bridge" ] || continue',
-      '  pid="${executable#/proc/}"',
-      '  printf "%s\\n" "${pid%/exe}"',
-      'done',
-    ]),
+    ...stopProcessLines(
+      [
+        'for executable in /proc/[0-9]*/exe; do',
+        '  [ -e "$executable" ] || continue',
+        '  [ "$(/usr/bin/readlink "$executable" 2>/dev/null || true)" = "/usr/bin/vis_bridge" ] || continue',
+        '  pid="${executable#/proc/}"',
+        '  printf "%s\\n" "${pid%/exe}"',
+        'done',
+      ],
+      { pgrep: '/usr/bin/pgrep', kill: '/usr/bin/kill', sleep: '/usr/bin/sleep' },
+    ),
     'exit 0',
     '',
   ].join('\n');
@@ -44,12 +47,15 @@ export function createLinuxMaintainerScript() {
 export function createMacPreinstallScript() {
   return [
     '#!/bin/sh',
-    ...stopProcessLines([
-      '/usr/bin/pgrep -x vis_bridge 2>/dev/null | while IFS= read -r pid; do',
-      '  executable="$(/usr/sbin/lsof -a -p "$pid" -d txt -Fn 2>/dev/null | /usr/bin/sed -n "s/^n//p" | /usr/bin/head -n 1)"',
-      '  [ "$executable" = "/usr/local/bin/vis_bridge" ] && printf "%s\\n" "$pid"',
-      'done',
-    ]),
+    ...stopProcessLines(
+      [
+        '/usr/bin/pgrep -x vis_bridge 2>/dev/null | while IFS= read -r pid; do',
+        '  executable="$(/usr/sbin/lsof -a -p "$pid" -d txt -Fn 2>/dev/null | /usr/bin/sed -n "s/^n//p" | /usr/bin/head -n 1)"',
+        '  [ "$executable" = "/usr/local/bin/vis_bridge" ] && printf "%s\\n" "$pid"',
+        'done',
+      ],
+      { pgrep: '/usr/bin/pgrep', kill: '/bin/kill', sleep: '/bin/sleep' },
+    ),
     'exit 0',
     '',
   ].join('\n');

--- a/scripts/vis-bridge-installer-posix.mjs
+++ b/scripts/vis-bridge-installer-posix.mjs
@@ -11,20 +11,29 @@ import { stageNodePtyRuntime } from './vis-bridge-node-pty.mjs';
 
 const execFileAsync = promisify(execFile);
 
-export async function packageLinuxInstaller(paths, target, rootDirectory, normalizedVersion) {
-  const binaryDirectory = path.join(paths.workspacePath, 'usr', 'bin');
-  const metadataDirectory = path.join(paths.workspacePath, 'DEBIAN');
+export async function stageLinuxRuntimePayload({ payloadPath, binaryPath, rootDirectory, target }) {
+  const binaryDirectory = path.join(payloadPath, 'usr', 'bin');
   await mkdir(binaryDirectory, { recursive: true });
-  await mkdir(metadataDirectory, { recursive: true });
   const installedBinary = path.join(binaryDirectory, 'vis_bridge');
-  await copyFile(paths.binaryPath, installedBinary);
+  await copyFile(binaryPath, installedBinary);
   await chmod(installedBinary, 0o755);
   await stageNodePtyRuntime(
     rootDirectory,
-    path.join(paths.workspacePath, 'usr', 'lib', 'vis_bridge', 'node_modules', 'node-pty'),
+    path.join(payloadPath, 'usr', 'lib', 'vis_bridge', 'node_modules', 'node-pty'),
     target.platform,
     target.arch,
   );
+}
+
+export async function packageLinuxInstaller(paths, target, rootDirectory, normalizedVersion) {
+  const metadataDirectory = path.join(paths.workspacePath, 'DEBIAN');
+  await mkdir(metadataDirectory, { recursive: true });
+  await stageLinuxRuntimePayload({
+    payloadPath: paths.workspacePath,
+    binaryPath: paths.binaryPath,
+    rootDirectory,
+    target,
+  });
   const architecture = target.arch === 'x64' ? 'amd64' : 'arm64';
   await writeFile(
     path.join(metadataDirectory, 'control'),

--- a/scripts/vis-bridge-installer-rpm.mjs
+++ b/scripts/vis-bridge-installer-rpm.mjs
@@ -1,0 +1,121 @@
+import { execFile } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { createLinuxMaintainerScript } from './vis-bridge-installer-lifecycle.mjs';
+import { stageLinuxRuntimePayload } from './vis-bridge-installer-posix.mjs';
+
+const execFileAsync = promisify(execFile);
+
+function rpmArchitecture(architecture) {
+  return architecture === 'x64' ? 'x86_64' : 'aarch64';
+}
+
+function rpmVersion(version) {
+  return version.replaceAll('-', '~');
+}
+
+function rpmLiteral(value) {
+  return value
+    .replaceAll('\\', '\\\\')
+    .replaceAll('$', '\\$')
+    .replaceAll('`', '\\`')
+    .replaceAll('"', '\\"')
+    .replaceAll('%', '%%');
+}
+
+function rpmMacroValue(value) {
+  return value.replaceAll('%', '%%');
+}
+
+function rpmLifecycleLines() {
+  return createLinuxMaintainerScript().trimEnd().split('\n').slice(1, -1);
+}
+
+export function createLinuxRpmSpec({ version, architecture, payloadPath }) {
+  const lifecycleLines = rpmLifecycleLines().map((line) => line.replaceAll('%', '%%'));
+  return [
+    '%global _enable_debug_packages 0',
+    '%global _build_id_links none',
+    '%global _no_recompute_build_ids 1',
+    '%global __os_install_post %{nil}',
+    '%global __brp_strip %{nil}',
+    '%global __brp_strip_comment_note %{nil}',
+    '%global __brp_strip_lto %{nil}',
+    '%global __brp_strip_static_archive %{nil}',
+    '%{?python_disable_dependency_generator}',
+    'Name: vis-bridge',
+    `Version: ${rpmVersion(version)}`,
+    'Release: 1',
+    'Summary: Local process supervisor and protocol bridge for Vis',
+    'License: MIT',
+    `BuildArch: ${architecture}`,
+    'Requires(pre): /bin/sh, /usr/bin/pgrep, /usr/bin/readlink, /usr/bin/kill, /usr/bin/sleep',
+    'Requires(preun): /bin/sh, /usr/bin/pgrep, /usr/bin/readlink, /usr/bin/kill, /usr/bin/sleep',
+    '',
+    '%description',
+    'Local process supervisor and protocol bridge for Vis.',
+    '',
+    '%prep',
+    '',
+    '%build',
+    '',
+    '%install',
+    'rm -rf "%{buildroot}"',
+    'mkdir -p "%{buildroot}"',
+    `cp -a "${rpmLiteral(payloadPath)}/." "%{buildroot}/"`,
+    '',
+    '%pre',
+    ...lifecycleLines,
+    'exit 0',
+    '',
+    '%preun',
+    'if [ "$1" -eq 0 ]; then',
+    ...lifecycleLines.map((line) => `  ${line}`),
+    'fi',
+    'exit 0',
+    '',
+    '%files',
+    '%defattr(-,root,root,-)',
+    '%attr(0755,root,root) /usr/bin/vis_bridge',
+    '/usr/lib/vis_bridge/node_modules/node-pty',
+    '',
+  ].join('\n');
+}
+
+export async function packageLinuxRpmInstaller(paths, target, rootDirectory, normalizedVersion) {
+  const payloadPath = path.join(paths.workspacePath, 'payload');
+  const topDirectory = path.join(paths.workspacePath, 'rpmbuild');
+  await stageLinuxRuntimePayload({
+    payloadPath,
+    binaryPath: paths.binaryPath,
+    rootDirectory,
+    target,
+  });
+  await Promise.all(
+    ['BUILD', 'BUILDROOT', 'RPMS', 'SOURCES', 'SPECS', 'SRPMS'].map((directory) =>
+      mkdir(path.join(topDirectory, directory), { recursive: true }),
+    ),
+  );
+  const specPath = path.join(topDirectory, 'SPECS', 'vis-bridge.spec');
+  await writeFile(
+    specPath,
+    createLinuxRpmSpec({
+      version: normalizedVersion(target.version),
+      architecture: rpmArchitecture(target.arch),
+      payloadPath,
+    }),
+    'utf8',
+  );
+  await execFileAsync('rpmbuild', [
+    '-bb',
+    '--define',
+    `_topdir ${rpmMacroValue(topDirectory)}`,
+    '--define',
+    `_rpmdir ${rpmMacroValue(paths.installerDirectory)}`,
+    '--define',
+    `_rpmfilename ${path.basename(paths.installerPath)}`,
+    specPath,
+  ]);
+}

--- a/vis_bridge.d.ts
+++ b/vis_bridge.d.ts
@@ -1,5 +1,6 @@
 import type { Server } from 'node:http';
 import type { BridgeRuntime } from './bridge/bridgeRuntime.js';
+export { parseBridgeUpdateArgs } from './bridge/updateCli.js';
 
 export type VisBridgeServerOptions = {
   host?: string;

--- a/vis_bridge.js
+++ b/vis_bridge.js
@@ -3,13 +3,23 @@ import { parseCliOptions, usage } from './bridge/visBridgeCli.js';
 import { createVisBridgeServer } from './bridge/visBridgeServer.js';
 import { createDaemonController } from './bridge/daemonController.js';
 import { runDaemonProcess } from './bridge/daemonProcess.js';
+import { parseBridgeUpdateArgs, runBridgeUpdate, updateUsage } from './bridge/updateCli.js';
 import packageInfo from './package.json' with { type: 'json' };
 
-export { createVisBridgeServer, parseCliOptions };
+export { createVisBridgeServer, parseBridgeUpdateArgs, parseCliOptions };
 
 export async function main() {
   if (process.argv.length === 3 && process.argv[2] === '--version') {
     console.log(packageInfo.version);
+    return;
+  }
+  const updateOptions = parseBridgeUpdateArgs();
+  if (updateOptions) {
+    if (updateOptions.help) {
+      console.log(updateUsage());
+      return;
+    }
+    await runBridgeUpdate(updateOptions, { currentVersion: packageInfo.version });
     return;
   }
   const options = parseCliOptions();


### PR DESCRIPTION
## 变更概述

上一条 PR #120 已合并。本 PR 仅包含后续终端更新与 RPM 发布功能，共 15 个提交。

### 终端手动更新
- 新增 `vis_bridge update` / `vis_bridge upgrade`，支持 `--check` 和 `--yes` / `-y`，独立于服务启动参数及环境变量解析。
- 查询正式版本，限制官方 HTTPS 下载来源，校验安装包大小与 SHA-256。
- 根据本机平台、架构和 Linux 包归属选择 DEB / RPM / PKG / NSIS；安装限于原生安装包管理的程序。
- 检查进程祖先，拒绝 bridge 托管终端更新；Linux 权限不足时使用限定命令的 sudo 身份检查，并校验进程身份未变化。
- POSIX 通过 execve 安全交接并保留安装器退出状态；Windows 等待原进程退出后安装，保留持久结果日志。
- 安装停止 bridge 及子进程，不自动重启。

### RPM 与发布链路
- 新增 Linux x64 / arm64 RPM 产物构建、元数据及载荷检查、上传与 GitHub Release 发布。
- 桌面端同步按包归属选择 RPM 更新，并保留连接失效隔离。
- 新增 Fedora 正常 dnf 安装、升级、卸载生命周期验证及 CI 接线。
- 提取桌面与终端共用的下载、校验、临时目录清理逻辑；补充中英文 README。

## 验证
- [x] 新行为及审查阻断项均有 RED → GREEN 回归证据。
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm bridge:build`
- [x] SEA 帮助、两个别名的联网 `--check`、非法参数处理实测。
- [x] `VIS_BRIDGE_NATIVE_UPDATE_QA=1 pnpm vitest run app/bridgeUpdaterTransaction.integration.test.ts`：容器内非 root 用户运行生产更新逻辑，SEA/package 从 0.7.12 更新到 0.8.0；实际执行 SHA-256 校验、身份检查、execve、sudo 和 dpkg；确认 fixture 进程树停止、无自动重启、无 staging 残留。仅版本及 release transport 使用受控 fixture。
- [x] Fedora 42 使用正常 dnf 依赖解析完成 RPM 安装、升级、卸载，无 `--nodeps`；确认实际 daemon 及子进程停止、载荷校验通过。
- [x] 五路初审发现的问题已修复，最终定向复审通过。

## 已知验证限制
- 全量 `pnpm test`：2325 通过、1 失败、6 跳过。失败为既有 `visBridgeDaemonSecurity.e2e.test.ts` 的 PTY 创建 HTTP 500；独立 `/dev/ptmx` 探针确认环境 `ENOSPC`，tmux 同样无法分配 PTY。未移除或放宽测试。
- 保留基线已有的 Vitest teardown / happy-dom 警告。
- 本机未执行完整 macOS PKG / Windows NSIS 更新事务。平台生命周期及 Windows PowerShell helper 协议测试已接入对应 CI；helper 协议测试使用假安装器，不等同于完整 NSIS 更新验证。
- 本机识别按安装路径及包归属判断；不提供远程主机安装功能。
