### PR TITLE
test(bridge): fix Windows helper cleanup race

### DIFF
--- a/app/bridgeUpdateHandoff.test.ts
+++ b/app/bridgeUpdateHandoff.test.ts
@@ -222,11 +222,19 @@ C:\Users\me\AppData\Local\Temp\vis_bridge-updates\installer.log`);
     temporaryDirectories.push(directory);
     const stagingDirectory = path.join(directory, 'staging');
     const acceptedPath = path.join(directory, 'accepted-path');
+    const cleanupReleasePath = path.join(directory, 'release-cleanup');
     const helperPath = path.join(stagingDirectory, 'install.ps1');
     const ackPath = path.join(stagingDirectory, 'ready');
     const installerPath = path.join(stagingDirectory, 'fake installer & handoff.cmd');
     await mkdir(stagingDirectory);
-    await writeFile(helperPath, createWindowsUpdateHelper());
+    const cleanupReleasePathBase64 = Buffer.from(cleanupReleasePath).toString('base64');
+    const helper = createWindowsUpdateHelper().replace(
+      '  Remove-Item -LiteralPath $StagingDirectory -Recurse -Force -ErrorAction SilentlyContinue',
+      `  $cleanupReleasePath = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${cleanupReleasePathBase64}'))
+  while (-not (Test-Path -LiteralPath $cleanupReleasePath)) { Start-Sleep -Milliseconds 10 }
+  Remove-Item -LiteralPath $StagingDirectory -Recurse -Force -ErrorAction SilentlyContinue`,
+    );
+    await writeFile(helperPath, helper);
     await writeFile(installerPath, `@exit /b ${installerExit}\r\n`);
     const moduleUrl = esmImportSpecifier(path.resolve(import.meta.dirname, '../bridge/updateHandoff.js'));
     const powershellPath = path.win32.join(process.env.SystemRoot ?? String.raw`C:\Windows`, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
@@ -252,9 +260,17 @@ C:\Users\me\AppData\Local\Temp\vis_bridge-updates\installer.log`);
     expect(driverExit, `driver exited with code ${driverExit}, signal ${driverSignal}; stderr:\n${driverStderr}`).toBe(0);
     const resultLogPath = await readFile(acceptedPath, 'utf8');
     temporaryFiles.push(resultLogPath);
-    await vi.waitFor(() => expect(existsSync(resultLogPath)).toBe(true), { timeout: 10_000 });
-
-    expect(await readFile(resultLogPath, 'utf8')).toContain(`status=${expectedStatus}`);
-    expect(existsSync(stagingDirectory)).toBe(false);
+    try {
+      await vi.waitFor(async () => {
+        expect(await readFile(resultLogPath, 'utf8')).toContain(`status=${expectedStatus}`);
+        expect(existsSync(stagingDirectory)).toBe(true);
+      }, { timeout: 10_000 });
+    } finally {
+      await writeFile(cleanupReleasePath, 'release');
+    }
+    await vi.waitFor(async () => {
+      expect(await readFile(resultLogPath, 'utf8')).toContain(`status=${expectedStatus}`);
+      expect(existsSync(stagingDirectory)).toBe(false);
+    }, { timeout: 10_000 });
   }, 20_000);
 });


### PR DESCRIPTION
## 原因
同一提交 696410f7 的 main CI 成功，但 v0.7.15 tag CI 失败。Windows helper 先写结果日志，再在 finally 中删除临时目录；测试只等待日志出现，就立即断言目录已删除，存在异步竞态。

## 修改
- 仅修改 app/bridgeUpdateHandoff.test.ts，不改生产 helper。
- 增加测试专用清理闸门，确定性覆盖日志已写入但清理尚未完成的窗口。
- 使用有界条件等待，确认日志内容正确且临时目录最终删除；保留成功和失败两条路径及全部清理断言，不以固定延时、跳过或重跑掩盖问题。

## 验证
- 原生 Windows RED：日志可读时 staging 仍存在；释放闸门后完成清理。
- 原生 Windows GREEN：成功与退出码 7 的失败路径均通过，最终目录不存在。
- Linux 聚焦 Vitest：10 passed、2 Windows-only skipped。
- vue-tsc、Oxlint、LSP、git diff --check 通过。

## 范围
仅 1 个提交、1 个测试文件。此 PR 不移动 tag，也不发布 Release。