### PR TITLE
fix(codex): 修复新会话发送与历史兼容，改善悬浮窗激活

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -76,6 +76,7 @@ All spacing derives from a 4px base.
 - **Variants**: code, diff, message, binary, term, plain.
 - **Spacing**: titlebar height 22px, inner terminal padding 4px/8px from existing chrome constants.
 - **States**: focused, minimized, closable, resizable, search-active, disabled action.
+- **Activation**: an explicit user reopen of an existing window restores it from the dock, raises it above siblings, and focuses the body without re-resolving content or changing user-set geometry; automatic refreshes go through `open` and never steal focus.
 - **Accessibility**: buttons use translated labels/titles; body remains keyboard focusable.
 - **Motion**: scale transition on open/close only.
 

--- a/app/App.vue
+++ b/app/App.vue
@@ -1114,6 +1114,10 @@ watch(showMinimizeButtons, (enabled) => {
 });
 
 function openCodexPanel() {
+  if (fw.has(CODEX_PANEL_KEY)) {
+    fw.activate(CODEX_PANEL_KEY);
+    return;
+  }
   const width = 760;
   const height = 560;
   const extent = fw.getExtent();
@@ -1339,13 +1343,19 @@ function openCodexSubpanel(panel: TopPanelCodexSubpanel) {
     openCodexPanel();
     return;
   }
+  const key = `codex-${panel}`;
+  if (fw.has(key)) {
+    fw.activate(key);
+    refreshCodexSubpanel(panel);
+    return;
+  }
   const extent = fw.getExtent();
   const x = Math.max(20, extent.width - definition.width - 36);
   const y = 96;
   const openCodexFilePreview = (path: string) => {
     void openCodexNativeFilePreview(path);
   };
-  void fw.open(`codex-${panel}`, {
+  void fw.open(key, {
     component: definition.component,
     props: createCodexSubpanelProps(codexApi, openCodexFilePreview),
     title: t(definition.titleKey),

--- a/app/backends/codex/codexAdapter.test.ts
+++ b/app/backends/codex/codexAdapter.test.ts
@@ -326,6 +326,46 @@ describe('CodexAdapter', () => {
     });
   });
 
+  it('starts the first turn on an adapter-created thread without trying to resume it', async () => {
+    MockWebSocket.instances = [];
+    const adapter = createCodexAdapter({
+      url: 'ws://localhost:4500',
+      webSocketCtor: MockWebSocket,
+    });
+
+    const started = adapter.startThread({ cwd: '/repo' });
+    const socket = MockWebSocket.instances[0]!;
+    socket.emitOpen();
+    await waitForSent(socket, 1);
+    socket.respond(1, {});
+    await waitForSent(socket, 3);
+    socket.respond(2, { thread: { id: 'thr_empty', cwd: '/repo' } });
+    await expect(started).resolves.toEqual({ thread: { id: 'thr_empty', cwd: '/repo' } });
+
+    const prompt = adapter.sendPrompt({
+      threadId: 'thr_empty',
+      text: 'First prompt.',
+      cwd: '/repo',
+    });
+    await waitForSent(socket, 4);
+
+    expect(JSON.parse(socket.sent[3] ?? '{}')).toEqual({
+      id: 3,
+      method: 'turn/start',
+      params: {
+        threadId: 'thr_empty',
+        input: [{ type: 'text', text: 'First prompt.' }],
+        cwd: '/repo',
+      },
+    });
+    socket.respond(3, { turn: { id: 'turn_first', status: 'inProgress' } });
+    await expect(prompt).resolves.toEqual({
+      threadId: 'thr_empty',
+      thread: undefined,
+      turn: { id: 'turn_first', status: 'inProgress' },
+    });
+  });
+
   it('forwards collaborationMode to turn/start when supplied via sendPrompt', async () => {
     MockWebSocket.instances = [];
     const adapter = createCodexAdapter({
@@ -654,6 +694,57 @@ describe('CodexAdapter', () => {
         input: [{ type: 'text', text: 'Continue.' }],
       },
     });
+  });
+
+  it('retries existing-thread resume without history when legacy hydration is unsupported', async () => {
+    MockWebSocket.instances = [];
+    const adapter = createCodexAdapter({
+      url: 'ws://localhost:4500',
+      webSocketCtor: MockWebSocket,
+    });
+
+    const prompt = adapter.sendPrompt({ threadId: 'thr_paginated', text: 'Continue.' });
+    const socket = MockWebSocket.instances[0]!;
+    socket.emitOpen();
+    await waitForSent(socket, 1);
+    socket.respond(1, {});
+    await waitForSent(socket, 3);
+    socket.reject(2, 'list_turns is not supported yet', -32601);
+    await waitForSent(socket, 4);
+
+    expect(JSON.parse(socket.sent[3] ?? '{}')).toEqual({
+      id: 3,
+      method: 'thread/resume',
+      params: { threadId: 'thr_paginated', excludeTurns: true },
+    });
+    socket.respond(3, { thread: { id: 'thr_paginated', turns: [] } });
+    await waitForSent(socket, 5);
+    socket.respond(4, { turn: { id: 'turn_paginated', status: 'inProgress' } });
+
+    await expect(prompt).resolves.toEqual({
+      threadId: 'thr_paginated',
+      thread: undefined,
+      turn: { id: 'turn_paginated', status: 'inProgress' },
+    });
+  });
+
+  it('propagates unrelated existing-thread resume errors without starting a turn', async () => {
+    MockWebSocket.instances = [];
+    const adapter = createCodexAdapter({
+      url: 'ws://localhost:4500',
+      webSocketCtor: MockWebSocket,
+    });
+
+    const prompt = adapter.sendPrompt({ threadId: 'thr_missing', text: 'Continue.' });
+    const socket = MockWebSocket.instances[0]!;
+    socket.emitOpen();
+    await waitForSent(socket, 1);
+    socket.respond(1, {});
+    await waitForSent(socket, 3);
+    socket.reject(2, 'thread not found', -32600);
+
+    await expect(prompt).rejects.toThrow('thread not found');
+    expect(socket.sent).toHaveLength(3);
   });
 
   it('passes cwd when resuming an existing thread and starting a prompt turn', async () => {

--- a/app/backends/codex/codexAdapter.ts
+++ b/app/backends/codex/codexAdapter.ts
@@ -15,7 +15,7 @@ import type {
   SessionUpdatePayload,
 } from '../types';
 import { CODEX_PROJECT_ID, codexBridgeHttpUrl } from './bridgeUrl';
-import { isUnmaterializedThreadError } from './errors';
+import { isUnmaterializedThreadError, isUnsupportedResumeHistoryError } from './errors';
 import { CODEX_IDEMPOTENT_RETRY_OPTIONS, type CodexIdempotentMethod } from './jsonRpcRetry';
 import { normalizeCodexTurnsToHistory } from './normalize';
 import { normalizeCodexPluginListResult } from './pluginProtocol';
@@ -83,6 +83,7 @@ export type CodexThread = {
   source?: 'main' | 'subagent';
   parentThreadId?: string;
   sessionId?: string;
+  historyMode?: 'legacy' | 'paginated';
 };
 
 export type CodexThreadListParams = {
@@ -121,6 +122,7 @@ export type CodexThreadResumeParams = {
   approvalPolicy?: string;
   sandbox?: string;
   personality?: string;
+  excludeTurns?: boolean;
 };
 
 type CodexThreadResumeResult = {
@@ -247,6 +249,7 @@ export type CodexThreadTurnsListParams = {
   cursor?: string | null;
   limit?: number;
   sortDirection?: 'asc' | 'desc';
+  itemsView?: 'notLoaded' | 'summary' | 'full';
 };
 
 type CodexThreadTurnsListResult = {
@@ -1426,6 +1429,8 @@ export class CodexAdapter implements BackendAdapter {
   private readonly mcpStatusTimeoutMs: number;
   private readonly bridgeUrl: string;
   private readonly activeTurnByThreadId = new Map<string, string>();
+  private readonly locallyStartedThreadIds = new Set<string>();
+  private resumeHistoryUnsupported = false;
   private initialized = false;
   private appServerVersion = '';
 
@@ -1493,6 +1498,8 @@ export class CodexAdapter implements BackendAdapter {
   disconnect() {
     this.initialized = false;
     this.appServerVersion = '';
+    this.locallyStartedThreadIds.clear();
+    this.resumeHistoryUnsupported = false;
     this.client.disconnect();
   }
 
@@ -1547,12 +1554,27 @@ export class CodexAdapter implements BackendAdapter {
 
   async startThread(params: CodexThreadStartParams = {}) {
     await this.ensureInitialized();
-    return this.client.request<CodexThreadStartResult>('thread/start', params);
+    const result = await this.client.request<CodexThreadStartResult>('thread/start', params);
+    this.locallyStartedThreadIds.add(result.thread.id);
+    return result;
   }
 
   async resumeThread(params: CodexThreadResumeParams) {
     await this.ensureInitialized();
-    return this.client.request<CodexThreadResumeResult>('thread/resume', params);
+    const resumeParams =
+      this.resumeHistoryUnsupported && params.excludeTurns === undefined
+        ? { ...params, excludeTurns: true }
+        : params;
+    try {
+      return await this.client.request<CodexThreadResumeResult>('thread/resume', resumeParams);
+    } catch (error) {
+      if (params.excludeTurns !== undefined || !isUnsupportedResumeHistoryError(error)) throw error;
+      this.resumeHistoryUnsupported = true;
+      return this.client.request<CodexThreadResumeResult>('thread/resume', {
+        ...params,
+        excludeTurns: true,
+      });
+    }
   }
 
   async setThreadName(params: CodexThreadNameSetParams) {
@@ -1639,7 +1661,7 @@ export class CodexAdapter implements BackendAdapter {
     if (!threadId) {
       throw new Error('Codex prompt requires a threadId or a started thread.');
     }
-    if (input.threadId) {
+    if (input.threadId && !this.locallyStartedThreadIds.has(input.threadId)) {
       try {
         await this.resumeThread({
           threadId: input.threadId,
@@ -1678,6 +1700,7 @@ export class CodexAdapter implements BackendAdapter {
       personality: input.personality,
       outputSchema: input.outputSchema,
     });
+    this.locallyStartedThreadIds.delete(threadId);
 
     return {
       threadId,

--- a/app/backends/codex/errors.ts
+++ b/app/backends/codex/errors.ts
@@ -1,8 +1,21 @@
+import { CodexJsonRpcError } from './jsonRpcClient';
+
 export function isUnmaterializedThreadError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return (
     /not materialized/i.test(message) ||
     /includeTurns is unavailable/i.test(message) ||
     /no rollout found/i.test(message)
+  );
+}
+
+export function isUnsupportedCodexMethodError(error: unknown): error is CodexJsonRpcError {
+  return error instanceof CodexJsonRpcError && error.code === -32601;
+}
+
+export function isUnsupportedResumeHistoryError(error: unknown): error is CodexJsonRpcError {
+  return (
+    isUnsupportedCodexMethodError(error) &&
+    /(?:list_turns|thread\/turns\/list).*(?:not supported|unsupported)/iu.test(error.message)
   );
 }

--- a/app/backends/codex/history.test.ts
+++ b/app/backends/codex/history.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CodexAdapter } from './codexAdapter';
+import { CodexJsonRpcError } from './jsonRpcClient';
+import { createCodexHistoryReader } from './history';
+
+type HistorySource = Pick<CodexAdapter, 'listThreadTurns' | 'readThread'>;
+
+function createSource(): HistorySource {
+  return {
+    readThread: vi.fn<HistorySource['readThread']>(),
+    listThreadTurns: vi.fn<HistorySource['listThreadTurns']>(),
+  };
+}
+
+describe('createCodexHistoryReader', () => {
+  it('falls back from unsupported hydrated reads and retrieves every full turn page', async () => {
+    const source = createSource();
+    vi.mocked(source.readThread)
+      .mockRejectedValueOnce(new CodexJsonRpcError(-32601, 'list_turns is not supported yet'))
+      .mockResolvedValueOnce({
+        thread: { id: 'thr_paginated', name: 'Paginated', historyMode: 'paginated' },
+      });
+    vi.mocked(source.listThreadTurns)
+      .mockResolvedValueOnce({
+        data: [{ id: 'turn_1', items: [{ type: 'userMessage' }] }],
+        nextCursor: 'page-2',
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'turn_2', items: [{ type: 'agentMessage' }] }],
+        nextCursor: null,
+      });
+
+    const readHistory = createCodexHistoryReader(source);
+    const result = await readHistory('thr_paginated');
+
+    expect(result).toEqual({
+      thread: {
+        id: 'thr_paginated',
+        name: 'Paginated',
+        historyMode: 'paginated',
+        turns: [
+          { id: 'turn_1', items: [{ type: 'userMessage' }] },
+          { id: 'turn_2', items: [{ type: 'agentMessage' }] },
+        ],
+      },
+    });
+    expect(source.listThreadTurns).toHaveBeenNthCalledWith(1, {
+      threadId: 'thr_paginated',
+      limit: 100,
+      sortDirection: 'asc',
+      itemsView: 'full',
+    });
+    expect(source.listThreadTurns).toHaveBeenNthCalledWith(2, {
+      threadId: 'thr_paginated',
+      cursor: 'page-2',
+      limit: 100,
+      sortDirection: 'asc',
+      itemsView: 'full',
+    });
+  });
+
+  it('scopes unsupported hydrated-read capability to one reader runtime', async () => {
+    const firstSource = createSource();
+    vi.mocked(firstSource.readThread)
+      .mockRejectedValueOnce(new CodexJsonRpcError(-32601, 'list_turns is not supported yet'))
+      .mockResolvedValueOnce({ thread: { id: 'thr_1' } })
+      .mockResolvedValueOnce({ thread: { id: 'thr_2' } });
+    vi.mocked(firstSource.listThreadTurns).mockResolvedValue({ data: [], nextCursor: null });
+    const firstRuntimeReader = createCodexHistoryReader(firstSource);
+
+    await firstRuntimeReader('thr_1');
+    await firstRuntimeReader('thr_2');
+
+    expect(firstSource.readThread).toHaveBeenNthCalledWith(3, {
+      threadId: 'thr_2',
+      includeTurns: false,
+    });
+
+    const secondSource = createSource();
+    vi.mocked(secondSource.readThread).mockResolvedValue({
+      thread: { id: 'thr_3', turns: [{ id: 'turn_3' }] },
+    });
+
+    await createCodexHistoryReader(secondSource)('thr_3');
+
+    expect(secondSource.readThread).toHaveBeenCalledWith({
+      threadId: 'thr_3',
+      includeTurns: true,
+    });
+  });
+
+  it('treats an unmaterialized thread as empty without disabling hydrated reads', async () => {
+    const source = createSource();
+    vi.mocked(source.readThread)
+      .mockRejectedValueOnce(
+        new CodexJsonRpcError(
+          -32600,
+          'thread thr_empty is not materialized yet; includeTurns is unavailable before first user message',
+        ),
+      )
+      .mockResolvedValueOnce({ thread: { id: 'thr_empty', historyMode: 'paginated' } })
+      .mockResolvedValueOnce({ thread: { id: 'thr_existing', turns: [{ id: 'turn_1' }] } });
+
+    const readHistory = createCodexHistoryReader(source);
+
+    await expect(readHistory('thr_empty')).resolves.toEqual({
+      thread: { id: 'thr_empty', historyMode: 'paginated', turns: [] },
+    });
+    await readHistory('thr_existing');
+
+    expect(source.listThreadTurns).not.toHaveBeenCalled();
+    expect(source.readThread).toHaveBeenNthCalledWith(3, {
+      threadId: 'thr_existing',
+      includeTurns: true,
+    });
+  });
+
+  it('propagates real hydrated-read failures without replacing stored history with empty turns', async () => {
+    const source = createSource();
+    const failure = new CodexJsonRpcError(-32600, 'invalid params: malformed thread id');
+    vi.mocked(source.readThread).mockRejectedValue(failure);
+
+    await expect(createCodexHistoryReader(source)('thr_bad')).rejects.toBe(failure);
+    expect(source.readThread).toHaveBeenCalledOnce();
+    expect(source.listThreadTurns).not.toHaveBeenCalled();
+  });
+
+  it('propagates an unsupported paginated read instead of reporting empty history', async () => {
+    const source = createSource();
+    vi.mocked(source.readThread)
+      .mockRejectedValueOnce(new CodexJsonRpcError(-32601, 'list_turns is not supported yet'))
+      .mockResolvedValueOnce({ thread: { id: 'thr_history', historyMode: 'paginated' } });
+    const failure = new CodexJsonRpcError(-32601, 'Method not found');
+    vi.mocked(source.listThreadTurns).mockRejectedValue(failure);
+
+    await expect(createCodexHistoryReader(source)('thr_history')).rejects.toBe(failure);
+  });
+});

--- a/app/backends/codex/history.ts
+++ b/app/backends/codex/history.ts
@@ -1,0 +1,59 @@
+import type { CodexAdapter, CodexThreadReadResult, CodexTurn } from './codexAdapter';
+import { isUnmaterializedThreadError, isUnsupportedCodexMethodError } from './errors';
+
+const HISTORY_PAGE_SIZE = 100;
+
+type CodexHistorySource = Pick<CodexAdapter, 'listThreadTurns' | 'readThread'>;
+
+async function readPaginatedHistory(
+  source: CodexHistorySource,
+  threadId: string,
+): Promise<CodexThreadReadResult> {
+  const metadata = await source.readThread({ threadId, includeTurns: false });
+  const turns: CodexTurn[] = [];
+  let cursor: string | null | undefined;
+
+  try {
+    do {
+      const page = await source.listThreadTurns({
+        threadId,
+        ...(cursor ? { cursor } : {}),
+        limit: HISTORY_PAGE_SIZE,
+        sortDirection: 'asc',
+        itemsView: 'full',
+      });
+      turns.push(...page.data);
+      cursor = page.nextCursor;
+    } while (cursor);
+  } catch (error) {
+    if (!isUnmaterializedThreadError(error) || turns.length > 0) throw error;
+  }
+
+  return {
+    ...metadata,
+    thread: {
+      ...metadata.thread,
+      turns,
+    },
+  };
+}
+
+export function createCodexHistoryReader(source: CodexHistorySource) {
+  let hydratedReadUnsupported = false;
+
+  return async (threadId: string): Promise<CodexThreadReadResult> => {
+    if (hydratedReadUnsupported) return readPaginatedHistory(source, threadId);
+
+    try {
+      return await source.readThread({ threadId, includeTurns: true });
+    } catch (error) {
+      if (isUnmaterializedThreadError(error)) {
+        const metadata = await source.readThread({ threadId, includeTurns: false });
+        return { ...metadata, thread: { ...metadata.thread, turns: [] } };
+      }
+      if (!isUnsupportedCodexMethodError(error)) throw error;
+      hydratedReadUnsupported = true;
+      return readPaginatedHistory(source, threadId);
+    }
+  };
+}

--- a/app/composables/useCodexApi.test.ts
+++ b/app/composables/useCodexApi.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useCodexApi } from './useCodexApi';
 import type { CodexAdapter, CodexPromptResult } from '../backends/codex/codexAdapter';
-import type { CodexJsonRpcId, CodexJsonRpcNotification } from '../backends/codex/jsonRpcClient';
+import {
+  CodexJsonRpcError,
+  type CodexJsonRpcId,
+  type CodexJsonRpcNotification,
+} from '../backends/codex/jsonRpcClient';
 import type { ToolStatePending } from '../types/sse';
 import {
   StorageKeys,
@@ -46,6 +50,7 @@ function createAdapterMock() {
       nextCursor: null,
     }),
     startThread: vi.fn().mockResolvedValue({ thread: { id: 'thr_new', preview: '' } }),
+    listThreadTurns: vi.fn().mockResolvedValue({ data: [], nextCursor: null }),
     readThread: vi.fn((params: { threadId: string }) =>
       Promise.resolve({
         thread: {
@@ -723,6 +728,42 @@ describe('useCodexApi', () => {
     }
   });
 
+  it('redetects hydrated history support when the same adapter reconnects', async () => {
+    // Given: this connection has already fallen back to paginated history.
+    const mock = createAdapterMock();
+    mock.adapter.readThread = vi.fn()
+      .mockRejectedValueOnce(new CodexJsonRpcError(-32601, 'list_turns is not supported yet'))
+      .mockResolvedValue({ thread: { id: 'thr_existing' } });
+    mock.adapter.listThreadTurns = vi.fn().mockResolvedValue({
+      data: [{ id: 'turn_old', items: [{ type: 'agentMessage', id: 'old', text: 'Old runtime' }] }],
+      nextCursor: null,
+    });
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    await api.selectThread('thr_existing');
+    api.disconnect();
+    mock.adapter.readThread = vi.fn().mockResolvedValue({
+      thread: {
+        id: 'thr_existing',
+        turns: [{ id: 'turn_new', items: [{ type: 'agentMessage', id: 'new', text: 'New runtime' }] }],
+      },
+    });
+    mock.adapter.listThreadTurns = vi.fn().mockRejectedValue(
+      new CodexJsonRpcError(-32601, 'Method not found'),
+    );
+
+    // When: the same adapter reconnects to a runtime supporting hydrated reads.
+    await api.connect();
+    await api.selectThread('thr_existing');
+
+    // Then: old connection capabilities do not force unsupported pagination.
+    expect(mock.adapter.readThread).toHaveBeenCalledWith({
+      threadId: 'thr_existing', includeTurns: true,
+    });
+    expect(mock.adapter.listThreadTurns).not.toHaveBeenCalled();
+    expect(api.transcript.value.map((entry) => entry.text)).toEqual(['New runtime']);
+  });
+
   it('sends Codex image input items without degrading them to file text', async () => {
     const mock = createAdapterMock();
     const api = useCodexApi({ adapterFactory: () => mock.adapter });
@@ -1015,6 +1056,52 @@ describe('useCodexApi', () => {
     expect(api.activeThreadId.value).toBe('thr_empty');
     expect(api.canonicalHistory.value).toEqual([]);
     expect(api.errorMessage.value).toBe('');
+  });
+
+  it('loads paginated full history when legacy hydrated reads are unsupported', async () => {
+    const mock = createAdapterMock();
+    mock.adapter.readThread = vi
+      .fn()
+      .mockRejectedValueOnce(new CodexJsonRpcError(-32601, 'list_turns is not supported yet'))
+      .mockResolvedValueOnce({
+        thread: { id: 'thr_paginated', name: 'Paginated', historyMode: 'paginated' },
+      });
+    mock.adapter.listThreadTurns = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 'turn_1',
+            items: [
+              { type: 'userMessage', id: 'u1', content: [{ type: 'text', text: 'First prompt' }] },
+            ],
+          },
+        ],
+        nextCursor: 'page-2',
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'turn_2', items: [{ type: 'agentMessage', id: 'a1', text: 'Final answer' }] }],
+        nextCursor: null,
+      });
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+
+    await api.connect();
+    await api.selectThread('thr_paginated');
+
+    expect(mock.adapter.listThreadTurns).toHaveBeenNthCalledWith(1, {
+      threadId: 'thr_paginated',
+      limit: 100,
+      sortDirection: 'asc',
+      itemsView: 'full',
+    });
+    expect(api.canonicalHistory.value.map((entry) => entry.info.role)).toEqual([
+      'user',
+      'assistant',
+    ]);
+    expect(api.transcript.value.map((entry) => entry.text)).toEqual([
+      'First prompt',
+      'Final answer',
+    ]);
   });
 
   it('keeps the newest thread selection when an older read resolves last', async () => {

--- a/app/composables/useCodexApi.ts
+++ b/app/composables/useCodexApi.ts
@@ -44,6 +44,7 @@ import {
 import { appendCodexBridgeToken, codexBridgeHttpUrl } from '../backends/codex/bridgeUrl';
 import { createCodexCapabilityRegistry } from '../backends/codex/capabilityRegistry';
 import { isUnmaterializedThreadError } from '../backends/codex/errors';
+import { createCodexHistoryReader } from '../backends/codex/history';
 import type {
   CodexJsonRpcId,
   CodexJsonRpcNotification,
@@ -633,6 +634,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   const capabilityRegistry = createCodexCapabilityRegistry();
 
   let adapter: CodexAdapter | null = null;
+  const historyReaders = new WeakMap<CodexAdapter, ReturnType<typeof createCodexHistoryReader>>();
   let unsubscribeNotifications: (() => void) | null = null;
   let unsubscribeServerRequests: (() => void) | null = null;
   let nextEventId = 1;
@@ -1858,6 +1860,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     unsubscribeNotifications = null;
     unsubscribeServerRequests?.();
     unsubscribeServerRequests = null;
+    if (adapter) historyReaders.delete(adapter);
     adapter?.disconnect();
     adapter = null;
     capabilityRegistry.reset();
@@ -2199,14 +2202,12 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     sourceAdapter: CodexAdapter | null = adapter,
   ): Promise<CodexThreadReadResult> {
     if (!sourceAdapter) throw new Error('Codex is not connected.');
-    try {
-      const read = await sourceAdapter.readThread({ threadId, includeTurns: true });
-      return mergeThreadReadResult(read, threadId);
-    } catch (error) {
-      if (!isUnmaterializedThreadError(error)) throw error;
-      const read = await sourceAdapter.readThread({ threadId, includeTurns: false });
-      return mergeThreadReadResult(read, threadId);
+    let readHistory = historyReaders.get(sourceAdapter);
+    if (!readHistory) {
+      readHistory = createCodexHistoryReader(sourceAdapter);
+      historyReaders.set(sourceAdapter, readHistory);
     }
+    return mergeThreadReadResult(await readHistory(threadId), threadId);
   }
 
   async function hydrateThreadImages(entries: CodexCanonicalHistoryEntry[]) {

--- a/app/composables/useFloatingWindows.activate.test.ts
+++ b/app/composables/useFloatingWindows.activate.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createApp, defineComponent, nextTick } from 'vue';
+import { createI18n } from 'vue-i18n';
+import { useFloatingWindows } from './useFloatingWindows';
+
+function mountFloatingWindows() {
+  let api: ReturnType<typeof useFloatingWindows> | undefined;
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  const app = createApp(
+    defineComponent({
+      setup() {
+        api = useFloatingWindows();
+        return () => null;
+      },
+    }),
+  );
+  app.use(createI18n({ legacy: false, locale: 'en', messages: { en: {} } }));
+  app.mount(root);
+  if (!api) throw new Error('Floating window composable did not mount.');
+  return {
+    api,
+    unmount() {
+      app.unmount();
+      root.remove();
+    },
+  };
+}
+
+function mountWindowBody(key: string): HTMLElement {
+  const host = document.createElement('div');
+  host.setAttribute('data-floating-key', key);
+  const body = document.createElement('div');
+  body.className = 'floating-window-body';
+  body.tabIndex = 0;
+  host.appendChild(body);
+  document.body.appendChild(host);
+  return body;
+}
+
+describe('useFloatingWindows explicit activation', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('restores a minimized window and brings it forward on explicit activation', async () => {
+    // Given: a minimized manual panel sits behind a later window
+    const mounted = mountFloatingWindows();
+    mounted.api.setExtent(1280, 720);
+    await mounted.api.open('codex-panel', {
+      title: 'Panel',
+      closable: true,
+      expiry: Infinity,
+    });
+    await mounted.api.open('codex-models', {
+      title: 'Models',
+      closable: true,
+      expiry: Infinity,
+    });
+    mounted.api.minimize('codex-panel');
+    const behindZ = mounted.api.get('codex-models')?.zIndex;
+
+    // When: the user explicitly reopens the existing panel
+    mounted.api.activate('codex-panel');
+
+    // Then: the panel leaves the dock and stacks above the later window
+    expect(mounted.api.get('codex-panel')).toMatchObject({ minimized: false });
+    expect(mounted.api.get('codex-panel')?.zIndex).toBeGreaterThan(behindZ ?? 0);
+    mounted.unmount();
+  });
+
+  it('brings an already visible existing window forward on explicit activation', async () => {
+    // Given: two visible manual windows where the later one is on top
+    const mounted = mountFloatingWindows();
+    mounted.api.setExtent(1280, 720);
+    await mounted.api.open('codex-panel', {
+      title: 'Panel',
+      closable: true,
+      expiry: Infinity,
+    });
+    await mounted.api.open('codex-config', {
+      title: 'Config',
+      closable: true,
+      expiry: Infinity,
+    });
+    const topZ = mounted.api.get('codex-config')?.zIndex ?? 0;
+
+    // When: the user explicitly reopens the earlier window
+    mounted.api.activate('codex-panel');
+
+    // Then: the earlier window rises above the previously topmost window
+    expect(mounted.api.get('codex-panel')?.zIndex).toBeGreaterThan(topZ);
+    mounted.unmount();
+  });
+
+  it('focuses the floating window body on explicit activation', async () => {
+    // Given: a rendered manual panel whose body is in the document
+    const mounted = mountFloatingWindows();
+    mounted.api.setExtent(1280, 720);
+    await mounted.api.open('codex-panel', {
+      title: 'Panel',
+      closable: true,
+      expiry: Infinity,
+    });
+    const body = mountWindowBody('codex-panel');
+    mounted.api.minimize('codex-panel');
+
+    // When: the user explicitly reopens the panel and the DOM settles
+    mounted.api.activate('codex-panel');
+    await nextTick();
+
+    // Then: keyboard focus lands inside the restored panel body
+    expect(document.activeElement).toBe(body);
+    mounted.unmount();
+  });
+
+  it('does not re-resolve content or reset user geometry on explicit activation', async () => {
+    // Given: an existing panel with resolved content and user-controlled geometry
+    const mounted = mountFloatingWindows();
+    mounted.api.setExtent(1280, 720);
+    await mounted.api.open('codex-panel', {
+      title: 'Panel',
+      content: 'resolved content',
+      closable: true,
+      expiry: Infinity,
+    });
+    mounted.api.updateOptions('codex-panel', { x: 340, y: 260, width: 900, height: 620 });
+    mounted.api.minimize('codex-panel');
+
+    // When: the user explicitly reopens the panel
+    mounted.api.activate('codex-panel');
+
+    // Then: content and geometry stay exactly as the user left them
+    expect(mounted.api.get('codex-panel')).toMatchObject({
+      resolvedHtml: 'resolved content',
+      x: 340,
+      y: 260,
+      width: 900,
+      height: 620,
+      minimized: false,
+    });
+    mounted.unmount();
+  });
+
+  it('preserves explicit activation while an older open is pending', async () => {
+    // Given: a background update is waiting while another window sits above it.
+    const mounted = mountFloatingWindows();
+    mounted.api.setExtent(1280, 720);
+    await mounted.api.open('codex-models', { closable: true, expiry: Infinity });
+    await mounted.api.open('codex-panel', { closable: true, expiry: Infinity });
+    const pending = Promise.withResolvers<void>();
+    const update = mounted.api.open('codex-models', { beforeOpen: () => pending.promise });
+
+    // When: explicit activation races with completion of that update.
+    mounted.api.activate('codex-models');
+    const activatedZ = mounted.api.get('codex-models')?.zIndex;
+    pending.resolve();
+    await update;
+
+    // Then: the stale update cannot put the activated window behind its sibling.
+    expect(mounted.api.get('codex-models')?.zIndex).toBe(activatedZ);
+    expect(mounted.api.get('codex-models')?.zIndex).toBeGreaterThan(
+      mounted.api.get('codex-panel')?.zIndex ?? 0,
+    );
+    mounted.unmount();
+  });
+
+  it('does not steal focus when an existing window is refreshed through open', async () => {
+    // Given: a rendered existing panel whose body could receive focus
+    const mounted = mountFloatingWindows();
+    mounted.api.setExtent(1280, 720);
+    await mounted.api.open('stream-window', {
+      title: 'Stream',
+      closable: true,
+      focusOnOpen: true,
+      expiry: Infinity,
+    });
+    const body = mountWindowBody('stream-window');
+
+    // When: an automatic streaming update reopens the same key with focusOnOpen
+    await mounted.api.open('stream-window', { title: 'Stream updated' });
+    await nextTick();
+
+    // Then: the update cannot move keyboard focus into the window
+    expect(document.activeElement).not.toBe(body);
+    mounted.unmount();
+  });
+});

--- a/app/composables/useFloatingWindows.ts
+++ b/app/composables/useFloatingWindows.ts
@@ -244,6 +244,16 @@ export function useFloatingWindows() {
     renderVersionMap.clear();
   });
 
+  function focusWindowBody(key: string): void {
+    nextTick(() => {
+      const body = document.querySelector(
+        `[data-floating-key="${key}"] .floating-window-body`,
+      ) as HTMLElement | null;
+      if (!body) return;
+      body.focus();
+    });
+  }
+
   async function open(key: string, opts: Partial<FloatingWindowEntry>): Promise<void> {
     const openToken = Symbol(key);
     activeOpenTokens.set(key, openToken);
@@ -290,6 +300,7 @@ export function useFloatingWindows() {
       merged.width = liveEntry.width;
       merged.height = liveEntry.height;
       merged.minimized = liveEntry.minimized;
+      merged.zIndex = liveEntry.zIndex;
     }
     if (!liveEntry && !clampEntryForCreation(merged, extent)) pendingInitialLayoutKeys.add(key);
 
@@ -359,13 +370,7 @@ export function useFloatingWindows() {
     }
 
     if (shouldFocusOnOpen) {
-      nextTick(() => {
-        const body = document.querySelector(
-          `[data-floating-key="${key}"] .floating-window-body`,
-        ) as HTMLElement | null;
-        if (!body) return;
-        body.focus();
-      });
+      focusWindowBody(key);
     }
   }
 
@@ -489,6 +494,16 @@ export function useFloatingWindows() {
     bringToFront(key);
   }
 
+  // Explicit user activation only: unlike open(), never re-resolves content,
+  // resets geometry, or runs on automatic updates.
+  function activate(key: string): void {
+    const entry = entriesMap.get(key);
+    if (!entry) return;
+    entry.minimized = false;
+    bringToFront(key);
+    focusWindowBody(key);
+  }
+
   function extend(key: string, ms: number): void {
     const entry = entriesMap.get(key);
     if (entry) {
@@ -558,6 +573,7 @@ export function useFloatingWindows() {
     bringToFront,
     minimize,
     restore,
+    activate,
     extend,
     close,
     closeAll,

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -1,5 +1,48 @@
 # Codex App Server
 
+## VIS 适配与运行时差异（2026-09-09）
+
+本节依据[官方 App Server 文档](https://learn.chatgpt.com/docs/app-server)（[Markdown 原文](https://learn.chatgpt.com/docs/app-server.md)）补充，并与本机 **Codex app-server 0.153.4** 的真实 JSON-RPC 响应交叉验证。下文保留协议参考；文档描述、生成的类型存在，并不代表当前服务的存储实现支持该能力。
+
+### 新会话与历史加载必须分离
+
+- 每条连接先完成 `initialize` → `initialized`。新会话使用 `thread/start` → `turn/start`；`thread/start` 已订阅该线程事件，首发不需要再 `thread/resume`。
+- 已有会话使用 `thread/resume` → `turn/start`。恢复只加载上下文，不启动生成；`thread/read` 与 `thread/turns/list` 仅用于读取展示历史，不能替代恢复订阅。
+- 0.153.4 的本地持久线程实测返回 `historyMode: "paginated"`。官方页面仍描述 paginated 创建暂不支持，因此 VIS 不按版本号或文档断言能力，而以当前连接的响应选择兼容路径。
+
+新建持久线程尚未发送第一条用户消息时，实测为：
+
+| 请求 | 实际结果 |
+| --- | --- |
+| `thread/read`，`includeTurns: true` | `-32601`，`list_turns is not supported yet` |
+| `thread/turns/list`，`itemsView: "full"` | `-32600`，`is not materialized yet; thread/turns/list is unavailable before first user message` |
+| `thread/read`，`includeTurns: false` | 成功返回线程元数据 |
+| `thread/resume`（首条消息前） | 可能返回 `no rollout found`；不能据此丢弃当前已启动线程 |
+
+VIS 对本连接创建、尚未成功首发的线程直接调用 `turn/start`，保留同一个线程 ID。历史分页的“尚未物化”是单线程状态，不是服务器全局不支持分页。
+
+### 完整历史与恢复的兼容路径
+
+1. 优先 `thread/read({ threadId, includeTurns: true })`，保留旧版服务器的历史读取方式。
+2. 遇到不支持错误后，读取元数据，再用 `thread/turns/list({ threadId, sortDirection: "asc", itemsView: "full", limit: 100 })`，沿 `nextCursor` 读取全部页面。只请求默认 `summary` 会丢失完整 item 数据，不能作为完整对话展示。
+3. 明确的首条消息前“尚未物化”可视为空历史；其他错误必须向上传递。分页不可用不能伪装为空会话，更不能清空已有历史。兼容性缓存不跨适配器连接复用。
+4. `thread/resume` 若因 `-32601`、`list_turns ... not supported` 失败，重试 `excludeTurns: true`，将恢复订阅与展示历史分开。该字段是实验字段；其他错误不触发这一重试。
+5. `thread/turns/list` / `thread/items/list` 及相关实验字段需要 `capabilities.experimentalApi: true`。开启实验 API 不是存储能力保证；`thread/items/list` 仍可能返回不支持。
+
+分页响应包含 `data`、`nextCursor`，以及可选的反向游标 `backwardsCursor`。默认排序是最新优先；VIS 的完整历史加载显式选择 `asc`，按时间顺序拼接。`itemsView` 的值为 `notLoaded`、`summary`（默认）、`full`。
+
+临时线程（`ephemeral: true`）没有持久历史：实测 `thread/read(includeTurns: true)` 与 `thread/turns/list` 均返回 `-32600`。不要将其错误缓存成所有持久线程的能力状态。VIS 当前新会话流程创建持久线程。
+
+### 会话与悬浮窗交互约束
+
+- 历史读取保持线程选择代际隔离，过期响应不能覆盖当前会话；实时 reasoning/tool 辅助历史仍需合并，不能假设所有服务器历史接口都会返回这些 item。
+- 用户再次点击已有 Codex 面板/子面板入口时，恢复最小化、置前并聚焦，保留拖动位置和尺寸。自动内容更新不应抢焦点或恢复用户主动最小化的窗口。
+- 本节不改变 VIS 既有归档语义：可恢复归档仍为本地隐藏状态；原生 `thread/archive` 对应现有 Delete 动作，不因上游新增 `thread/delete` 自动更换行为。
+
+实现参考：上游 [`thread_processor.rs`](https://github.com/openai/codex/blob/8afccec87aa15f73ee7fc35a3a4e7834afc5ef62/codex-rs/app-server/src/request_processors/thread_processor.rs) 与 [`thread-store/src/store.rs`](https://github.com/openai/codex/blob/8afccec87aa15f73ee7fc35a3a4e7834afc5ef62/codex-rs/thread-store/src/store.rs)。协议的新方法必须另行验证实际能力后再暴露 UI，不按本文补充清单自动启用。
+
+## 官方协议参考
+
 Codex app-server is the interface Codex uses to power rich clients (for example, the Codex VS Code extension). Use it when you want a deep integration inside your own product: authentication, conversation history, approvals, and streamed agent events. The app-server implementation is open source in the Codex GitHub repository ([openai/codex/codex-rs/app-server](https://github.com/openai/codex/tree/main/codex-rs/app-server)). See the [Open Source](https://learn.chatgpt.com/docs/open-source) page for the full list of open-source Codex components.
 
 If you are automating jobs or running Codex in CI, use the


### PR DESCRIPTION
## 概要
- 修复 Codex 新会话发送时报 `list_turns is not supported yet`：本连接创建的线程首发直接使用 `turn/start`，保留线程 ID。
- 完整历史读取不支持时改用 `thread/turns/list`，显式请求 `itemsView: full` 并遍历所有页面；仅将明确的未物化线程视为空历史，其他错误继续上报。
- 已有会话恢复遇到特定历史不支持错误时重试 `excludeTurns: true`；重连清除历史能力缓存，包括复用同一适配器的情况。
- 再次打开已有 Codex 主面板或子面板时恢复最小化、置前并聚焦，保留位置和尺寸；异步更新保留最新 z-index，自动更新不抢焦点。
- 根据官方 App Server 文档及 0.153.4 实测补充 `docs/codex.md`，并记录悬浮窗交互契约。

## 根因与协议证据
在真实 Codex app-server 0.153.4 上，新建持久线程返回 `historyMode: paginated`：
- `thread/read(includeTurns: true)` 返回 `-32601: list_turns is not supported yet`。
- 首条消息前的 `thread/turns/list` 返回 `-32600: is not materialized yet`。
- 元数据读取正常；发送首条消息后，完整分页能返回用户消息与助手回复。

新会话创建、恢复订阅和展示历史因此需要分离，不能由历史加载失败阻断首发，也不能将任意历史错误伪装为空会话。

## 验证
- [x] 回归测试 RED → GREEN，覆盖新线程首发、恢复降级、完整分页、错误传播、同适配器重连、异步打开与置前竞争。
- [x] `pnpm lint`，所有修改代码文件 LSP 无错误。
- [x] `pnpm test`：2345 passed，6 skipped，291 个测试文件通过。
- [x] Vite 生产构建与 `pnpm bridge:build` SEA 构建通过。
- [x] 真实浏览器连接现有 bridge/Codex：新会话发送、收到 `VIS_CODEX_SESSION_OK`、刷新后恢复历史。
- [x] 独立 JSON-RPC 读取确认该 turn 为 completed，完整分页含原始用户消息与助手回复，不仅依赖前端缓存。
- [x] Playwright 验证主面板及 Models 子面板恢复、置前、焦点和几何保持。
- [x] 五通道独立审查；发现的缓存及 z-index 边界问题已补失败测试、修复并独立复审通过。

## 范围与已知告警
- 不改变现有本地可恢复归档与原生 Delete 映射，不改变共享消息/worker 状态契约，不增加依赖。
- 保留既有测试 worker 退出超时告警及构建大包告警。
- 当前 bridge `/fs/capabilities` 500 为实测中的既有问题，本 PR 未扩展处理。
- 验证基于本机 Linux 浏览器及 Codex 0.153.4；未宣称其他服务器版本或原生桌面平台全部验证。
- 本次自建测试会话、浏览器及开发进程已清理。
