### PR TITLE
fix(codex): preserve chronological session history and live updates

### DIFF
--- a/app/App.vue
+++ b/app/App.vue
@@ -9014,6 +9014,7 @@ function handleShowSubagentHistory(payload: { sessionId: string; label: string }
     component: SubagentHistoryContent,
     props: {
       parentThreadId: sessionId,
+      loadHistory: activeBackendKind.value === 'codex' ? codexApi.readSubagentHistory : undefined,
       sessionLabel: label,
       theme: shikiTheme.value,
       onToolClick: (part: ToolPart) => handleOpenHistoryTool({ part }),

--- a/app/backends/codex/normalize.test.ts
+++ b/app/backends/codex/normalize.test.ts
@@ -2,6 +2,28 @@ import { describe, expect, it } from 'vitest';
 import { normalizeCodexTurnItems, normalizeCodexTurnsToHistory } from './normalize';
 
 describe('normalizeCodexTurnItems', () => {
+  it('retains each assistant item as a separate chronological message around tools', () => {
+    const result = normalizeCodexTurnItems({ sessionId: 's', turnId: 't', createdAt: 100, items: [
+      { id: 'u', type: 'userMessage', content: [{ type: 'text', text: 'request' }] },
+      { id: 'a1', type: 'agentMessage', text: 'first' },
+      { id: 'cmd', type: 'commandExecution', command: ['ls'] },
+      { id: 'a2', type: 'agentMessage', text: 'second' },
+    ] });
+    const replies = result.parts.filter(part => part.type === 'text' && part.text !== 'request');
+    expect(new Set(replies.map(part => part.id)).size).toBe(2);
+    expect(new Set(replies.map(part => part.messageID)).size).toBe(2);
+    expect(result.messages.filter(message => message.role === 'assistant').map(message => message.time.created)).toEqual([101, 102, 103]);
+    expect(result.messages.filter(message => message.role === 'assistant').every(message => message.parentID === 't:user:0')).toBe(true);
+    const reloaded = normalizeCodexTurnsToHistory({ sessionId: 's', turns: [{ id: 't', items: [
+      { id: 'u', type: 'userMessage', content: [{ type: 'text', text: 'request' }] },
+      { id: 'a1', type: 'agentMessage', text: 'first' },
+      { id: 'cmd', type: 'commandExecution', command: ['ls'] },
+      { id: 'a2', type: 'agentMessage', text: 'second' },
+    ] }] });
+    expect(reloaded.flatMap(entry => entry.parts).filter(part => part.type === 'text' && part.text !== 'request').map(part => part.id)).toEqual(replies.map(part => part.id));
+
+  });
+
   it('maps user and agent messages to canonical message parts', () => {
     const result = normalizeCodexTurnItems({
       sessionId: 'thread-1',
@@ -30,7 +52,7 @@ describe('normalizeCodexTurnItems', () => {
     });
     expect(result.parts[1]).toMatchObject({
       type: 'text',
-      messageID: 'turn-1:assistant',
+      messageID: 'turn-1:assistant:agent-item',
       text: 'hello vis',
     });
     expect(result.messages[1]).toMatchObject({
@@ -69,7 +91,7 @@ describe('normalizeCodexTurnItems', () => {
 
     expect(result.messages.find((message) => message.role === 'assistant')).toMatchObject({
       id: 'turn-time:assistant',
-      time: { created: 120, completed: 135 },
+      time: { created: 120, completed: 120 },
       parentID: 'turn-time:user:0',
     });
   });
@@ -322,8 +344,12 @@ describe('normalizeCodexTurnItems', () => {
     expect(result.parts).toEqual([
       expect.objectContaining({
         type: 'tool',
-        tool: 'spawnAgent',
-        state: expect.objectContaining({ status: 'completed' }),
+        tool: 'task',
+        state: expect.objectContaining({
+          status: 'completed',
+          input: expect.objectContaining({ operation: 'spawnAgent', prompt: 'Inspect the parser' }),
+          metadata: expect.objectContaining({ sessionIds: ['thread-child'], agentsStates: { 'thread-child': { status: 'completed' } } }),
+        }),
       }),
     ]);
   });
@@ -430,7 +456,7 @@ describe('normalizeCodexTurnItems', () => {
     });
 
     expect(result.parts[0]?.id).toBe('turn-stable:user:0:text');
-    expect(result.parts[1]?.id).toBe('turn-stable:assistant:text');
+    expect(result.parts[1]?.id).toBe('turn-stable:assistant:stable-agent-id:text');
     expect(result.parts[2]?.id).toBe('stable-cmd-id');
   });
 
@@ -450,12 +476,14 @@ describe('normalizeCodexTurnItems', () => {
       ],
     });
 
-    expect(history.map((entry) => entry.info.role)).toEqual(['user', 'assistant']);
+    expect(history.map((entry) => entry.info.role)).toEqual(['user', 'assistant', 'assistant']);
     expect(history[0]?.parts).toEqual([
       expect.objectContaining({ type: 'text', text: 'inspect repo' }),
     ]);
     expect(history[1]?.parts).toEqual([
       expect.objectContaining({ type: 'tool', tool: 'bash' }),
+    ]);
+    expect(history[2]?.parts).toEqual([
       expect.objectContaining({ type: 'text', text: 'done' }),
     ]);
     const assistantInfo = history[1]?.info;
@@ -481,10 +509,10 @@ describe('normalizeCodexTurnItems', () => {
       ],
     });
 
-    expect(history).toHaveLength(2);
+    expect(history).toHaveLength(3);
     expect(history[0]?.info.role).toBe('user');
     expect(history[1]?.info.role).toBe('assistant');
-    expect(history[1]?.parts).toEqual(
+    expect(history.flatMap(entry => entry.parts)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ type: 'reasoning', text: 'analyzing code' }),
         expect.objectContaining({ type: 'text', text: 'fixed' }),

--- a/app/backends/codex/normalize.ts
+++ b/app/backends/codex/normalize.ts
@@ -9,6 +9,7 @@ import type {
   ToolPart,
   UserMessageInfo,
 } from '../../types/sse';
+import { codexReasoningText } from './reasoning';
 
 type CodexRecord = Record<string, unknown>;
 
@@ -31,12 +32,12 @@ export function codexUserMessageId(turnId: string, index = 0) {
   return `${turnId}:user:${index}`;
 }
 
-export function codexAssistantMessageId(turnId: string) {
-  return `${turnId}:assistant`;
+export function codexAssistantMessageId(turnId: string, itemId?: string) {
+  return itemId ? `${turnId}:assistant:${itemId}` : `${turnId}:assistant`;
 }
 
-export function codexAssistantTextPartId(turnId: string) {
-  return `${codexAssistantMessageId(turnId)}:text`;
+export function codexAssistantTextPartId(turnId: string, itemId?: string) {
+  return `${codexAssistantMessageId(turnId, itemId)}:text`;
 }
 
 function isRecord(value: unknown): value is CodexRecord {
@@ -45,16 +46,6 @@ function isRecord(value: unknown): value is CodexRecord {
 
 function stringValue(value: unknown, fallback = '') {
   return typeof value === 'string' ? value : fallback;
-}
-
-function stringListValue(value: unknown, separator = '\n\n') {
-  if (typeof value === 'string') return value;
-  if (!Array.isArray(value)) return '';
-  return value
-    .filter((entry): entry is string => typeof entry === 'string')
-    .map((entry) => entry.trim())
-    .filter(Boolean)
-    .join(separator);
 }
 
 function toolResultText(value: unknown) {
@@ -407,7 +398,7 @@ export function normalizeCodexTurnItems(params: {
       }
       files.forEach((file, fileIndex) => {
         parts.push(createFilePart({
-          id: `${message.id}:file:${file.id || fileIndex}`,
+          id: `${message.id}:file:${fileIndex}`,
           sessionId: params.sessionId,
           messageId: message.id,
           mime: file.mime,
@@ -420,20 +411,26 @@ export function normalizeCodexTurnItems(params: {
       return;
     }
 
-    ensureAssistantMessage(itemTime);
-
     if (type === 'agentMessage') {
       const text = stringValue(item.text);
       if (!text) return;
+      const messageId = codexAssistantMessageId(params.turnId, itemId);
+      messages.push(createAssistantMessage({
+        id: messageId, sessionId: params.sessionId, parentId: parentMessageId,
+        createdAt: itemTime, completedAt: isCompleted ? turnCompletedTime ?? itemTime : !hasExplicitStatus ? itemTime : undefined,
+        model: params.model,
+      }));
       parts.push(createTextPart({
-        id: codexAssistantTextPartId(params.turnId),
+        id: codexAssistantTextPartId(params.turnId, itemId),
         sessionId: params.sessionId,
-        messageId: assistantMessageId,
+        messageId,
         text,
         createdAt: itemTime,
       }));
       return;
     }
+
+    ensureAssistantMessage(itemTime);
 
     if (type === 'commandExecution') {
       const command = commandText(item);
@@ -493,9 +490,7 @@ export function normalizeCodexTurnItems(params: {
     }
 
     if (type === 'reasoning') {
-      const summary = stringListValue(item.summary);
-      const content = stringValue(item.text) || stringListValue(item.content);
-      const text = summary || content;
+      const text = codexReasoningText(item);
       if (!text) return;
       parts.push(createReasoningPart({
         id: itemId,
@@ -532,7 +527,29 @@ export function normalizeCodexTurnItems(params: {
       return;
     }
 
-    if (type === 'dynamicToolCall' || type === 'collabToolCall' || type === 'collabAgentToolCall') {
+    if (type === 'collabToolCall' || type === 'collabAgentToolCall') {
+      const tool = stringValue(item.tool);
+      const receiverIds = Array.isArray(item.receiverThreadIds)
+        ? item.receiverThreadIds.filter((id): id is string => typeof id === 'string' && !!id.trim())
+        : [stringValue(item.newThreadId) || stringValue(item.receiverThreadId)].filter(Boolean);
+      const agentsStates = isRecord(item.agentsStates) ? item.agentsStates : {};
+      const prompt = stringValue(item.prompt);
+      parts.push(createToolPart({
+        id: itemId,
+        sessionId: params.sessionId,
+        messageId: assistantMessageId,
+        tool: 'task',
+        title: tool || 'Codex agent',
+        input: { operation: tool, prompt, model: item.model, reasoningEffort: item.reasoningEffort },
+        output: Object.entries(agentsStates).map(([id, state]) => `${id}: ${JSON.stringify(state)}`).join('\n') || stringValue(item.status),
+        createdAt: itemTime,
+        status: stringValue(item.status),
+        metadata: { sessionIds: receiverIds, sessionId: receiverIds[0], agentsStates, senderThreadId: item.senderThreadId },
+      }));
+      return;
+    }
+
+    if (type === 'dynamicToolCall') {
       const tool = stringValue(item.tool);
       const args = isRecord(item.arguments) ? item.arguments : {};
       const status = stringValue(item.status);

--- a/app/backends/codex/reasoning.ts
+++ b/app/backends/codex/reasoning.ts
@@ -1,0 +1,13 @@
+function reasoningBlocks(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (!Array.isArray(value)) return '';
+  return value
+    .filter((block): block is string => typeof block === 'string')
+    .map((block) => block.trim())
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+export function codexReasoningText(item: Readonly<Record<string, unknown>>): string {
+  return reasoningBlocks(item.summary) || reasoningBlocks(item.text) || reasoningBlocks(item.content);
+}

--- a/app/backends/codex/transcriptEntries.test.ts
+++ b/app/backends/codex/transcriptEntries.test.ts
@@ -71,6 +71,16 @@ describe('extractItemTranscriptEntries', () => {
       expected: [{ role: 'system', text: 'Reasoning: reasoning text' }],
     },
     {
+      name: 'reasoning summary blocks from app-server history',
+      item: { type: 'reasoning', summary: ['Inspecting code', 'Checking results'], content: ['Raw detail'] },
+      expected: [{ role: 'system', text: 'Reasoning: Inspecting code\n\nChecking results' }],
+    },
+    {
+      name: 'transmitted reasoning content without a summary',
+      item: { type: 'reasoning', summary: [], content: ['Inspecting code', 'Checking results'] },
+      expected: [{ role: 'system', text: 'Reasoning: Inspecting code\n\nChecking results' }],
+    },
+    {
       name: 'entered review mode',
       item: { type: 'enteredReviewMode', review: 'current changes' },
       expected: [{ role: 'system', text: 'Entered review mode: current changes' }],

--- a/app/backends/codex/transcriptEntries.ts
+++ b/app/backends/codex/transcriptEntries.ts
@@ -1,3 +1,5 @@
+import { codexReasoningText } from './reasoning';
+
 export type CodexTranscriptEntry = {
   id: number;
   role: 'user' | 'assistant' | 'system';
@@ -156,8 +158,8 @@ function mapFileChange(item: TranscriptItemOf<'fileChange'>, createEntry: Transc
 }
 
 function mapReasoning(item: TranscriptItemOf<'reasoning'>, createEntry: TranscriptEntryFactory) {
-  const summary = stringValue(item.summary);
-  const text = summary ? `Reasoning: ${summary}` : '';
+  const reasoning = codexReasoningText(item);
+  const text = reasoning ? `Reasoning: ${reasoning}` : '';
   return text ? [createEntry('system', text)] : [];
 }
 

--- a/app/components/SubagentHistoryContent.test.ts
+++ b/app/components/SubagentHistoryContent.test.ts
@@ -3,14 +3,18 @@ import { createApp, defineComponent, h, nextTick } from 'vue';
 import { createI18n } from 'vue-i18n';
 import { ref } from 'vue';
 
+import type { CodexCanonicalHistoryEntry } from '../backends/codex/normalize';
 import SubagentHistoryContent from './SubagentHistoryContent.vue';
 import { FLOATING_WINDOW_KEY } from '../composables/useFloatingWindow';
 import { useMessages } from '../composables/useMessages';
 import type { MessageInfo, ReasoningPart, ToolPart } from '../types/sse';
 
+vi.mock('./MessageViewer.vue', () => ({ default: defineComponent({ props: ['code'], setup: (props) => () => h('div', props.code) }) }));
+
 function createMessages() {
   return {
     en: {
+      common: { loading: 'Loading...' },
       toolTitles: {
         shell: 'SHELL',
         write: 'WRITE',
@@ -130,6 +134,7 @@ function makeFloatingWindowStub() {
 
 function mount(props: {
   parentThreadId: string;
+  loadHistory?: (threadId: string) => Promise<CodexCanonicalHistoryEntry[]>;
   sessionLabel?: string;
   theme?: string;
   onToolClick?: (part: ToolPart) => void;
@@ -366,4 +371,26 @@ describe('SubagentHistoryContent', () => {
     app.unmount();
     root.remove();
   });
+});
+
+it('loads Codex child history independently of the parent message store', async () => {
+  const loadHistory = vi.fn(async () => [{
+    info: makeAssistantMessage('child-codex', 'child-answer', 'child-user', 2),
+    parts: [makeTextPart('child-answer', 'child-codex', 'Codex child result')],
+  }]);
+  const { root, app } = mount({ parentThreadId: 'child-codex', loadHistory });
+  await flushRender();
+  expect(loadHistory).toHaveBeenCalledWith('child-codex');
+  expect(root.textContent).toContain('Codex child result');
+  expect(useMessages().getParts('child-answer')).toEqual([]);
+  app.unmount();
+  root.remove();
+});
+
+it('shows failed Codex child reads instead of claiming history is empty', async () => {
+  const { root, app } = mount({ parentThreadId: 'child-codex', loadHistory: async () => { throw new Error('Child history unavailable'); } });
+  await flushRender();
+  expect(root.querySelector('[role="alert"]')?.textContent).toContain('Child history unavailable');
+  app.unmount();
+  root.remove();
 });

--- a/app/components/SubagentHistoryContent.vue
+++ b/app/components/SubagentHistoryContent.vue
@@ -21,8 +21,10 @@
         {{ t('subagentHistory.close') }}
       </button>
     </div>
+    <div v-if="loading" class="subagent-empty">{{ t('common.loading') }}</div>
+    <div v-else-if="loadError" class="subagent-empty" role="alert">{{ loadError }}</div>
     <ThreadHistoryContent
-      v-if="entries.length > 0"
+      v-else-if="entries.length > 0"
       :entries="entries"
       :theme="theme"
       :on-tool-click="handleToolClick"
@@ -35,7 +37,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
+import type { CodexCanonicalHistoryEntry } from '../backends/codex/normalize';
 import { useI18n } from 'vue-i18n';
 import ThreadHistoryContent from './ThreadHistoryContent.vue';
 import { useMessages } from '../composables/useMessages';
@@ -55,6 +58,7 @@ const props = withDefaults(
     parentThreadId: string;
     sessionLabel?: string;
     theme?: string;
+    loadHistory?: (threadId: string) => Promise<CodexCanonicalHistoryEntry[]>;
   }>(),
   {
     sessionLabel: '',
@@ -70,24 +74,52 @@ const emit = defineEmits<{
 
 const msg = useMessages();
 const floatingWindow = useFloatingWindow();
+const loadedHistory = ref<CodexCanonicalHistoryEntry[]>([]);
+const loading = ref(false);
+const loadError = ref('');
+watch(() => [props.parentThreadId, props.loadHistory] as const, async ([threadId, loadHistory], _, onCleanup) => {
+  let stale = false;
+  onCleanup(() => { stale = true; });
+  loadedHistory.value = [];
+  loadError.value = '';
+  loading.value = !!loadHistory;
+  if (!loadHistory) return;
+  try {
+    const history = await loadHistory(threadId);
+    if (!stale) loadedHistory.value = history;
+  } catch (error) {
+    if (!stale) loadError.value = error instanceof Error ? error.message : String(error);
+  } finally {
+    if (!stale) loading.value = false;
+  }
+}, { immediate: true });
+
+function getParts(messageId: string) {
+  return props.loadHistory
+    ? loadedHistory.value.find((entry) => entry.info.id === messageId)?.parts ?? []
+    : msg.getParts(messageId);
+}
+
 
 function hasTextContent(message: { id: string }): boolean {
-  return msg.hasTextContent(message.id);
+  return getParts(message.id).some((part) => part.type === 'text' && !!part.text.trim());
 }
 
 function getMessageContent(message: { id: string }): string {
-  return msg.getTextContent(message.id);
+  return getParts(message.id).filter((part) => part.type === 'text').map((part) => part.text).join('\n');
 }
 
 const subagentMessages = computed(() =>
-  selectSubagentMessages(msg.roots.value, (rootId) => msg.getThread(rootId), props.parentThreadId),
+  props.loadHistory
+    ? loadedHistory.value.map((entry) => entry.info)
+    : selectSubagentMessages(msg.roots.value, (rootId) => msg.getThread(rootId), props.parentThreadId),
 );
 
 const internalEntries = computed<HistoryEntry[]>(() =>
   buildHistoryEntries({
     messages: subagentMessages.value,
     hasTextContent,
-    getParts: (messageId) => msg.getParts(messageId),
+    getParts,
   }),
 );
 

--- a/app/components/ThreadBlock.test.ts
+++ b/app/components/ThreadBlock.test.ts
@@ -92,6 +92,7 @@ function mount(
   props: {
     root: MessageInfo;
     currentSessionId?: string;
+    backendKind?: 'codex' | 'opencode';
   },
   onShowThreadHistory: (payload: { entries: unknown[] }) => void,
 ) {
@@ -110,6 +111,7 @@ function mount(
             filesWithBasenames: [],
             isRevertedPreview: false,
             currentSessionId: props.currentSessionId,
+            backendKind: props.backendKind,
             deferredTransitionKey: 'test',
             onShowThreadHistory,
           });
@@ -126,6 +128,23 @@ describe('ThreadBlock history wiring', () => {
   afterEach(() => {
     document.body.innerHTML = '';
     useMessages().reset();
+  });
+
+  it('shows Codex turn attachments when the latest reply is a separate assistant message', async () => {
+    const user = makeUserMessage('main', 'u1', 1);
+    useMessages().loadHistory([
+      { info: user, parts: [] },
+      { info: makeAssistantMessage('main', 'turn-tools', 'u1', 2, 'codex'), parts: [{
+        id: 'image-1', sessionID: 'main', messageID: 'turn-tools', type: 'file',
+        mime: 'image/png', filename: 'preview.png', url: 'data:image/png;base64,AA==',
+      }] },
+      { info: makeAssistantMessage('main', 'reply-2', 'u1', 3, 'codex'), parts: [makeTextPart('reply-2', 'main', 'Final answer')] },
+    ]);
+    const view = mount({ root: user, currentSessionId: 'main', backendKind: 'codex' }, vi.fn());
+    await flushRender();
+    expect(view.root.querySelectorAll('.thread-assistant img')).toHaveLength(1);
+    expect(view.root.querySelector('img')?.getAttribute('alt')).toBe('preview.png');
+    view.app.unmount();
   });
 
   it('Given a thread with a subagent-session assistant message, When the history button is clicked, Then the emitted entry carries isSubagent true and the agent name', async () => {

--- a/app/components/ThreadBlock.vue
+++ b/app/components/ThreadBlock.vue
@@ -202,7 +202,9 @@ const assistantMessages = computed(() =>
 const finalAnswer = computed(() => assistantMessages.value[assistantMessages.value.length - 1]);
 const hasAssistantText = computed(() => assistantMessages.value.length > 0);
 const userAttachments = computed(() => getMessageAttachments(props.root));
-const assistantAttachments = computed(() => getMessageAttachments(finalAnswer.value));
+const assistantAttachments = computed(() => props.backendKind === 'codex'
+  ? threadMessages.value.filter(message => message.role === 'assistant').flatMap(getMessageAttachments)
+  : getMessageAttachments(finalAnswer.value));
 const historyEntries = computed(() => getHistoryEntries());
 const historyCount = computed(() => historyEntries.value.length);
 const hasHistory = computed(() => historyCount.value > 0);

--- a/app/components/ThreadHistoryContent.vue
+++ b/app/components/ThreadHistoryContent.vue
@@ -25,8 +25,12 @@
         <div
           v-else-if="entry.kind === 'reasoning'"
           class="history-item history-item-reasoning"
+          role="button"
+          tabindex="0"
           :data-history-key="entry.key"
           @click="handleReasoningClick(entry.part)"
+          @keydown.enter.prevent="handleReasoningClick(entry.part)"
+          @keydown.space.prevent="handleReasoningClick(entry.part)"
         >
           <div class="history-meta">
             <span class="history-index">🤔</span>
@@ -491,7 +495,8 @@ function formatMessageTime(value?: number) {
     background 0.15s;
 }
 
-.history-item-reasoning:hover {
+.history-item-reasoning:hover,
+.history-item-reasoning:focus-visible {
   border-color: color-mix(
     in srgb,
     var(--history-reasoning-color) 60%,

--- a/app/composables/useCodexApi.test.ts
+++ b/app/composables/useCodexApi.test.ts
@@ -137,6 +137,74 @@ describe('useCodexApi', () => {
     localStorage.clear();
   });
 
+  it('keeps restored replies attached to their original user across tool events', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    await api.selectThread('thr_existing');
+    const original = api.canonicalHistory.value.find(entry => entry.info.role === 'assistant')!;
+    mock.emit({ method: 'item/started', params: { threadId: 'thr_existing', turnId: 'turn_old', item: { id: 'command-live', type: 'commandExecution', command: 'pwd' } } });
+    expect(api.realtimeToolParts.value[0]?.info).toMatchObject({
+      parentID: 'turn_old:user:0',
+      id: 'turn_old:assistant',
+    });
+    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_old', item: { id: 'command-live', type: 'commandExecution', command: 'pwd', status: 'completed', aggregatedOutput: '/repo' } } });
+    expect(api.realtimeHistoryQueue.value.find(entry => entry.info.role === 'assistant')?.info).toMatchObject({ parentID: 'turn_old:user:0' });
+    expect(api.canonicalHistory.value.find(entry => entry.info.id === original.info.id)).toEqual(original);
+  });
+
+  it('retains streamed reasoning when completion contains no summary and separates consecutive items', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    await api.selectThread('thr_existing');
+    for (const [itemId, delta] of [['reason-1', 'First summary'], ['reason-2', 'Second summary']]) {
+      mock.emit({ method: 'item/reasoning/summaryTextDelta', params: { threadId: 'thr_existing', turnId: 'turn_old', itemId, delta } });
+      mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_old', item: { id: itemId, type: 'reasoning', summary: [], content: [] } } });
+    }
+    const reasoning = api.realtimeHistoryQueue.value.flatMap(entry => entry.parts).filter(part => part.type === 'reasoning');
+    expect(reasoning.map(part => [part.id, part.text])).toEqual([['reason-1', 'First summary'], ['reason-2', 'Second summary']]);
+  });
+
+  it('keeps authoritative completed reasoning through the turn completion event', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    mock.emit({ method: 'item/reasoning/summaryTextDelta', params: { threadId: 'thr_existing', turnId: 'turn-live', itemId: 'reason-final', delta: 'Draft' } });
+    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn-live', item: { id: 'reason-final', type: 'reasoning', summary: ['Final summary'], content: [] } } });
+    mock.emit({ method: 'turn/completed', params: { threadId: 'thr_existing', turn: { id: 'turn-live', status: 'completed' } } });
+    expect(api.realtimeReasoningPart.value?.part).toMatchObject({ id: 'reason-final', text: 'Final summary' });
+  });
+
+  it('reparents early tool events when the optimistic user receives its final ID', async () => {
+    const mock = createAdapterMock();
+    const reply = deferred<CodexPromptResult>();
+    mock.adapter.sendPrompt = vi.fn(() => reply.promise);
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    const sending = api.sendPrompt('Continue');
+    mock.emit({ method: 'item/started', params: { threadId: 'thr_existing', turnId: 'turn-race', item: { id: 'early-tool', type: 'commandExecution', command: 'pwd' } } });
+    reply.resolve({ threadId: 'thr_existing', turn: { id: 'turn-race', status: 'inProgress' } });
+    await sending;
+    mock.emit({ method: 'item/commandExecution/outputDelta', params: { threadId: 'thr_existing', turnId: 'turn-race', itemId: 'early-tool', delta: '/repo' } });
+    expect(api.realtimeToolParts.value[0]?.info).toMatchObject({ parentID: 'turn-race:user:0' });
+    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn-race', item: { id: 'early-tool', type: 'commandExecution', command: 'pwd', status: 'completed' } } });
+    expect(api.realtimeHistoryQueue.value.find(entry => entry.info.role === 'assistant')?.info).toMatchObject({ parentID: 'turn-race:user:0' });
+  });
+
+  it('reads child history without changing the selected parent session', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    await api.selectThread('thr_existing');
+    const parentHistory = api.canonicalHistory.value;
+    const result = await api.readSubagentHistory('thr_child');
+    expect(result.every(entry => entry.info.sessionID === 'thr_child')).toBe(true);
+    expect(result.flatMap(entry => entry.parts).some(part => part.type === 'text' && part.text.includes('thr_child answer'))).toBe(true);
+    expect(api.activeThreadId.value).toBe('thr_existing');
+    expect(api.canonicalHistory.value).toBe(parentHistory);
+  });
+
   it('reports each successful live turn once, including background threads', async () => {
     const mock = createAdapterMock();
     const onTaskCompleted = vi.fn();
@@ -854,6 +922,7 @@ describe('useCodexApi', () => {
     });
 
     expect(mock.adapter.sendPrompt).toHaveBeenLastCalledWith({
+      summary: 'auto',
       text: '',
       threadId: 'thr_existing',
       input: [{ type: 'image', url: 'data:image/png;base64,AA==' }],
@@ -869,6 +938,7 @@ describe('useCodexApi', () => {
     await api.sendPrompt('Hello custom model.', { threadId: 'thr_existing' });
 
     expect(mock.adapter.sendPrompt).toHaveBeenLastCalledWith({
+      summary: 'auto',
       text: 'Hello custom model.',
       threadId: 'thr_existing',
       model: 'mimo/mimo-v2.5',
@@ -887,6 +957,7 @@ describe('useCodexApi', () => {
     });
 
     expect(mock.adapter.sendPrompt).toHaveBeenLastCalledWith({
+      summary: 'auto',
       text: 'Hello explicit custom model.',
       threadId: 'thr_existing',
       model: 'mimo/mimo-v2.5',
@@ -1555,6 +1626,7 @@ describe('useCodexApi', () => {
     const result = await api.sendPrompt('  Summarize this repo.  ');
 
     expect(mock.adapter.sendPrompt).toHaveBeenCalledWith({
+      summary: 'auto',
       threadId: 'thr_existing',
       text: 'Summarize this repo.',
     });
@@ -1573,6 +1645,7 @@ describe('useCodexApi', () => {
     await api.sendPrompt('Continue here.', { threadId: 'thr_existing', cwd: '~/repo' });
 
     expect(mock.adapter.sendPrompt).toHaveBeenLastCalledWith({
+      summary: 'auto',
       threadId: 'thr_existing',
       text: 'Continue here.',
       cwd: '/home/codex/repo',
@@ -1592,6 +1665,7 @@ describe('useCodexApi', () => {
     });
 
     expect(mock.adapter.sendPrompt).toHaveBeenLastCalledWith({
+      summary: 'auto',
       text: 'Start on the selected provider.',
       model: 'mimo/mimo-v2.5',
       cwd: '/repo',
@@ -2155,6 +2229,74 @@ describe('useCodexApi', () => {
     expect(userEntries[0]?.parts[0]).toMatchObject({ type: 'text', text: 'Hello immediately.' });
   });
 
+  it('hydrates images in the turn-completed history refresh', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    await api.selectThread('thr_existing');
+    mock.adapter.readFile = vi.fn().mockResolvedValue({ dataBase64: 'AA==' });
+    mock.adapter.readThread = vi.fn().mockResolvedValue({ thread: { id: 'thr_existing', turns: [{ id: 'turn_img', items: [{ id: 'shot', type: 'imageView', path: '/tmp/shot.png' }] }] } });
+    mock.emit({ method: 'turn/completed', params: { threadId: 'thr_existing', turn: { id: 'turn_img', status: 'completed' } } });
+    await vi.waitFor(() => expect(api.canonicalHistory.value.flatMap(e => e.parts)).toContainEqual(expect.objectContaining({ type: 'file', url: 'data:image/png;base64,AA==' })));
+    api.disconnect();
+  });
+
+  it('hydrates a realtime agent image before publishing its local path', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    await api.selectThread('thr_existing');
+    const read = deferred<{ dataBase64: string }>();
+    mock.adapter.readFile = vi.fn(() => read.promise);
+    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_img', item: { id: 'shot', type: 'imageView', path: '/tmp/shot.png' } } });
+    expect(api.realtimeHistoryQueue.value.flatMap(e => e.parts).filter(p => p.type === 'file')).toHaveLength(0);
+    read.resolve({ dataBase64: 'AA==' });
+    await vi.waitFor(() => expect(api.realtimeHistoryQueue.value.flatMap(e => e.parts)).toContainEqual(expect.objectContaining({ type: 'file', url: 'data:image/png;base64,AA==' })));
+    api.disconnect();
+  });
+
+  it('ignores realtime image reads after a thread switch', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    await api.selectThread('thr_existing');
+    const read = deferred<{ dataBase64: string }>();
+    mock.adapter.readFile = vi.fn(() => read.promise);
+    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_img', item: { id: 'shot', type: 'imageView', path: '/tmp/shot.png' } } });
+    await api.selectThread('thr_other');
+    read.resolve({ dataBase64: 'AA==' });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(api.realtimeHistoryQueue.value.flatMap(e => e.parts).filter(p => p.type === 'file')).toHaveLength(0);
+    api.disconnect();
+  });
+
+  it('retains the sent image preview when the echoed local file cannot be read', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    await api.sendPrompt('Look', { input: [{ type: 'image', url: 'data:image/png;base64,AA==' }] });
+    mock.adapter.readFile = vi.fn().mockRejectedValue(new Error('File temporarily unavailable'));
+    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_1', item: { id: 'echo', type: 'userMessage', content: [{ type: 'localImage', path: '/tmp/upload.png' }] } } });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(api.realtimeHistoryQueue.value.flatMap(e => e.parts).filter(p => p.type === 'file')).toEqual([expect.objectContaining({ url: 'data:image/png;base64,AA==' })]);
+    api.disconnect();
+  });
+
+  it.each(['image', 'localImage'])('keeps sent images single when echoed as %s', async (kind) => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    await api.sendPrompt('Look', { input: [{ type: 'text', text: 'Look' }, { type: 'image', url: 'data:image/png;base64,AA==' }, { type: 'image', url: 'data:image/png;base64,AA==' }] });
+    const initial = api.realtimeHistoryQueue.value.find(e => e.info.role === 'user')?.parts.filter(p => p.type === 'file');
+    expect(initial).toHaveLength(2);
+    mock.emit({ method: 'item/completed', params: { threadId: api.activeThreadId.value, turnId: 'turn_1', item: { type: 'userMessage', id: 'echo', content: [{ type: 'text', text: 'Look' }, ...[0, 1].map(i => kind === 'image' ? { type: 'image', url: 'data:image/png;base64,AA==' } : { type: 'localImage', path: '/tmp/sent-' + i + '.png' })] } } });
+    const files = api.realtimeHistoryQueue.value.find(e => e.info.role === 'user')?.parts.filter(p => p.type === 'file');
+    expect(files).toHaveLength(2);
+    expect(files?.map(p => p.id)).toEqual(initial?.map(p => p.id));
+    expect(mock.adapter.sendPrompt).toHaveBeenCalledTimes(1);
+    api.disconnect();
+  });
+
   it('does not reuse the previous active turn id for a new provisional user message', async () => {
     const mock = createAdapterMock();
     mock.adapter.sendPrompt = vi.fn().mockResolvedValue({
@@ -2224,6 +2366,24 @@ describe('useCodexApi', () => {
     expect(Object.values(api.realtimeMessageAliases.value)).toContain('turn_race:user:0');
   });
 
+  it('keeps successive streamed assistant items independently through completion', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    await api.sendPrompt('Multiple replies');
+    for (const [itemId, text] of [['a1', 'First reply'], ['a2', 'Second reply']]) {
+      mock.emit({ method: 'item/agentMessage/delta', params: { itemId, turnId: 'turn_1', delta: text } });
+      expect(api.realtimeStreamingPart.value?.part.text).toBe(text);
+      mock.emit({ method: 'item/completed', params: { turnId: 'turn_1', item: { id: itemId, type: 'agentMessage', text } } });
+    }
+    const replies = api.realtimeHistoryQueue.value.flatMap(entry => entry.parts).filter(part => part.type === 'text' && part.text.endsWith('reply'));
+    expect(replies.map(part => part.type === 'text' ? part.text : '')).toEqual(['First reply', 'Second reply']);
+    expect(new Set(replies.map(part => part.messageID)).size).toBe(2);
+    mock.emit({ method: 'item/completed', params: { turnId: 'turn_1', item: { id: 'a1', type: 'agentMessage', text: 'First reply amended' } } });
+    expect(api.realtimeStreamingPart.value?.part.text).toBe('Second reply');
+    expect(api.transcript.value.filter(entry => entry.role === 'assistant').slice(-2).map(entry => entry.text)).toEqual(['First reply amended', 'Second reply']);
+  });
+
   it('updates realtimeStreamingPart on agent message deltas', async () => {
     const mock = createAdapterMock();
     const api = useCodexApi({ adapterFactory: () => mock.adapter });
@@ -2231,9 +2391,7 @@ describe('useCodexApi', () => {
     await api.connect();
     await api.sendPrompt('Stream test.');
 
-    expect(api.realtimeStreamingPart.value).not.toBeNull();
-    expect(api.realtimeStreamingPart.value?.info.id).toContain(':assistant');
-    expect(api.realtimeStreamingPart.value?.part.text).toBe('');
+    expect(api.realtimeStreamingPart.value).toBeNull();
 
     mock.emit({ method: 'item/agentMessage/delta', params: { delta: 'Hello' } });
     expect(api.realtimeStreamingPart.value?.part.text).toBe('Hello');
@@ -2279,8 +2437,8 @@ describe('useCodexApi', () => {
     expect(assistantEntries).toHaveLength(1);
     const textParts = assistantEntries[0]?.parts.filter((part) => part.type === 'text') ?? [];
     expect(textParts).toHaveLength(1);
-    expect(textParts[0]?.id).toBe('turn_1:assistant:text');
-    expect(textParts[0]).toMatchObject({ messageID: 'turn_1:assistant', text: 'Hello, world!' });
+    expect(textParts[0]?.id).toBe('turn_1:assistant:agent-1:text');
+    expect(textParts[0]).toMatchObject({ messageID: 'turn_1:assistant:agent-1', text: 'Hello, world!' });
   });
 
   it('merges completed tool parts into the existing assistant entry instead of duplicating assistant history rows', async () => {
@@ -2314,10 +2472,10 @@ describe('useCodexApi', () => {
     const assistantEntries = api.realtimeHistoryQueue.value.filter(
       (entry) => entry.info.role === 'assistant',
     );
-    expect(assistantEntries).toHaveLength(1);
+    expect(assistantEntries).toHaveLength(2);
     expect(assistantEntries[0]?.parts.some((part) => part.type === 'tool')).toBe(true);
     expect(
-      assistantEntries[0]?.parts.some(
+      assistantEntries[1]?.parts.some(
         (part) => part.type === 'text' && 'text' in part && part.text === 'Done',
       ),
     ).toBe(true);
@@ -2347,7 +2505,7 @@ describe('useCodexApi', () => {
     expect(api.realtimeReasoningPart.value?.part.text).toBe('Thinking... more thoughts');
   });
 
-  it('interleaves summary and raw reasoning deltas while preserving separators and metadata', async () => {
+  it('keeps summary and raw reasoning separate and displays the summary with separators', async () => {
     const mock = createAdapterMock();
     const api = useCodexApi({ adapterFactory: () => mock.adapter });
 
@@ -2380,8 +2538,8 @@ describe('useCodexApi', () => {
       raw: 'raw oneraw two',
     });
     expect(api.realtimeReasoningPart.value?.part).toMatchObject({
-      id: 'reasoning-interleaved:reasoning',
-      text: 'summary oneraw one\n---\nraw twosummary two',
+      id: 'reasoning-interleaved',
+      text: 'summary one\n---\nsummary two',
       sessionID: 'thr_existing',
       type: 'reasoning',
     });

--- a/app/composables/useCodexApi.ts
+++ b/app/composables/useCodexApi.ts
@@ -1,3 +1,4 @@
+import { codexReasoningText } from '../backends/codex/reasoning';
 import { computed, ref, watch } from 'vue';
 import {
   CodexAdapter,
@@ -805,6 +806,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   }
 
   function setTranscriptFromTurns(turns: CodexTurn[] = []) {
+    assistantTranscriptIds.clear();
     const activeThread = threads.value.find((thread) => thread.id === activeThreadId.value);
     for (const turn of turns) recordObservedTurnId(activeThreadId.value, turn.id);
     const selectedModelInfo = parseSelectedCodexModel(selectedModel.value);
@@ -836,18 +838,45 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     transcript.value = [...textEntries, ...systemEntries];
   }
 
-  function appendAssistantDelta(text: string) {
-    if (!text) return;
-    const last = transcript.value.at(-1);
-    if (last?.role === 'assistant') {
-      transcript.value[transcript.value.length - 1] = {
-        ...last,
-        text: `${last.text}${text}`,
-        modelName: last.modelName ?? currentSelectedModelName(),
-      };
-      return;
+  const assistantTranscriptIds = new Map<string, number>();
+
+  function updateAssistantItem(sessionId: string, turnId: string, itemId: string, text: string, completed: boolean, createdAt?: number) {
+    const messageId = codexAssistantMessageId(turnId, itemId || 'pending');
+    const previous = realtimeStreamingPart.value;
+    const sameItem = previous?.info.id === messageId;
+    const provisional = previous?.info.id === codexAssistantMessageId(turnId, 'pending');
+    const now = Date.now();
+    if (previous && !sameItem && !provisional && previous.part.text) {
+      mergeRealtimeHistoryEntry({ info: previous.info, parts: [previous.part] });
     }
-    pushTranscript('assistant', text, currentSelectedModelName());
+    if (provisional && itemId) {
+      realtimeMessageAliases.value = { ...realtimeMessageAliases.value, [previous.info.id]: messageId };
+      realtimeHistoryQueue.value = realtimeHistoryQueue.value.filter(entry => entry.info.id !== previous.info.id);
+    }
+    const stored = realtimeHistoryQueue.value.find(entry => entry.info.id === messageId);
+    const storedText = stored?.parts.find((part): part is TextPart => part.type === 'text');
+    const currentText = sameItem || provisional ? previous?.part.text ?? '' : storedText?.text ?? '';
+    const info = previous && (sameItem || provisional) ? { ...previous.info, id: messageId }
+      : createCodexAssistantInfo(sessionId, messageId, createdAt ?? now, currentRealtimeParentId(sessionId, turnId));
+    const part: TextPart = {
+      id: codexAssistantTextPartId(turnId, itemId || 'pending'), sessionID: sessionId, messageID: messageId,
+      type: 'text', text: completed ? text : currentText + text,
+      time: { start: sameItem || provisional ? previous?.part.time?.start ?? info.time.created : storedText?.time?.start ?? info.time.created, ...(completed ? { end: now } : {}) },
+    };
+    if (!completed || !stored || sameItem || provisional) realtimeStreamingPart.value = { info, part, updatedAt: now };
+    mergeRealtimeHistoryEntry({ info, parts: [part] });
+    const transcriptId = assistantTranscriptIds.get(messageId)
+      ?? (provisional ? assistantTranscriptIds.get(previous.info.id) : undefined);
+    const transcriptIndex = transcript.value.findIndex(entry => entry.id === transcriptId);
+    const transcriptEntry = transcript.value[transcriptIndex];
+    if (transcriptEntry) {
+      transcript.value[transcriptIndex] = { ...transcriptEntry, text: part.text };
+    } else {
+      const entry = createTranscriptEntry('assistant', part.text, currentSelectedModelName());
+      transcript.value.push(entry);
+      assistantTranscriptIds.set(messageId, entry.id);
+    }
+    if (transcriptId !== undefined) assistantTranscriptIds.set(messageId, transcriptId);
   }
 
   function parseSelectedCodexModel(value: string | undefined) {
@@ -873,6 +902,17 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     createdAt: number,
     parentId = '',
   ): MessageInfo {
+    parentId = realtimeMessageAliases.value[parentId] || parentId;
+    const existing = [
+      realtimeStreamingPart.value?.info,
+      ...realtimeHistoryQueue.value.map(entry => entry.info),
+      ...canonicalHistory.value.map(entry => entry.info),
+      realtimeReasoningPart.value?.info,
+      ...realtimeToolParts.value.map(entry => entry.info),
+    ].find(info => info?.id === messageId && info.sessionID === sessionId && info.role === 'assistant');
+    if (existing?.role === 'assistant') {
+      return { ...existing, parentID: parentId || existing.parentID };
+    }
     const model = parseSelectedCodexModel(selectedModel.value);
     return {
       id: messageId,
@@ -895,16 +935,19 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     };
   }
 
-  function currentRealtimeParentId(sessionId?: string) {
+  function currentRealtimeParentId(sessionId?: string, turnId?: string) {
     const targetSessionId = sessionId?.trim() || activeThreadId.value || '';
-    const queueParent = [...realtimeHistoryQueue.value].reverse().find((entry) => {
-      if (entry.info.role !== 'user') return false;
-      if (!targetSessionId) return true;
-      return entry.info.sessionID === targetSessionId || entry.info.sessionID === 'codex-pending';
-    })?.info.id;
-    if (queueParent) return queueParent;
-    const aliases = realtimeMessageAliases.value;
-    return Object.values(aliases).at(-1) || '';
+    const entries = [...canonicalHistory.value, ...realtimeHistoryQueue.value];
+    if (turnId) {
+      const assistantId = codexAssistantMessageId(turnId);
+      const existing = entries.find(entry => entry.info.id === assistantId && entry.info.sessionID === targetSessionId);
+      if (existing?.info.role === 'assistant' && existing.info.parentID) return existing.info.parentID;
+      const user = entries.find(entry => entry.info.id === codexUserMessageId(turnId, 0) && entry.info.sessionID === targetSessionId);
+      if (user) return user.info.id;
+    }
+    return entries.reverse().find(entry => entry.info.role === 'user' && (
+      entry.info.sessionID === targetSessionId || entry.info.sessionID === 'codex-pending'
+    ))?.info.id || '';
   }
 
   function buildRealtimeUserParts(
@@ -925,13 +968,14 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
         time: { start: createdAt, end: createdAt },
       } satisfies TextPart);
     }
+    let fileIndex = 0;
     inputItems?.forEach((item, index) => {
       if (item.type === 'image') {
         const mimeMatch = item.url.match(/^data:([^;,]+)/u);
         const mime = mimeMatch?.[1] || 'image/*';
         const extension = mime.split('/')[1]?.split('+')[0] || 'img';
         parts.push({
-          id: `${messageId}:file:${index}`,
+          id: `${messageId}:file:${fileIndex++}`,
           sessionID: sessionId,
           messageID: messageId,
           type: 'file',
@@ -945,7 +989,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
         const filename = item.path.split(/[\\/]/u).filter(Boolean).pop() || `image-${index + 1}`;
         const extension = filename.split('.').pop()?.toLowerCase() || '';
         parts.push({
-          id: `${messageId}:file:${index}`,
+          id: `${messageId}:file:${fileIndex++}`,
           sessionID: sessionId,
           messageID: messageId,
           type: 'file',
@@ -1049,13 +1093,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     realtimeToolParts.value = realtimeToolParts.value.filter(
       (_, entryIndex) => entryIndex !== index,
     );
-    const info =
-      current.info.role === 'assistant'
-        ? {
-            ...current.info,
-            time: { ...current.info.time, completed: current.info.time.completed ?? completedAt },
-          }
-        : current.info;
+    const info = current.info;
     return {
       info,
       part: completedPart,
@@ -1072,6 +1110,9 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   }
 
   function mergeRealtimeHistoryEntry(entry: CodexCanonicalHistoryEntry) {
+    if (entry.info.role === 'assistant') {
+      entry = { ...entry, info: createCodexAssistantInfo(entry.info.sessionID, entry.info.id, entry.info.time.created, entry.info.parentID) };
+    }
     const existingIndex = realtimeHistoryQueue.value.findIndex(
       (current) => current.info.id === entry.info.id,
     );
@@ -1096,12 +1137,34 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     realtimeHistoryQueue.value = dedupeRealtimeHistoryQueue(nextQueue);
   }
 
-  function mergeRealtimeHistoryBundle(bundle: { messages: MessageInfo[]; parts: MessagePart[] }) {
+  const realtimeImageRequests = new Map<string, symbol>();
+  function isLocalImage(part: MessagePart): part is FilePart {
+    return part.type === 'file' && part.mime.startsWith('image/') && !/^(data:|https?:|blob:)/u.test(part.url);
+  }
+
+  function mergeRealtimeHistoryBundle(bundle: { messages: MessageInfo[]; parts: MessagePart[] }, request: ConnectionRequest, turnId: string) {
+    const selectionGeneration = threadSelectionGeneration;
     for (const info of bundle.messages) {
       mergeRealtimeHistoryEntry({
         info,
-        parts: bundle.parts.filter((part) => part.messageID === info.id),
+        parts: bundle.parts.filter((part) => part.messageID === info.id && !isLocalImage(part)),
       });
+      for (const part of bundle.parts.filter((part) => part.messageID === info.id)) {
+        const token = Symbol(part.id);
+        realtimeImageRequests.set(part.id, token);
+        if (!isLocalImage(part)) {
+          realtimeImageRequests.delete(part.id);
+          continue;
+        }
+        void hydrateThreadImages([{ info, parts: [part] }], request.sourceAdapter).then(([hydrated]) => {
+          if (!isCurrentConnection(request) || selectionGeneration !== threadSelectionGeneration ||
+              activeThreadId.value !== info.sessionID || isInvalidatedTurnId(info.sessionID, turnId) ||
+              realtimeImageRequests.get(part.id) !== token) return;
+          if (hydrated) mergeRealtimeHistoryEntry({ ...hydrated, parts: hydrated.parts.filter(part => !isLocalImage(part)) });
+        }).finally(() => {
+          if (realtimeImageRequests.get(part.id) === token) realtimeImageRequests.delete(part.id);
+        });
+      }
     }
   }
 
@@ -1288,42 +1351,21 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       const params = isRecord(notification.params) ? notification.params : null;
       const item = params?.item;
       if (isRecord(item) && item.type === 'agentMessage' && typeof item.text === 'string') {
-        const last = transcript.value.at(-1);
-        if (last?.role === 'assistant') {
-          transcript.value[transcript.value.length - 1] = {
-            ...last,
-            text: item.text,
-            modelName: last.modelName ?? currentSelectedModelName(),
-          };
-        } else {
-          pushTranscript('assistant', item.text, currentSelectedModelName());
-        }
-        if (realtimeStreamingPart.value) {
-          const completedAt = Date.now();
-          realtimeStreamingPart.value = {
-            ...realtimeStreamingPart.value,
-            part: {
-              ...realtimeStreamingPart.value.part,
-              text: item.text,
-              time: {
-                start:
-                  realtimeStreamingPart.value.part.time?.start ??
-                  realtimeStreamingPart.value.info.time.created,
-                end: completedAt,
-              },
-            },
-            updatedAt: completedAt,
-          };
-        }
+        const sessionId = notificationThreadId || activeThreadId.value || 'codex-thread';
+        const turnId = notificationTurnId || activeTurn.value?.id || `${sessionId}:realtime`;
+        updateAssistantItem(sessionId, turnId, typeof item.id === 'string' ? item.id : '', item.text, true, typeof item.createdAt === 'number' ? item.createdAt : undefined);
       }
       if (isRecord(item) && item.type === 'reasoning') {
-        if (realtimeReasoningPart.value) {
+        if (realtimeReasoningPart.value && realtimeReasoningPart.value.part.id === item.id) {
           const completedAt = Date.now();
-          const finalPart = realtimeReasoningPart.value.part;
-          mergeRealtimeHistoryEntry({
-            info: realtimeReasoningPart.value.info,
-            parts: [{ ...finalPart, time: { start: finalPart.time.start, end: completedAt } }],
-          });
+          const current = realtimeReasoningPart.value;
+          const finalPart: ReasoningPart = {
+            ...current.part,
+            text: codexReasoningText(item) || current.part.text,
+            time: { start: current.part.time.start, end: completedAt },
+          };
+          realtimeReasoningPart.value = { ...current, part: finalPart, updatedAt: completedAt };
+          mergeRealtimeHistoryEntry({ info: current.info, parts: [finalPart] });
         }
       }
       const realtimeSessionId = notificationThreadId || activeThreadId.value || 'codex-thread';
@@ -1335,7 +1377,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
               sessionId: realtimeSessionId,
               turnId: realtimeTurnId,
               items: [item],
-              parentMessageId: currentRealtimeParentId(realtimeSessionId),
+              parentMessageId: currentRealtimeParentId(realtimeSessionId, realtimeTurnId),
             })
           : null;
       const normalizedToolPart =
@@ -1389,7 +1431,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       if (isRecord(item) && typeof item.type === 'string' && !completedToolMerged) {
         const bundle = normalizedBundle ?? { messages: [], parts: [] };
         if (bundle.messages.length > 0 || bundle.parts.length > 0) {
-          mergeRealtimeHistoryBundle(bundle);
+          mergeRealtimeHistoryBundle(bundle, request, realtimeTurnId);
         }
       }
       return;
@@ -1397,15 +1439,10 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
 
     if (notification.method === 'item/agentMessage/delta') {
       const delta = extractAgentDelta(notification.params);
-      appendAssistantDelta(delta);
-      if (delta && realtimeStreamingPart.value) {
-        const current = realtimeStreamingPart.value.part;
-        realtimeStreamingPart.value = {
-          info: realtimeStreamingPart.value.info,
-          part: { ...current, text: current.text + delta },
-          updatedAt: Date.now(),
-        };
-      }
+      const params = isRecord(notification.params) ? notification.params : null;
+      const sessionId = notificationThreadId || activeThreadId.value || 'codex-thread';
+      const turnId = notificationTurnId || activeTurn.value?.id || `${sessionId}:realtime`;
+      if (delta) updateAssistantItem(sessionId, turnId, typeof params?.itemId === 'string' ? params.itemId : '', delta, false);
       return;
     }
 
@@ -1437,7 +1474,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
           sessionId: realtimeSessionId,
           turnId,
           items: [item],
-          parentMessageId: currentRealtimeParentId(realtimeSessionId),
+          parentMessageId: currentRealtimeParentId(realtimeSessionId, turnId),
         });
         for (const part of bundle.parts) {
           if (part.type === 'tool') {
@@ -1446,7 +1483,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
                 realtimeSessionId,
                 part.messageID,
                 Date.now(),
-                currentRealtimeParentId(realtimeSessionId),
+                currentRealtimeParentId(realtimeSessionId, turnId),
               ),
               part: { ...part, state: { ...part.state, status: 'running' } as ToolPart['state'] },
               updatedAt: Date.now(),
@@ -1581,7 +1618,13 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     }
 
     if (notification.method === 'item/plan/delta') {
-      appendAssistantDelta(extractAgentDelta(notification.params));
+      const delta = extractAgentDelta(notification.params);
+      const last = transcript.value.at(-1);
+      if (last?.role === 'assistant') {
+        transcript.value[transcript.value.length - 1] = { ...last, text: last.text + delta };
+      } else if (delta) {
+        pushTranscript('assistant', delta, currentSelectedModelName());
+      }
       return;
     }
 
@@ -1606,21 +1649,21 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
           notificationTurnId || activeTurn.value?.id || `reasoning:${threadId}`,
         );
         const existing = realtimeReasoningPart.value?.part;
-        const accumulated = existing?.id === `${itemId}:reasoning` ? existing.text + delta : delta;
+        const accumulated = reasoningStreams.value[itemId]?.summary || reasoningStreams.value[itemId]?.raw || delta;
         realtimeReasoningPart.value = {
           info: createCodexAssistantInfo(
             threadId,
             messageId,
             Date.now(),
-            currentRealtimeParentId(threadId),
+            currentRealtimeParentId(threadId, notificationTurnId || activeTurn.value?.id),
           ),
           part: {
-            id: `${itemId}:reasoning`,
+            id: itemId,
             sessionID: threadId,
             messageID: messageId,
             type: 'reasoning',
             text: accumulated,
-            time: { start: realtimeReasoningPart.value?.part.time.start ?? Date.now() },
+            time: { start: existing?.id === itemId ? existing.time.start : Date.now() },
           },
           updatedAt: Date.now(),
         };
@@ -1633,13 +1676,13 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       const itemId = typeof params?.itemId === 'string' ? params.itemId : '';
       if (itemId) {
         const existing = reasoningStreams.value[itemId] ?? { summary: '', raw: '' };
-        reasoningStreams.value[itemId] = { ...existing, summary: existing.summary + '\n---\n' };
+        reasoningStreams.value[itemId] = { ...existing, summary: existing.summary ? existing.summary + '\n---\n' : '' };
       }
-      if (itemId && realtimeReasoningPart.value) {
+      if (itemId && realtimeReasoningPart.value?.part.id === itemId) {
         const current = realtimeReasoningPart.value.part;
         realtimeReasoningPart.value = {
           info: realtimeReasoningPart.value.info,
-          part: { ...current, text: current.text + '\n---\n' },
+          part: { ...current, text: reasoningStreams.value[itemId]?.summary || reasoningStreams.value[itemId]?.raw || current.text },
           updatedAt: Date.now(),
         };
       }
@@ -2251,7 +2294,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     return mergeThreadReadResult(await readHistory(threadId), threadId);
   }
 
-  async function hydrateThreadImages(entries: CodexCanonicalHistoryEntry[]) {
+  async function hydrateThreadImages(entries: CodexCanonicalHistoryEntry[], sourceAdapter = adapter) {
     const nextEntries = await Promise.all(
       entries.map(async (entry) => {
         const parts = await Promise.all(
@@ -2260,12 +2303,13 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
             if (
               part.url.startsWith('data:') ||
               part.url.startsWith('http://') ||
-              part.url.startsWith('https://')
+              part.url.startsWith('https://') || part.url.startsWith('blob:')
             )
               return part;
             if (!part.mime.startsWith('image/')) return part;
             try {
-              const raw = await readFileRaw(part.url);
+              if (!sourceAdapter) return part;
+              const raw = await sourceAdapter.readFile({ path: expandPath(part.url) });
               const dataUrl = fileResultToDataUrl(part.url, raw);
               return dataUrl ? { ...part, url: dataUrl } : part;
             } catch {
@@ -2322,7 +2366,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       if (!isCurrentSelection()) return;
       upsertThread(read.thread);
       setTranscriptFromTurns(read.thread.turns ?? []);
-      const hydratedHistory = await hydrateThreadImages(canonicalHistory.value);
+      const hydratedHistory = await hydrateThreadImages(canonicalHistory.value, sourceAdapter);
       if (!isCurrentSelection()) return;
       canonicalHistory.value = hydratedHistory;
       try {
@@ -2352,6 +2396,20 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     }
   }
 
+  async function readSubagentHistory(threadId: string): Promise<CodexCanonicalHistoryEntry[]> {
+    const sourceAdapter = adapter;
+    if (!sourceAdapter) throw new Error('Codex is not connected.');
+    const read = await readThreadForHistory(threadId, sourceAdapter);
+    const entries = normalizeCodexTurnsToHistory({
+      sessionId: threadId,
+      turns: read.thread.turns ?? [],
+      model: { providerID: read.thread.modelProvider },
+    });
+    const hydrated = await hydrateThreadImages(entries, sourceAdapter);
+    if (adapter !== sourceAdapter) throw new Error('Codex connection changed.');
+    return hydrated;
+  }
+
   async function hydrateThread(threadId: string) {
     const sourceAdapter = adapter;
     if (!sourceAdapter) return;
@@ -2364,8 +2422,15 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     ) {
       return;
     }
+    const hydrated = await hydrateThreadImages(normalizeCodexTurnsToHistory({
+      sessionId: threadId, turns: read.thread.turns ?? [],
+    }), sourceAdapter);
+    if (adapter !== sourceAdapter || threadSelectionGeneration !== selectionGeneration || activeThreadId.value !== threadId) return;
     upsertThread(read.thread);
     setTranscriptFromTurns(read.thread.turns ?? []);
+    const imageUrls = new Map(hydrated.flatMap(entry => entry.parts.filter(part => part.type === 'file').map(part => [part.id, part.url])));
+    canonicalHistory.value = canonicalHistory.value.map(entry => ({ ...entry, parts: entry.parts.map(part =>
+      part.type === 'file' ? { ...part, url: imageUrls.get(part.id) ?? part.url } : part) }));
   }
 
   async function startThread(cwd?: string) {
@@ -2791,7 +2856,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       const model =
         options.model?.trim() || parseSelectedCodexModel(selectedModel.value).modelID || undefined;
       const cwd = resolvePromptCwd(options.cwd, targetThreadId);
-      const input: CodexPromptInput = { text: prompt };
+      const input: CodexPromptInput = { text: prompt, summary: 'auto' };
       if (inputItems.length > 0) input.input = inputItems;
       if (targetThreadId) input.threadId = targetThreadId;
       if (model) input.model = model;
@@ -2832,25 +2897,18 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
         [userMessageId]: finalizedUserMessageId,
       };
 
-      const assistantMessageId = codexAssistantMessageId(finalizedTurnId);
-      const assistantPartId = codexAssistantTextPartId(finalizedTurnId);
-      realtimeStreamingPart.value = {
-        info: createCodexAssistantInfo(
-          result.threadId,
-          assistantMessageId,
-          Date.now(),
-          finalizedUserMessageId,
-        ),
-        part: {
-          id: assistantPartId,
-          sessionID: result.threadId,
-          messageID: assistantMessageId,
-          type: 'text',
-          text: '',
-          time: { start: Date.now() },
-        },
-        updatedAt: Date.now(),
-      };
+      const reparent = (info: MessageInfo): MessageInfo => info.role === 'assistant' && info.parentID === userMessageId
+        ? { ...info, parentID: finalizedUserMessageId }
+        : info;
+      realtimeHistoryQueue.value = realtimeHistoryQueue.value.map(entry => ({ ...entry, info: reparent(entry.info) }));
+      realtimeToolParts.value = realtimeToolParts.value.map(entry => ({ ...entry, info: reparent(entry.info) }));
+      if (realtimeReasoningPart.value) {
+        realtimeReasoningPart.value = { ...realtimeReasoningPart.value, info: reparent(realtimeReasoningPart.value.info) };
+      }
+
+      if (realtimeStreamingPart.value) {
+        realtimeStreamingPart.value = { ...realtimeStreamingPart.value, info: reparent(realtimeStreamingPart.value.info) };
+      }
 
       return result;
     } catch (error) {
@@ -3585,6 +3643,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   }
 
   return {
+    readSubagentHistory,
     status,
     reconnectOnMount,
     url,

--- a/app/composables/useCodexMessageBridge.test.ts
+++ b/app/composables/useCodexMessageBridge.test.ts
@@ -1,6 +1,6 @@
 import { nextTick, ref } from 'vue';
 import { describe, expect, it, vi } from 'vitest';
-import { normalizeCodexTurnsToHistory } from '../backends/codex/normalize';
+import { normalizeCodexTurnsToHistory, type CodexCanonicalHistoryEntry } from '../backends/codex/normalize';
 import type { BackendKind } from '../backends/types';
 import type {
   AssistantMessageInfo,
@@ -11,7 +11,133 @@ import type {
 } from '../types/sse';
 import { useCodexMessageBridge } from './useCodexMessageBridge';
 
+function bridgeFixture() {
+  const params = {
+    activeBackendKind: ref<BackendKind>('codex'),
+    selectedSessionId: ref('thread-1'),
+    codexPendingSessionLock: ref(''),
+    history: ref<CodexCanonicalHistoryEntry[]>([]),
+    codexApi: {
+      realtimeHistoryQueue: ref<CodexCanonicalHistoryEntry[]>([]),
+      realtimeMessageAliases: ref<Record<string, string>>({}),
+      realtimeStreamingPart: ref<{ info: AssistantMessageInfo | UserMessageInfo; part: MessagePart } | null>(null),
+      realtimeReasoningPart: ref<{ info: AssistantMessageInfo | UserMessageInfo; part: ReasoningPart } | null>(null),
+      realtimeToolParts: ref<Array<{ info: AssistantMessageInfo | UserMessageInfo; part: ToolPart }>>([]),
+      tokenUsage: ref<unknown>(null),
+      diffState: ref<{ threadId: string; turnId: string; diff: string } | null>(null),
+    },
+    msg: { loadHistory: vi.fn(), updateMessage: vi.fn(), updatePart: vi.fn(), removeMessage: vi.fn() },
+    syncRealtimeToolWindows: vi.fn(),
+    updateReasoningExpiry: vi.fn(),
+  };
+  useCodexMessageBridge(params);
+  return params;
+}
+
+function liveHistory() {
+  return normalizeCodexTurnsToHistory({
+    sessionId: 'thread-1',
+    turns: [{ id: 'turn-1', items: [
+      { id: 'user', type: 'userMessage', content: [{ type: 'text', text: 'Inspect' }] },
+      { id: 'text', type: 'agentMessage', text: 'Checking files' },
+      { id: 'tool-1', type: 'commandExecution', command: 'pwd', status: 'inProgress', aggregatedOutput: '' },
+      { id: 'tool-2', type: 'commandExecution', command: 'ls', status: 'inProgress', aggregatedOutput: '' },
+    ] }],
+  });
+}
+
 describe('useCodexMessageBridge', () => {
+  it('publishes only the changed tool across queue and tool watchers', async () => {
+    const params = bridgeFixture();
+    const entries = liveHistory();
+    params.codexApi.realtimeHistoryQueue.value = entries;
+    await nextTick();
+    params.msg.updateMessage.mockClear();
+    params.msg.updatePart.mockClear();
+    const changed = entries.map(entry => ({ ...entry, parts: entry.parts.map(part =>
+      part.type === 'tool' && part.id === 'tool-1' && part.state.status === 'completed'
+        ? { ...part, state: { ...part.state, output: '/repo' } }
+        : part,
+    ) }));
+    params.codexApi.realtimeHistoryQueue.value = changed;
+    params.codexApi.realtimeToolParts.value = changed.flatMap(entry => entry.parts.flatMap(part =>
+      part.type === 'tool' ? [{ info: entry.info, part }] : [],
+    ));
+    await nextTick();
+    expect(params.msg.updateMessage).not.toHaveBeenCalled();
+    expect(params.msg.updatePart).toHaveBeenCalledTimes(1);
+    expect(params.msg.updatePart).toHaveBeenCalledWith(expect.objectContaining({ id: 'tool-1' }));
+  });
+
+  it('forwards parent-only changes without replaying parts', async () => {
+    const params = bridgeFixture();
+    params.codexApi.realtimeHistoryQueue.value = liveHistory();
+    await nextTick();
+    params.msg.updateMessage.mockClear();
+    params.msg.updatePart.mockClear();
+    params.codexApi.realtimeHistoryQueue.value = params.codexApi.realtimeHistoryQueue.value.map(entry => ({
+      ...entry,
+      info: entry.info.role === 'assistant' ? { ...entry.info, parentID: 'correct-user' } : entry.info,
+    }));
+    await nextTick();
+    expect(params.msg.updateMessage).toHaveBeenCalledTimes(2);
+    expect(params.msg.updateMessage.mock.calls.map(([info]) => info.id)).toEqual(
+      params.codexApi.realtimeHistoryQueue.value.filter(entry => entry.info.role === 'assistant').map(entry => entry.info.id),
+    );
+    expect(params.msg.updateMessage).toHaveBeenCalledWith(expect.objectContaining({ parentID: 'correct-user' }));
+    expect(params.msg.updatePart).not.toHaveBeenCalled();
+  });
+
+  it('shares text deduplication with streaming updates while removing provisional aliases', async () => {
+    const params = bridgeFixture();
+    const entries = liveHistory();
+    params.codexApi.realtimeHistoryQueue.value = entries;
+    params.codexApi.realtimeMessageAliases.value = { provisional: 'turn-1:user:0' };
+    await nextTick();
+    expect(params.msg.removeMessage).toHaveBeenCalledWith('provisional');
+    params.msg.updateMessage.mockClear();
+    params.msg.updatePart.mockClear();
+    const assistant = entries.find(entry => entry.info.role === 'assistant');
+    const text = assistant?.parts.find(part => part.type === 'text');
+    if (!assistant || !text) throw new Error('Expected assistant text fixture');
+    params.codexApi.realtimeStreamingPart.value = { info: assistant.info, part: text };
+    await nextTick();
+    expect(params.msg.updateMessage).not.toHaveBeenCalled();
+    expect(params.msg.updatePart).not.toHaveBeenCalled();
+    params.codexApi.realtimeStreamingPart.value = { info: assistant.info, part: { ...text, text: 'Checking more files' } };
+    await nextTick();
+    expect(params.msg.updateMessage).not.toHaveBeenCalled();
+    expect(params.msg.updatePart).toHaveBeenCalledOnce();
+  });
+
+  it('seeds live deduplication from loaded history and resets it across sessions and backends', async () => {
+    const params = bridgeFixture();
+    const entries = liveHistory();
+    params.history.value = entries;
+    await nextTick();
+    params.codexApi.realtimeHistoryQueue.value = entries;
+    await nextTick();
+    expect(params.msg.loadHistory).toHaveBeenCalledWith(entries);
+    expect(params.msg.updateMessage).not.toHaveBeenCalled();
+    expect(params.msg.updatePart).not.toHaveBeenCalled();
+    params.activeBackendKind.value = 'opencode';
+    await nextTick();
+    params.activeBackendKind.value = 'codex';
+    params.codexApi.realtimeHistoryQueue.value = [];
+    await nextTick();
+    params.codexApi.realtimeHistoryQueue.value = entries;
+    await nextTick();
+    expect(params.msg.updatePart).toHaveBeenCalledTimes(entries.flatMap(entry => entry.parts).length);
+    params.msg.updatePart.mockClear();
+    params.selectedSessionId.value = 'thread-2';
+    await nextTick();
+    params.selectedSessionId.value = 'thread-1';
+    params.codexApi.realtimeHistoryQueue.value = [];
+    await nextTick();
+    params.codexApi.realtimeHistoryQueue.value = entries;
+    await nextTick();
+    expect(params.msg.updatePart).toHaveBeenCalledTimes(entries.flatMap(entry => entry.parts).length);
+  });
   it('forwards restored reasoning and tool parts to the shared VIS message store', async () => {
     const history = normalizeCodexTurnsToHistory({
       sessionId: 'thread-1',
@@ -43,7 +169,7 @@ describe('useCodexMessageBridge', () => {
     const updatePart = vi.fn<(part: MessagePart) => void>();
     const syncRealtimeToolWindows = vi.fn();
 
-    const realtimeHistoryQueue = ref<typeof restored>([]);
+    const realtimeHistoryQueue = ref<CodexCanonicalHistoryEntry[]>([]);
     useCodexMessageBridge({
       activeBackendKind: ref<BackendKind>('codex'),
       selectedSessionId: ref('thread-1'),
@@ -82,5 +208,13 @@ describe('useCodexMessageBridge', () => {
 
     expect(updatePart.mock.calls.map(([part]) => part.type)).toEqual(['reasoning', 'tool']);
     expect(syncRealtimeToolWindows).toHaveBeenCalledWith(restored);
+    const images = normalizeCodexTurnsToHistory({ sessionId: 'thread-1', turns: [{ id: 'image-turn', items: [{ id: 'shot', type: 'imageView', path: '/tmp/shot.png' }] }] });
+    realtimeHistoryQueue.value = images;
+    await nextTick();
+    updatePart.mockClear();
+    realtimeHistoryQueue.value = images.map(entry => ({ ...entry, parts: entry.parts.map(part => part.type === 'file' ? { ...part, url: 'data:image/png;base64,AA==' } : part) }));
+    await nextTick();
+    expect(updatePart).toHaveBeenCalledWith(expect.objectContaining({ type: 'file', url: 'data:image/png;base64,AA==' }));
+
   });
 });

--- a/app/composables/useCodexMessageBridge.ts
+++ b/app/composables/useCodexMessageBridge.ts
@@ -34,20 +34,7 @@ function parseCodexDiffEntries(diffText: string): MessageDiffEntry[] {
 }
 
 function buildRealtimeQueueSignature(queue: CodexCanonicalHistoryEntry[]) {
-  return queue.map((entry) => `${entry.info.id}:${entry.parts.map((part) => {
-    if (part.type === 'tool') {
-      const output = part.state.status === 'completed'
-        ? part.state.output
-        : part.state.status === 'error'
-          ? part.state.error
-          : part.state.status === 'running'
-            ? part.state.metadata?.output || ''
-            : '';
-      return `${part.id}:${part.state.status}:${output}`;
-    }
-    if (part.type === 'text' || part.type === 'reasoning') return `${part.id}:${part.text}`;
-    return part.id;
-  }).join(',')}`).join('|');
+  return JSON.stringify(queue);
 }
 
 export function useCodexMessageBridge(params: {
@@ -61,6 +48,28 @@ export function useCodexMessageBridge(params: {
   updateReasoningExpiry: (sessionId: string, state: 'idle' | 'busy') => void;
 }) {
   const lastRealtimeQueueSignature = ref('');
+  const publishedMessages = new Map<string, string>();
+  const publishedParts = new Map<string, string>();
+
+  function updateMessage(info: AssistantMessageInfo | UserMessageInfo) {
+    const signature = JSON.stringify(info);
+    if (publishedMessages.get(info.id) === signature) return;
+    publishedMessages.set(info.id, signature);
+    params.msg.updateMessage(info);
+  }
+
+  function updatePart(part: MessagePart) {
+    const signature = JSON.stringify(part);
+    if (publishedParts.get(part.id) === signature) return;
+    publishedParts.set(part.id, signature);
+    params.msg.updatePart(part);
+  }
+
+  function resetPublishedState() {
+    lastRealtimeQueueSignature.value = '';
+    publishedMessages.clear();
+    publishedParts.clear();
+  }
 
   function matchesActiveCodexRealtimeSession(sessionId: string) {
     const target = params.selectedSessionId.value;
@@ -137,6 +146,12 @@ export function useCodexMessageBridge(params: {
     if (params.activeBackendKind.value !== 'codex') return;
     if (!params.selectedSessionId.value) return;
     params.msg.loadHistory(history);
+    publishedMessages.clear();
+    publishedParts.clear();
+    for (const entry of history) {
+      publishedMessages.set(entry.info.id, JSON.stringify(entry.info));
+      for (const part of entry.parts) publishedParts.set(part.id, JSON.stringify(part));
+    }
     reapplyCodexSharedBackfill();
   });
 
@@ -154,25 +169,24 @@ export function useCodexMessageBridge(params: {
     for (const [provisionalId, finalizedId] of Object.entries(params.codexApi.realtimeMessageAliases.value)) {
       if (!provisionalId || !finalizedId || provisionalId === finalizedId) continue;
       params.msg.removeMessage(provisionalId);
+      publishedMessages.delete(provisionalId);
     }
     const realtimeEntries = params.codexApi.realtimeHistoryQueue.value.filter((entry) => matchesActiveCodexRealtimeSession(entry.info.sessionID));
     for (const entry of realtimeEntries) {
-      params.msg.updateMessage(entry.info as AssistantMessageInfo | UserMessageInfo);
-      for (const part of entry.parts) params.msg.updatePart(part);
+      updateMessage(entry.info);
+      for (const part of entry.parts) updatePart(part);
     }
     params.syncRealtimeToolWindows(realtimeEntries);
   });
 
-  watch(params.selectedSessionId, () => {
-    lastRealtimeQueueSignature.value = '';
-  });
+  watch([params.selectedSessionId, params.activeBackendKind], resetPublishedState, { flush: 'sync' });
 
   watch(params.codexApi.realtimeStreamingPart, (streaming) => {
     if (params.activeBackendKind.value !== 'codex') return;
     if (!params.selectedSessionId.value || !streaming) return;
     if (!matchesActiveCodexRealtimeSession(streaming.info.sessionID)) return;
-    params.msg.updateMessage(streaming.info);
-    params.msg.updatePart(streaming.part);
+    updateMessage(streaming.info);
+    updatePart(streaming.part);
     if (streaming.part.type === 'text' && streaming.part.time?.end) {
       params.updateReasoningExpiry(streaming.part.sessionID, 'idle');
     }
@@ -182,8 +196,8 @@ export function useCodexMessageBridge(params: {
     if (params.activeBackendKind.value !== 'codex') return;
     if (!params.selectedSessionId.value || !reasoning) return;
     if (!matchesActiveCodexRealtimeSession(reasoning.info.sessionID)) return;
-    params.msg.updateMessage(reasoning.info);
-    params.msg.updatePart(reasoning.part);
+    updateMessage(reasoning.info);
+    updatePart(reasoning.part);
     params.updateReasoningExpiry(reasoning.part.sessionID, reasoning.part.time?.end ? 'idle' : 'busy');
   });
 
@@ -191,8 +205,8 @@ export function useCodexMessageBridge(params: {
     if (params.activeBackendKind.value !== 'codex') return;
     if (!params.selectedSessionId.value) return;
     for (const { info, part } of toolParts.filter(({ info }) => matchesActiveCodexRealtimeSession(info.sessionID))) {
-      params.msg.updateMessage(info);
-      params.msg.updatePart(part);
+      updateMessage(info);
+      updatePart(part);
     }
   }, { deep: true });
 
@@ -212,7 +226,7 @@ export function useCodexMessageBridge(params: {
     matchesActiveCodexRealtimeSession,
     reapplyCodexSharedBackfill,
     resetRealtimeQueueSignature() {
-      lastRealtimeQueueSignature.value = '';
+      resetPublishedState();
     },
   };
 }

--- a/app/utils/threadSubagents.test.ts
+++ b/app/utils/threadSubagents.test.ts
@@ -209,3 +209,11 @@ describe('resolveThreadSubagentSessions', () => {
     expect(resolveThreadSubagentSessions(parts, '  ', meta)).toEqual([]);
   });
 });
+
+it('resolves all Codex collaboration receiver threads without requiring OpenCode session metadata', () => {
+  const parts = [makeTaskPart('codex-wait', { source: 'codex', sessionIds: ['child-a', 'child-b', 'child-a', CURRENT_SESSION] })];
+  expect(resolveThreadSubagentSessions(parts, CURRENT_SESSION, { 'child-a': { label: 'Parser' } })).toEqual([
+    { sessionId: 'child-a', label: 'Parser' },
+    { sessionId: 'child-b', label: 'child-b' },
+  ]);
+});

--- a/app/utils/threadSubagents.ts
+++ b/app/utils/threadSubagents.ts
@@ -31,15 +31,19 @@ export function resolveThreadSubagentSessions(
     if (part.type !== 'tool' || part.tool !== 'task') continue;
     const state = part.state;
     if (state.status === 'pending') continue;
-    const rawChildId = state.metadata?.sessionId;
-    if (typeof rawChildId !== 'string') continue;
-    const childId = rawChildId.trim();
-    if (!childId) continue;
-    const meta = metaById?.[childId];
-    if (meta && meta.parentID !== sessionId) continue;
-    const fallbackLabel = meta?.label || childId;
-    if (isMagicContextWorkerName(fallbackLabel)) continue;
-    if (!seen.has(childId)) seen.set(childId, resolveTaskWorkerLabel(part, fallbackLabel));
+    const childIds = Array.isArray(state.metadata?.sessionIds)
+      ? state.metadata.sessionIds
+      : [state.metadata?.sessionId];
+    for (const rawChildId of childIds) {
+      if (typeof rawChildId !== 'string') continue;
+      const childId = rawChildId.trim();
+      if (!childId || childId === sessionId) continue;
+      const meta = metaById?.[childId];
+      if (meta && meta.parentID !== sessionId && (state.metadata?.source !== 'codex' || meta.parentID)) continue;
+      const fallbackLabel = meta?.label || childId;
+      if (isMagicContextWorkerName(fallbackLabel)) continue;
+      if (!seen.has(childId)) seen.set(childId, resolveTaskWorkerLabel(part, fallbackLabel));
+    }
   }
   return Array.from(seen.entries()).map(([sessionId, label]) => ({ sessionId, label }));
 }
@@ -62,9 +66,10 @@ export function resolveChildOwners(
   threads.forEach(({ rootId, parts }) => {
     parts.forEach((part) => {
       if (part.type !== 'tool' || part.tool !== 'task') return;
-      const rawChildId = 'metadata' in part.state ? part.state.metadata?.sessionId : undefined;
-      if (typeof rawChildId === 'string' && rawChildId.trim()) {
-        exactIds.add(rawChildId.trim());
+      const metadata = 'metadata' in part.state ? part.state.metadata : undefined;
+      const ids = Array.isArray(metadata?.sessionIds) ? metadata.sessionIds : [metadata?.sessionId];
+      for (const id of ids) {
+        if (typeof id === 'string' && id.trim()) exactIds.add(id.trim());
       }
       const description = taskDescription(part);
       if (!description) return;

--- a/docs/codex-interaction-validation.md
+++ b/docs/codex-interaction-validation.md
@@ -50,3 +50,20 @@
 - 默认主题 375/768/1280、Ocean、Sakura、自定义浅色主题的展开/关闭状态共 12 张组件截图通过独立复核，未见目标区域溢出或中文裁切。浅色为 token 兼容测试，不表示新增内置主题。
 - 27 项相关测试、vue-tsc、oxlint、构建通过；真实 Vis 窗口中选择 Paused、保存与清除均成功。新建线程验证等待会话切换完成后再打开编辑器。
 - 本轮证据：`/tmp/goal-theme-qa/report.json`、`pass-a.md`、`pass-b.md` 及 `real-app-dropdown.png`。临时 fixture 已移除，测试线程已归档。
+
+## 会话记录与实时更新
+
+- 对照 Codex CLI 0.153.4 生成的 app-server schema 和[官方协议文档](https://learn.chatgpt.com/docs/app-server)，确认支持 reasoning 摘要事件、协作代理调用和子线程历史读取。只展示服务端传回的摘要或内容；历史中未生成、未保存的思考内容无法补造。
+- 请求启用 `summary: auto`；统一解析摘要数组，实时与历史使用相同 reasoning item ID，保留完成事件的最终摘要，摘要与 raw 内容分别累积。
+- 协作调用映射到已有 task/子代理入口，支持多个 receiverThreadIds。子代理历史独立读取，含加载与错误状态，不替换主会话 store。
+- 回复保留原父消息、创建时间和模型信息；发送确认时同步替换工具及思考记录中的临时父消息 ID。实时桥接只提交有变化的消息与片段。
+- 浏览器使用真实 OutputPanel、历史/思考/子代理组件和模拟协议：连续六次工具操作及最终历史回填后，根节点与 assistant DOM 节点均保持同一对象，只有一个 user 根记录。子代理历史及思考可打开，主会话保持选中，无浏览器运行错误。
+- 本轮未调用模型验证新的生成结果。协议支持来自官方文档及本机 schema，交互证据位于 `/tmp/vis-session-browser/`，回归结果位于 `/tmp/vis-session-tests-final.log`。
+
+## 同一卡片内多条助手消息
+
+- 每条 Codex agentMessage 按 turnId/itemId 保存独立消息和文本 ID；实时片段、完成通知及历史读取使用相同身份。工具和思考仍归属同一 user 卡片，后续文本不再覆盖先前回复或继承其排序时间。
+- 切换流式消息、完成通知迟到和发送确认均保留已有回复；主卡片显示最新回复，历史按各条消息时间展示全部回复。
+- Codex 卡片从全部助手记录收集图片，避免独立文本消息隐藏 turn 级 imageView 附件。
+- 224 项相关测试、额外 3 项 ThreadBlock 测试断言通过，类型检查、lint、构建通过。ThreadBlock 既有测试环境仍输出 happy-dom AbortError/worker 退出超时警告，测试命令退出码为 0。
+- 真实组件的模拟协议浏览器验证覆盖三条历史回复、两条实时追加回复、交错工具/思考、迟到完成、历史回填和重新加载；五条助手消息均保留、八条历史记录有序、仅一个 user 根节点，附件可见，无 pageerror。两项独立视觉复核通过。证据位于 `/tmp/vis-multi-message/`；未调用真实模型。


### PR DESCRIPTION
## 问题与修改

同一卡片内的多条 Codex 助手回复此前共用消息和文本 ID，后续回复会覆盖先前内容，并沿用最早的时间排在历史顶部。现在按 turn/item 保存独立记录，实时更新、完成通知和历史回填使用相同 ID，全部回复按时间顺序保留。

- 保留回复的父消息、时间与模型信息；发送确认时替换临时父消息 ID，工具事件只更新变化的片段，避免回复脱离用户卡片或反复重建。
- 接入思考摘要解析及历史展示，区分摘要与 raw 内容，并保留完成通知中的最终内容。
- 将子代理调用接入现有任务入口，支持多个子代理及独立加载历史，不切换主会话；思考记录支持键盘打开。
- 统一图片回传 ID，异步读取实时图片；读取失败时保留已显示的发送预览，避免重复图片和刷新前图片损坏。分拆助手记录后继续显示卡片附件。

基于已合并 PR #124 的最新 main，保留其中的协作模式、线程目标和悬浮窗修正。

## 验证

- 290 项相关测试通过，包含已合并的线程目标回归；类型检查和生产构建通过。
- 独立分支浏览器验证使用真实 Vue 组件和模拟 Codex 协议，覆盖多条回复、工具/思考交错、迟到完成通知、历史回填、重新加载、子代理历史与图片显示。
- 未调用真实模型验证新生成结果；协议能力已对照官方文档和本机 app-server schema。
