### PR TITLE
fix(codex): auto-open live reasoning and subagent windows

### DIFF
--- a/app/App.vue
+++ b/app/App.vue
@@ -7637,6 +7637,8 @@ const codexMessageBridge = useCodexMessageBridge({
   msg,
   syncRealtimeToolWindows: syncRealtimeCodexToolWindows,
   updateReasoningExpiry,
+  onLiveReasoning: (info, part) => reasoning.handlePart(part, info),
+  onLiveSubagent: (info, part) => subagentWindows.handlePart(part, info),
 });
 
 function upsertAcpSession(info: BackendSessionInfo) {

--- a/app/App.vue
+++ b/app/App.vue
@@ -7436,7 +7436,7 @@ watch(
 watch(
   isThinking,
   (active) => {
-    if (active) return;
+    if (active || activeBackendKind.value === 'codex') return;
     if (!selectedSessionId.value) return;
     updateReasoningExpiry(selectedSessionId.value, 'idle');
   },

--- a/app/composables/useCodexApi.test.ts
+++ b/app/composables/useCodexApi.test.ts
@@ -192,6 +192,19 @@ describe('useCodexApi', () => {
     expect(api.realtimeHistoryQueue.value.find(entry => entry.info.role === 'assistant')?.info).toMatchObject({ parentID: 'turn-race:user:0' });
   });
 
+  it('publishes completed-only reasoning and collaboration notifications to live window sources', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn-c', item: { id: 'reason-only', type: 'reasoning', summary: ['Decision'] } } });
+    expect(api.realtimeReasoningPart.value?.part).toMatchObject({id: 'reason-only', text: 'Decision', time: {end: expect.any(Number)}});
+    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn-c', item: { id: 'spawn-only', type: 'collabAgentToolCall', tool: 'spawnAgent', status: 'completed', senderThreadId: 'thr_existing', receiverThreadIds: ['child'], prompt: 'Review', agentsStates: {child: {status: 'running'}} } } });
+    expect(api.realtimeCompletedPart.value?.part).toMatchObject({tool: 'task', state: {metadata: {sessionIds: ['child']}}});
+    await api.selectThread('thr_existing');
+    expect(api.realtimeReasoningPart.value).toBeNull();
+    expect(api.realtimeToolParts.value).toEqual([]);
+  });
+
   it('reads child history without changing the selected parent session', async () => {
     const mock = createAdapterMock();
     const api = useCodexApi({ adapterFactory: () => mock.adapter });

--- a/app/composables/useCodexApi.test.ts
+++ b/app/composables/useCodexApi.test.ts
@@ -166,6 +166,26 @@ describe('useCodexApi', () => {
     expect(reasoning.map(part => [part.id, part.text])).toEqual([['reason-1', 'First summary'], ['reason-2', 'Second summary']]);
   });
 
+  it('does not revive completed reasoning when this or a later turn finishes', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(100);
+    try {
+      mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn-a', item: { id: 'reason-a', type: 'reasoning', summary: ['Finished thought'], content: [] } } });
+      const finishedPart = api.realtimeReasoningPart.value?.part;
+      clock.mockReturnValue(200);
+      mock.emit({ method: 'turn/completed', params: { threadId: 'thr_existing', turn: { id: 'turn-a', status: 'completed' } } });
+      expect(api.realtimeReasoningPart.value?.part).toBe(finishedPart);
+      clock.mockReturnValue(300);
+      mock.emit({ method: 'turn/started', params: { threadId: 'thr_existing', turn: { id: 'turn-b', status: 'inProgress' } } });
+      mock.emit({ method: 'turn/completed', params: { threadId: 'thr_existing', turn: { id: 'turn-b', status: 'completed' } } });
+      expect(api.realtimeReasoningPart.value?.part).toBe(finishedPart);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
   it('keeps authoritative completed reasoning through the turn completion event', async () => {
     const mock = createAdapterMock();
     const api = useCodexApi({ adapterFactory: () => mock.adapter });

--- a/app/composables/useCodexApi.ts
+++ b/app/composables/useCodexApi.ts
@@ -619,6 +619,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   const dynamicToolCalls = ref<CodexDynamicToolCallRequest[]>([]);
   const realtimeHistoryQueue = ref<CodexCanonicalHistoryEntry[]>([]);
   const realtimeMessageAliases = ref<Record<string, string>>({});
+  const realtimeCompletedPart = ref<CodexRealtimePartRecord<ToolPart> | null>(null);
   const realtimeStreamingPart = ref<CodexRealtimePartRecord<TextPart> | null>(null);
   const realtimeReasoningPart = ref<CodexRealtimePartRecord<ReasoningPart> | null>(null);
   const realtimeToolParts = ref<Array<CodexRealtimePartRecord<ToolPart>>>([]);
@@ -1382,6 +1383,18 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
           : null;
       const normalizedToolPart =
         normalizedBundle?.parts.find((part): part is ToolPart => part.type === 'tool') ?? null;
+      const completedReasoning = normalizedBundle?.parts.find((part): part is ReasoningPart => part.type === 'reasoning');
+      const completedInfo = normalizedBundle?.messages.find((info) => info.role === 'assistant');
+      if (completedReasoning && completedInfo && realtimeReasoningPart.value?.part.id !== completedReasoning.id) {
+        realtimeReasoningPart.value = {
+          info: completedInfo,
+          part: { ...completedReasoning, time: { ...completedReasoning.time, end: Date.now() } },
+          updatedAt: Date.now(),
+        };
+      }
+      if (normalizedToolPart?.tool === 'task' && completedInfo) {
+        realtimeCompletedPart.value = { info: completedInfo, part: normalizedToolPart, updatedAt: Date.now() };
+      }
       let completedToolMerged = false;
       if (isRecord(item) && typeof item.type === 'string') {
         const itemId = typeof item.id === 'string' ? item.id : '';
@@ -2357,6 +2370,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     realtimeHistoryQueue.value = [];
     realtimeMessageAliases.value = {};
     realtimeStreamingPart.value = null;
+    realtimeCompletedPart.value = null;
     realtimeReasoningPart.value = null;
     realtimeToolParts.value = [];
     loadingThread.value = true;
@@ -2450,6 +2464,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     canonicalHistory.value = [];
     realtimeHistoryQueue.value = [];
     realtimeStreamingPart.value = null;
+    realtimeCompletedPart.value = null;
     realtimeReasoningPart.value = null;
     realtimeToolParts.value = [];
     activeTurn.value = null;
@@ -2531,6 +2546,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       (entry) => entry.info.sessionID !== threadId,
     );
     if (activeThreadId.value === threadId) {
+      realtimeCompletedPart.value = null;
       realtimeReasoningPart.value = null;
       realtimeToolParts.value = [];
     }
@@ -3656,6 +3672,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     canonicalHistory,
     realtimeHistoryQueue,
     realtimeMessageAliases,
+    realtimeCompletedPart,
     realtimeStreamingPart,
     realtimeReasoningPart,
     realtimeToolParts,

--- a/app/composables/useCodexApi.ts
+++ b/app/composables/useCodexApi.ts
@@ -1016,8 +1016,9 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     };
   }
 
-  function setRealtimeReasoningCompleted(completedAt = Date.now()) {
-    if (!realtimeReasoningPart.value) return;
+  function setRealtimeReasoningCompleted(completedAt = Date.now(), turnId?: string) {
+    if (!realtimeReasoningPart.value || realtimeReasoningPart.value.part.time.end != null) return;
+    if (turnId && realtimeReasoningPart.value.part.messageID !== codexAssistantMessageId(turnId)) return;
     const current = realtimeReasoningPart.value;
     realtimeReasoningPart.value = {
       ...current,
@@ -1334,7 +1335,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       pruneServerRequestsForActiveContext();
       if (notification.method === 'turn/completed') {
         setRealtimeAssistantCompleted();
-        setRealtimeReasoningCompleted();
+        setRealtimeReasoningCompleted(Date.now(), turn?.id);
         realtimeStreamingPart.value = realtimeStreamingPart.value
           ? { ...realtimeStreamingPart.value, updatedAt: Date.now() }
           : null;

--- a/app/composables/useCodexMessageBridge.test.ts
+++ b/app/composables/useCodexMessageBridge.test.ts
@@ -20,6 +20,7 @@ function bridgeFixture() {
     codexApi: {
       realtimeHistoryQueue: ref<CodexCanonicalHistoryEntry[]>([]),
       realtimeMessageAliases: ref<Record<string, string>>({}),
+      realtimeCompletedPart: ref<{ info: AssistantMessageInfo | UserMessageInfo; part: MessagePart } | null>(null),
       realtimeStreamingPart: ref<{ info: AssistantMessageInfo | UserMessageInfo; part: MessagePart } | null>(null),
       realtimeReasoningPart: ref<{ info: AssistantMessageInfo | UserMessageInfo; part: ReasoningPart } | null>(null),
       realtimeToolParts: ref<Array<{ info: AssistantMessageInfo | UserMessageInfo; part: ToolPart }>>([]),
@@ -29,6 +30,8 @@ function bridgeFixture() {
     msg: { loadHistory: vi.fn(), updateMessage: vi.fn(), updatePart: vi.fn(), removeMessage: vi.fn() },
     syncRealtimeToolWindows: vi.fn(),
     updateReasoningExpiry: vi.fn(),
+    onLiveReasoning: vi.fn(),
+    onLiveSubagent: vi.fn(),
   };
   useCodexMessageBridge(params);
   return params;
@@ -201,6 +204,8 @@ describe('useCodexMessageBridge', () => {
       },
       syncRealtimeToolWindows,
       updateReasoningExpiry: vi.fn(),
+    onLiveReasoning: vi.fn(),
+    onLiveSubagent: vi.fn(),
     });
 
     realtimeHistoryQueue.value = restored;
@@ -217,4 +222,57 @@ describe('useCodexMessageBridge', () => {
     expect(updatePart).toHaveBeenCalledWith(expect.objectContaining({ type: 'file', url: 'data:image/png;base64,AA==' }));
 
   });
+});
+
+
+describe('Codex automatic streaming windows', () => {
+  it('opens reasoning only for live updates, deduplicates queue/stream and retains close delay', async () => {
+    const p = bridgeFixture();
+    const entries = normalizeCodexTurnsToHistory({sessionId: 'thread-1', turns: [{id: 'turn-r', items: [{id: 'reason', type: 'reasoning', summary: ['Thinking']}]}]});
+    const entry = entries.find(e => e.info.role === 'assistant');
+    const part = entry?.parts.find(p => p.type === 'reasoning');
+    if (!entry || !part) throw new Error('missing reasoning fixture');
+    p.history.value = entries;
+    await nextTick();
+    expect(p.onLiveReasoning).not.toHaveBeenCalled();
+    p.codexApi.realtimeHistoryQueue.value = entries;
+    await nextTick();
+    expect(p.onLiveReasoning).not.toHaveBeenCalled();
+    p.codexApi.realtimeReasoningPart.value = {info: entry.info, part};
+    await nextTick();
+    expect(p.onLiveReasoning).toHaveBeenCalledTimes(1);
+    expect(p.updateReasoningExpiry).not.toHaveBeenCalled();
+  });
+
+  it('opens each child from parent collaboration state and ignores historical or unrelated events', async () => {
+    const p = bridgeFixture();
+    const entries = normalizeCodexTurnsToHistory({sessionId: 'thread-1', turns: [{id: 'turn-c', items: [{id: 'spawn', type: 'collabAgentToolCall', tool: 'spawnAgent', status: 'completed', senderThreadId: 'thread-1', receiverThreadIds: ['child-a', 'child-b'], prompt: 'Inspect files', agentsStates: {'child-a': {status: 'running'}, 'child-b': {status: 'completed', message: 'All checked'}}}]}]});
+    p.history.value = entries;
+    await nextTick();
+    expect(p.onLiveSubagent).not.toHaveBeenCalled();
+    p.codexApi.realtimeHistoryQueue.value = entries;
+    await nextTick();
+    expect(p.onLiveSubagent).not.toHaveBeenCalled();
+    p.codexApi.realtimeToolParts.value = entries.flatMap(entry => entry.parts.flatMap(part => part.type === 'tool' ? [{info: entry.info, part}] : []));
+    await nextTick();
+    expect(p.onLiveSubagent).toHaveBeenCalledTimes(2);
+    expect(p.onLiveSubagent).toHaveBeenCalledWith(expect.objectContaining({sessionID: 'child-a'}), expect.objectContaining({text: expect.stringContaining('Inspect files'), time: expect.not.objectContaining({end: expect.any(Number)})}));
+    expect(p.onLiveSubagent).toHaveBeenCalledWith(expect.objectContaining({sessionID: 'child-b'}), expect.objectContaining({text: expect.stringContaining('All checked'), time: expect.objectContaining({end: expect.any(Number)})}));
+    p.codexApi.realtimeHistoryQueue.value = [...entries, ...normalizeCodexTurnsToHistory({sessionId:'unrelated', turns:[{id:'other',items:[{id:'other-spawn',type:'collabAgentToolCall', tool:'spawnAgent', receiverThreadIds:['stranger'], prompt:'Ignore'}]}]})];
+    await nextTick();
+    expect(p.onLiveSubagent).toHaveBeenCalledTimes(2);
+  });
+  it('publishes completed collaboration synchronously and deduplicates unchanged parts', async () => {
+    const p = bridgeFixture();
+    const [entry] = normalizeCodexTurnsToHistory({sessionId: 'thread-1', turns: [{id: 'turn-c', items: [{id: 'wait', type: 'collabAgentToolCall', tool: 'wait', status: 'completed', senderThreadId: 'thread-1', receiverThreadIds: ['child'], agentsStates: {child: {status: 'interrupted'}}}]}]});
+    const part = entry?.parts[0];
+    if (!entry || !part) throw new Error('missing completed fixture');
+    p.codexApi.realtimeCompletedPart.value = { info: entry.info, part };
+    expect(p.onLiveSubagent).toHaveBeenCalledTimes(1);
+    expect(p.onLiveSubagent.mock.calls[0]?.[1]).toMatchObject({text: 'interrupted', time: {end: expect.any(Number)}});
+    p.codexApi.realtimeCompletedPart.value = { info: entry.info, part: {...part} };
+    await nextTick();
+    expect(p.onLiveSubagent).toHaveBeenCalledTimes(1);
+  });
+
 });

--- a/app/composables/useCodexMessageBridge.ts
+++ b/app/composables/useCodexMessageBridge.ts
@@ -1,8 +1,9 @@
 import { computed, ref, watch, type Ref } from 'vue';
 import type { BackendKind } from '../backends/types';
 import type { CodexCanonicalHistoryEntry } from '../backends/codex/normalize';
+import { codexSubagentWindowEntries } from '../utils/codexSubagentWindowEntries';
 import type { MessageDiffEntry } from '../types/message';
-import type { AssistantMessageInfo, MessagePart, ReasoningPart, ToolPart, UserMessageInfo } from '../types/sse';
+import type { AssistantMessageInfo, MessagePart, ReasoningPart, TextPart, ToolPart, UserMessageInfo } from '../types/sse';
 
 type SharedMessageStore = {
   loadHistory: (entries: unknown[]) => void;
@@ -14,6 +15,7 @@ type SharedMessageStore = {
 type CodexMessageBridgeApi = {
   realtimeHistoryQueue: Ref<CodexCanonicalHistoryEntry[]>;
   realtimeMessageAliases: Ref<Record<string, string>>;
+  realtimeCompletedPart?: Ref<{ info: AssistantMessageInfo | UserMessageInfo; part: MessagePart } | null>;
   realtimeStreamingPart: Ref<{ info: AssistantMessageInfo | UserMessageInfo; part: MessagePart } | null>;
   realtimeReasoningPart: Ref<{ info: AssistantMessageInfo | UserMessageInfo; part: ReasoningPart } | null>;
   realtimeToolParts: Ref<Array<{ info: AssistantMessageInfo | UserMessageInfo; part: ToolPart }>>;
@@ -46,10 +48,28 @@ export function useCodexMessageBridge(params: {
   msg: SharedMessageStore;
   syncRealtimeToolWindows: (entries: CodexCanonicalHistoryEntry[]) => void;
   updateReasoningExpiry: (sessionId: string, state: 'idle' | 'busy') => void;
+  onLiveReasoning?: (info: AssistantMessageInfo | UserMessageInfo, part: ReasoningPart) => void;
+  onLiveSubagent?: (info: AssistantMessageInfo, part: TextPart) => void;
 }) {
   const lastRealtimeQueueSignature = ref('');
   const publishedMessages = new Map<string, string>();
   const publishedParts = new Map<string, string>();
+  const liveWindowParts = new Map<string, string>();
+
+  function publishLiveWindow(info: AssistantMessageInfo | UserMessageInfo, part: MessagePart) {
+    if (part.type !== 'reasoning' && !(part.type === 'tool' && part.tool === 'task')) return;
+    const key = `${info.sessionID}:${part.id}`;
+    const signature = JSON.stringify(part);
+    if (liveWindowParts.get(key) === signature) return;
+    liveWindowParts.set(key, signature);
+    if (part.type === 'reasoning') {
+      if (part.text.trim()) params.onLiveReasoning?.(info, part);
+    } else if (info.role === 'assistant') {
+      for (const child of codexSubagentWindowEntries(info, part)) {
+        params.onLiveSubagent?.(child.info, child.part);
+      }
+    }
+  }
 
   function updateMessage(info: AssistantMessageInfo | UserMessageInfo) {
     const signature = JSON.stringify(info);
@@ -67,6 +87,7 @@ export function useCodexMessageBridge(params: {
 
   function resetPublishedState() {
     lastRealtimeQueueSignature.value = '';
+    liveWindowParts.clear();
     publishedMessages.clear();
     publishedParts.clear();
   }
@@ -174,7 +195,9 @@ export function useCodexMessageBridge(params: {
     const realtimeEntries = params.codexApi.realtimeHistoryQueue.value.filter((entry) => matchesActiveCodexRealtimeSession(entry.info.sessionID));
     for (const entry of realtimeEntries) {
       updateMessage(entry.info);
-      for (const part of entry.parts) updatePart(part);
+      for (const part of entry.parts) {
+        updatePart(part);
+      }
     }
     params.syncRealtimeToolWindows(realtimeEntries);
   });
@@ -187,7 +210,7 @@ export function useCodexMessageBridge(params: {
     if (!matchesActiveCodexRealtimeSession(streaming.info.sessionID)) return;
     updateMessage(streaming.info);
     updatePart(streaming.part);
-    if (streaming.part.type === 'text' && streaming.part.time?.end) {
+    if (!params.onLiveReasoning && streaming.part.type === 'text' && streaming.part.time?.end) {
       params.updateReasoningExpiry(streaming.part.sessionID, 'idle');
     }
   });
@@ -198,8 +221,17 @@ export function useCodexMessageBridge(params: {
     if (!matchesActiveCodexRealtimeSession(reasoning.info.sessionID)) return;
     updateMessage(reasoning.info);
     updatePart(reasoning.part);
-    params.updateReasoningExpiry(reasoning.part.sessionID, reasoning.part.time?.end ? 'idle' : 'busy');
+    publishLiveWindow(reasoning.info, reasoning.part);
+    if (!params.onLiveReasoning) params.updateReasoningExpiry(reasoning.part.sessionID, reasoning.part.time?.end ? 'idle' : 'busy');
   });
+
+  if (params.codexApi.realtimeCompletedPart) {
+    watch(params.codexApi.realtimeCompletedPart, (entry) => {
+      if (params.activeBackendKind.value !== 'codex' || !entry) return;
+      if (!matchesActiveCodexRealtimeSession(entry.info.sessionID)) return;
+      publishLiveWindow(entry.info, entry.part);
+    }, { flush: 'sync' });
+  }
 
   watch(params.codexApi.realtimeToolParts, (toolParts) => {
     if (params.activeBackendKind.value !== 'codex') return;
@@ -207,6 +239,7 @@ export function useCodexMessageBridge(params: {
     for (const { info, part } of toolParts.filter(({ info }) => matchesActiveCodexRealtimeSession(info.sessionID))) {
       updateMessage(info);
       updatePart(part);
+      publishLiveWindow(info, part);
     }
   }, { deep: true });
 

--- a/app/composables/useReasoningWindows.ts
+++ b/app/composables/useReasoningWindows.ts
@@ -1,5 +1,6 @@
 import { type Component, type Ref } from 'vue';
 import type {
+  MessageInfo,
   MessagePart,
   MessagePartDeltaPacket,
   MessagePartUpdatedPacket,
@@ -118,7 +119,7 @@ export function useReasoningWindows(options: UseReasoningWindowsOptions) {
     finishedReasoningByKey.clear();
   }
 
-  function handleReasoningPart(part: MessagePart) {
+  function handleReasoningPart(part: MessagePart, info?: MessageInfo) {
     if (part.type !== 'reasoning') return;
 
     const resolvedSessionId = part.sessionID || selectedSessionId.value;
@@ -137,7 +138,7 @@ export function useReasoningWindows(options: UseReasoningWindowsOptions) {
 
     manager.upsertEntry(resolvedSessionId, partId, messageText, !!part.time?.end);
 
-    const messageInfo = manager.acc.getMessage(messageId)?.info;
+    const messageInfo = info ?? manager.acc.getMessage(messageId)?.info;
     const isSubagent = resolvedSessionId !== selectedSessionId.value;
     let modelLabel: string | undefined;
     if (messageInfo?.role === 'assistant') {
@@ -207,5 +208,6 @@ export function useReasoningWindows(options: UseReasoningWindowsOptions) {
     reset,
     entriesBySession: manager.entriesBySession,
     bindScope: subscribe,
+    handlePart: handleReasoningPart,
   };
 }

--- a/app/composables/useSubagentWindows.ts
+++ b/app/composables/useSubagentWindows.ts
@@ -1,5 +1,6 @@
 import { type Component, type Ref } from 'vue';
 import type {
+  MessageInfo,
   MessagePart,
   MessagePartDeltaPacket,
   MessagePartUpdatedPacket,
@@ -50,7 +51,7 @@ export function useSubagentWindows(options: UseSubagentWindowsOptions) {
     activeMessageIdBySession.clear();
   }
 
-  function handleTextPart(part: MessagePart) {
+  function handleTextPart(part: MessagePart, info?: MessageInfo) {
     if (part.type !== 'text') return;
 
     const resolvedSessionId = part.sessionID || selectedSessionId.value;
@@ -65,7 +66,7 @@ export function useSubagentWindows(options: UseSubagentWindowsOptions) {
 
     manager.upsertEntry(resolvedSessionId, partId, messageText, !!part.time?.end);
 
-    const messageInfo = manager.acc.getMessage(messageId)?.info;
+    const messageInfo = info ?? manager.acc.getMessage(messageId)?.info;
     let modelLabel: string | undefined;
     let agentLabel: string | undefined;
     if (messageInfo?.role === 'assistant') {
@@ -80,6 +81,7 @@ export function useSubagentWindows(options: UseSubagentWindowsOptions) {
       ? `🤖 [${modelLabel}] ${agentPart}Working...`
       : `🤖 ${agentPart}Working...`;
 
+    if (part.time?.end) manager.markSessionCompleted(resolvedSessionId);
     manager.openWindow(resolvedSessionId, title);
 
     if (part.time?.end) {
@@ -120,5 +122,6 @@ export function useSubagentWindows(options: UseSubagentWindowsOptions) {
     reset,
     entriesBySession: manager.entriesBySession,
     bindScope: subscribe,
+    handlePart: handleTextPart,
   };
 }

--- a/app/utils/codexSubagentWindowEntries.ts
+++ b/app/utils/codexSubagentWindowEntries.ts
@@ -1,0 +1,40 @@
+import type { AssistantMessageInfo, TextPart, ToolPart } from '../types/sse';
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+export function codexSubagentWindowEntries(info: AssistantMessageInfo, part: ToolPart) {
+  if (part.tool !== 'task' || part.state.status === 'pending') return [];
+  const metadata = part.state.metadata;
+  if (!metadata || (metadata.senderThreadId && metadata.senderThreadId !== info.sessionID)) return [];
+  const ids = Array.isArray(metadata.sessionIds) ? metadata.sessionIds : [metadata.sessionId];
+  const states = record(metadata.agentsStates);
+  const prompt = typeof part.state.input.prompt === 'string' ? part.state.input.prompt : '';
+  const model = typeof part.state.input.model === 'string' ? part.state.input.model : '';
+  const entries: Array<{ info: AssistantMessageInfo; part: TextPart }> = [];
+  for (const id of new Set(ids)) {
+    if (typeof id !== 'string' || !id || id === info.sessionID) continue;
+    const state = record(states?.[id]);
+    const status = typeof state?.status === 'string' ? state.status : '';
+    const message = typeof state?.message === 'string' ? state.message : '';
+    const text = [status, message || prompt].filter(Boolean).join('\n\n');
+    if (!text.trim()) continue;
+    const completed = ['completed', 'interrupted', 'errored', 'shutdown', 'notFound'].includes(status);
+    const messageId = `${part.messageID}:subagent:${id}`;
+    entries.push({
+      info: { ...info, id: messageId, sessionID: id, modelID: model, agent: '', time: { created: info.time.created } },
+      part: {
+        id: `${part.id}:subagent:${id}`,
+        messageID: messageId,
+        sessionID: id,
+        type: 'text',
+        text,
+        time: { start: part.state.time.start, ...(completed ? { end: Date.now() } : {}) },
+      },
+    });
+  }
+  return entries;
+}


### PR DESCRIPTION
## 修改

Codex 的实时思考和子代理记录此前仅更新消息数据，没有接入自动悬浮窗。现在实时思考内容、父会话上报的子代理状态/任务/结果会使用现有窗口展示。

- 历史加载、缓存恢复和无关会话事件不会触发自动弹出，保留“禁止自动弹窗”开关。
- 独立传递工具完成事件，避免实时记录移除后丢失子代理最终内容。
- 完成、打断等终态保留关闭延迟；回合结束不会提前关窗，后续无思考内容的回合也不会重新弹出旧思考。
- 复用现有窗口组件与主题，保持 OpenCode 事件接入。

子代理窗口展示父会话报告的状态、任务和结果，不声称订阅独立子线程的全文实时流。

## 验证

- 156 项相关测试、类型检查、lint 和构建通过。
- 浏览器使用真实 Vue 组件、窗口管理器及模拟 Codex 协议，验证自动显示内容、最终状态保留约 3 秒、禁止弹窗、历史回填和跨回合不重放。
- 浏览器额外执行 App 的实际停止思考监听，覆盖思考完成后紧接回合完成的关闭时序。
- 未调用真实模型；五项独立 PR 审查与运行时检查通过。
