### PR TITLE
fix(codex): show reasoning effort in message headers

### DIFF
--- a/app/backends/codex/messageEffort.test.ts
+++ b/app/backends/codex/messageEffort.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { restoreCodexMessageEfforts, saveCodexTurnEffort } from './messageEffort';
+import { normalizeCodexTurnsToHistory } from './normalize';
+import { StorageKeys, storageSetJSON } from '../../utils/storageKeys';
+
+function history(threadId: string) {
+  return normalizeCodexTurnsToHistory({
+    sessionId: threadId,
+    turns: [{ id: 'turn', items: [
+      { type: 'userMessage', content: [{ type: 'text', text: 'Question' }] },
+      { type: 'agentMessage', id: 'answer', text: 'Answer' },
+    ] }],
+  });
+}
+
+describe('Codex per-turn effort metadata', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('keeps identical turn IDs isolated by thread', () => {
+    saveCodexTurnEffort('thread-a', 'turn', 'high');
+    saveCodexTurnEffort('thread-b', 'turn', 'low');
+    expect(restoreCodexMessageEfforts('thread-a', history('thread-a')).map(entry => entry.info.variant)).toEqual(['high', 'high']);
+    expect(restoreCodexMessageEfforts('thread-b', history('thread-b')).map(entry => entry.info.variant)).toEqual(['low', 'low']);
+  });
+
+  it('ignores malformed saved effort values', () => {
+    storageSetJSON(`${StorageKeys.state.codexTurnEfforts}.thread`, { 'turn:user:0': { effort: 'high' } });
+    expect(restoreCodexMessageEfforts('thread', history('thread')).map(entry => entry.info.variant)).toEqual([undefined, undefined]);
+  });
+
+  it('does not infer a variant when the request omitted its effort', () => {
+    saveCodexTurnEffort('thread', 'turn', undefined);
+    expect(restoreCodexMessageEfforts('thread', history('thread')).map(entry => entry.info.variant)).toEqual([undefined, undefined]);
+  });
+
+  it('preserves effort supplied by message metadata over a saved selection', () => {
+    saveCodexTurnEffort('thread', 'turn', 'high');
+    const entries = history('thread').map(entry => ({ ...entry, info: { ...entry.info, variant: 'low' } }));
+    expect(restoreCodexMessageEfforts('thread', entries).map(entry => entry.info.variant)).toEqual(['low', 'low']);
+  });
+});

--- a/app/backends/codex/messageEffort.ts
+++ b/app/backends/codex/messageEffort.ts
@@ -1,0 +1,33 @@
+import type { CodexCanonicalHistoryEntry } from './normalize';
+import { codexUserMessageId } from './normalize';
+import { StorageKeys, storageGetJSON, storageSetJSON } from '../../utils/storageKeys';
+
+function snapshotKey(threadId: string) {
+  return `${StorageKeys.state.codexTurnEfforts}.${encodeURIComponent(threadId)}`;
+}
+
+function loadEfforts(threadId: string): Map<string, string> {
+  const value = storageGetJSON<unknown>(snapshotKey(threadId));
+  const efforts = new Map<string, string>();
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return efforts;
+  for (const [id, effort] of Object.entries(value)) {
+    if (typeof effort === 'string' && effort.trim()) efforts.set(id, effort);
+  }
+  return efforts;
+}
+
+export function saveCodexTurnEffort(threadId: string, turnId: string, effort: string | undefined) {
+  if (!effort) return;
+  const efforts = loadEfforts(threadId);
+  efforts.set(codexUserMessageId(turnId, 0), effort);
+  storageSetJSON(snapshotKey(threadId), Object.fromEntries(efforts));
+}
+
+export function restoreCodexMessageEfforts(threadId: string, entries: CodexCanonicalHistoryEntry[]) {
+  const efforts = loadEfforts(threadId);
+  return entries.map(entry => {
+    const userId = entry.info.role === 'user' ? entry.info.id : entry.info.parentID;
+    const variant = entry.info.variant ?? efforts.get(userId);
+    return variant ? { ...entry, info: { ...entry.info, variant } } : entry;
+  });
+}

--- a/app/composables/useCodexApi.test.ts
+++ b/app/composables/useCodexApi.test.ts
@@ -137,6 +137,44 @@ describe('useCodexApi', () => {
     localStorage.clear();
   });
 
+  it('retains selected effort through the pending prompt and server echo', async () => {
+    const mock = createAdapterMock();
+    const reply = deferred<CodexPromptResult>();
+    mock.adapter.sendPrompt = vi.fn(() => reply.promise);
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    const sending = api.sendPrompt('Explain', { effort: 'high' });
+    expect(api.realtimeHistoryQueue.value.find(entry => entry.info.role === 'user')?.info.variant).toBe('high');
+    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_effort', item: { type: 'userMessage', id: 'u', content: [{ type: 'text', text: 'Explain' }] } } });
+    reply.resolve({ threadId: 'thr_existing', turn: { id: 'turn_effort', status: 'inProgress' } });
+    await sending;
+    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_effort', item: { type: 'agentMessage', id: 'a', text: 'Answer' } } });
+    const messages = api.realtimeHistoryQueue.value.map(entry => entry.info);
+    expect(messages.filter(info => info.role === 'user')).toHaveLength(1);
+    expect(messages.every(info => info.variant === 'high')).toBe(true);
+  });
+
+  it('restores each captured turn effort after reload without labelling unknown turns', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    for (const [id, effort] of [['turn_high', 'high'], ['turn_low', 'low']]) {
+      vi.mocked(mock.adapter.sendPrompt).mockResolvedValueOnce({ threadId: 'thr_existing', turn: { id, status: 'inProgress' } });
+      await api.sendPrompt('Explain', { effort });
+    }
+    vi.mocked(mock.adapter.readThread).mockResolvedValue({ thread: { id: 'thr_existing', name: 'Existing', turns: ['turn_high', 'turn_low', 'turn_unknown'].map(id => ({ id, items: [
+      { type: 'userMessage', id: 'u', content: [{ type: 'text', text: 'Explain' }] },
+      { type: 'agentMessage', id: 'a', text: 'Answer' },
+    ] })) } });
+    api.disconnect();
+    const restored = useCodexApi({ adapterFactory: () => mock.adapter });
+    await restored.connect();
+    await restored.selectThread('thr_existing');
+    expect(restored.canonicalHistory.value.map(entry => entry.info.variant)).toEqual(['high', 'high', 'low', 'low', undefined, undefined]);
+    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_high', item: { type: 'userMessage', id: 'u', content: [{ type: 'text', text: 'Explain' }] } } });
+    expect(restored.realtimeHistoryQueue.value.find(entry => entry.info.id === 'turn_high:user:0')?.info.variant).toBe('high');
+  });
+
   it('keeps restored replies attached to their original user across tool events', async () => {
     const mock = createAdapterMock();
     const api = useCodexApi({ adapterFactory: () => mock.adapter });

--- a/app/composables/useCodexApi.ts
+++ b/app/composables/useCodexApi.ts
@@ -88,6 +88,7 @@ import {
   mergeCodexAuxiliaryHistory,
   saveCodexAuxiliaryHistory,
 } from '../backends/codex/auxiliaryHistory';
+import { restoreCodexMessageEfforts, saveCodexTurnEffort } from '../backends/codex/messageEffort';
 import type { ConfigMergeStrategy } from '../backends/types';
 import { getPersistedCodexBridgeToken, getPersistedCodexBridgeUrl } from '../backends/registry';
 import type {
@@ -812,14 +813,14 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     for (const turn of turns) recordObservedTurnId(activeThreadId.value, turn.id);
     const selectedModelInfo = parseSelectedCodexModel(selectedModel.value);
     const modelName = selectedModelInfo.modelID || selectedModelInfo.providerID;
-    canonicalHistory.value = normalizeCodexTurnsToHistory({
+    canonicalHistory.value = restoreCodexMessageEfforts(activeThreadId.value, normalizeCodexTurnsToHistory({
       sessionId: activeThreadId.value ?? 'codex-thread',
       turns,
       model: {
         providerID: activeThread?.modelProvider || selectedModelInfo.providerID,
         modelID: selectedModelInfo.modelID || undefined,
       },
-    });
+    }));
     const textEntries = canonicalHistory.value.flatMap((entry) => {
       const role = entry.info.role === 'assistant' ? 'assistant' : 'user';
       return entry.parts
@@ -915,6 +916,8 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       return { ...existing, parentID: parentId || existing.parentID };
     }
     const model = parseSelectedCodexModel(selectedModel.value);
+    const parent = [...realtimeHistoryQueue.value, ...canonicalHistory.value]
+      .find(entry => entry.info.id === parentId && entry.info.sessionID === sessionId);
     return {
       id: messageId,
       sessionID: sessionId,
@@ -923,6 +926,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       parentID: parentId,
       modelID: model.modelID || 'codex',
       providerID: model.providerID,
+      variant: parent?.info.variant,
       mode: 'codex',
       agent: 'codex',
       path: { cwd: '', root: '' },
@@ -1119,9 +1123,12 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       (current) => current.info.id === entry.info.id,
     );
     if (existingIndex === -1) {
+      const knownVariant = canonicalHistory.value.find(current =>
+        current.info.id === entry.info.id && current.info.sessionID === entry.info.sessionID,
+      )?.info.variant;
       realtimeHistoryQueue.value = dedupeRealtimeHistoryQueue([
         ...realtimeHistoryQueue.value,
-        entry,
+        knownVariant && !entry.info.variant ? { ...entry, info: { ...entry.info, variant: knownVariant } } : entry,
       ]);
       return;
     }
@@ -1133,7 +1140,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     });
     const nextQueue = [...realtimeHistoryQueue.value];
     nextQueue[existingIndex] = {
-      info: entry.info,
+      info: { ...entry.info, variant: entry.info.variant ?? existing.info.variant },
       parts: Array.from(partsById.values()),
     };
     realtimeHistoryQueue.value = dedupeRealtimeHistoryQueue(nextQueue);
@@ -2415,11 +2422,11 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     const sourceAdapter = adapter;
     if (!sourceAdapter) throw new Error('Codex is not connected.');
     const read = await readThreadForHistory(threadId, sourceAdapter);
-    const entries = normalizeCodexTurnsToHistory({
+    const entries = restoreCodexMessageEfforts(threadId, normalizeCodexTurnsToHistory({
       sessionId: threadId,
       turns: read.thread.turns ?? [],
       model: { providerID: read.thread.modelProvider },
-    });
+    }));
     const hydrated = await hydrateThreadImages(entries, sourceAdapter);
     if (adapter !== sourceAdapter) throw new Error('Codex connection changed.');
     return hydrated;
@@ -2858,6 +2865,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       role: 'user',
       time: { created: now },
       agent: 'codex',
+      variant: options.effort,
       model: {
         providerID: selectedModelInfo.providerID,
         modelID: selectedModelInfo.modelID || 'unknown',
@@ -2886,11 +2894,15 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       activeTurn.value = result.turn;
 
       const finalizedTurnId = result.turn.id || pendingTurnId;
+      saveCodexTurnEffort(result.threadId, finalizedTurnId, options.effort);
       recordObservedTurnId(result.threadId, finalizedTurnId);
       const finalizedUserMessageId = codexUserMessageId(finalizedTurnId, 0);
       if (realtimeHistoryQueue.value.length > 0) {
         let updated = false;
         const nextQueue = realtimeHistoryQueue.value.map((entry) => {
+          if (entry.info.id === finalizedUserMessageId) {
+            return { ...entry, info: { ...entry.info, variant: options.effort } };
+          }
           if (entry.info.id !== userMessageId) return entry;
           updated = true;
           return {

--- a/app/utils/storageKeys.ts
+++ b/app/utils/storageKeys.ts
@@ -196,6 +196,7 @@ export const StorageKeys = {
     codexActiveThread: 'state.codexActiveThread.v1',
     codexPanelConnected: 'state.codexPanelConnected.v1',
     codexAuxiliaryHistory: 'state.codexAuxiliaryHistory.v1',
+    codexTurnEfforts: 'state.codexTurnEfforts.v1',
     forgePtyId: 'state.forgePtyId.v1',
     acpArchivedSessions: 'state.acpArchivedSessions.v1',
     acpMessageAttribution: 'state.acpMessageAttribution.v1',


### PR DESCRIPTION
## 修改

Codex 回合卡片此前只显示代理和模型名，缺少已选择的思考强度。现在沿用 OpenCode 的标题组件，显示为 `codex gpt-6-astra · high`。

- 发送时保存所选强度，保留消息回传和历史刷新后的标题显示。
- 按线程和回合保存强度；连续使用 high、low 的回合各自保留原值。
- 无法确定强度的旧历史保持留空，不用线程当前配置推断旧回合。
- 复用现有组件与主题，不更改请求的思考强度或 OpenCode 展示逻辑。

## 验证

- 187 项相关测试、类型检查、lint、构建通过。
- 浏览器使用真实组件与模拟 Codex 协议，覆盖发送、回传、完成、刷新、未知历史及 375/768/1280 像素宽度。
- 未调用真实模型，也未覆盖完整 App 页面和真实服务端通信。

非阻塞跟进：若助手完成通知早于发送响应，助手自身元数据可能暂缺强度；卡片标题优先读取用户消息的强度，因此本次修复的标题显示不受影响。
