### PR TITLE
fix(codex): preserve session activity and supplemental message history

### DIFF
--- a/app/backends/codex/auxiliaryHistoryIdentity.test.ts
+++ b/app/backends/codex/auxiliaryHistoryIdentity.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { migrateCodexAuxiliaryHistory } from './auxiliaryHistoryIdentity';
+import { normalizeCodexTurnsToHistory, type CodexCanonicalHistoryEntry } from './normalize';
+
+function fixture() {
+  const canonical = normalizeCodexTurnsToHistory({ sessionId: 's', turns: [{ id: 'turn', items: [
+    { id: 'wire-a', type: 'userMessage', content: [{ type: 'text', text: 'A' }] },
+    { id: 'reason-a', type: 'reasoning', summary: ['Think A'] },
+    { id: 'wire-b', type: 'userMessage', content: [{ type: 'text', text: 'B' }] },
+    { id: 'tool-b', type: 'commandExecution', command: 'echo B', status: 'completed' },
+  ] }] });
+  const assistant = canonical.find(entry => entry.info.role === 'assistant');
+  if (!assistant || assistant.info.role !== 'assistant') throw new Error('Missing fixture assistant');
+  const cached: CodexCanonicalHistoryEntry[] = [{
+    info: { ...assistant.info, id: 'turn:assistant', parentID: 'turn:user:1' },
+    parts: canonical.flatMap(entry => entry.parts).filter(part => part.type === 'tool' || part.type === 'reasoning')
+      .map(part => ({ ...part, messageID: 'turn:assistant' })),
+  }];
+  return { canonical, cached };
+}
+
+describe('cached Codex auxiliary identity migration', () => {
+  it('splits legacy shared assistants and maps their known ordinal parent to a canonical user', () => {
+    const { canonical, cached } = fixture();
+    const migrated = migrateCodexAuxiliaryHistory(cached, canonical);
+    expect(migrated.map(entry => entry.info.id)).toEqual(['turn:assistant:reason-a', 'turn:assistant:tool-b']);
+    expect(migrated.map(entry => entry.info.role === 'assistant' && entry.info.parentID)).toEqual(['turn:user:wire-b', 'turn:user:wire-b']);
+    expect(migrated.every(entry => entry.parts.length === 1 && entry.parts[0]?.messageID === entry.info.id)).toBe(true);
+    expect(cached[0]?.info.id).toBe('turn:assistant');
+  });
+
+  it('preserves new IDs and parents and does not guess missing legacy parent mappings', () => {
+    const { canonical, cached } = fixture();
+    expect(migrateCodexAuxiliaryHistory(canonical, canonical)).toEqual(canonical);
+    const migrated = migrateCodexAuxiliaryHistory(cached, []);
+    expect(migrated.every(entry => entry.info.role === 'assistant' && entry.info.parentID === 'turn:user:1')).toBe(true);
+  });
+});

--- a/app/backends/codex/auxiliaryHistoryIdentity.ts
+++ b/app/backends/codex/auxiliaryHistoryIdentity.ts
@@ -1,0 +1,42 @@
+import { codexAssistantMessageId, codexUserMessageId, type CodexCanonicalHistoryEntry } from './normalize';
+
+export function migrateCodexAuxiliaryHistory(
+  cached: ReadonlyArray<CodexCanonicalHistoryEntry>,
+  canonical: ReadonlyArray<CodexCanonicalHistoryEntry>,
+): CodexCanonicalHistoryEntry[] {
+  const aliases = new Map<string, Map<string, string>>();
+  const canonicalUsers = new Map<string, Set<string>>();
+  const ordinals = new Map<string, Map<string, number>>();
+  for (const { info } of canonical) {
+    if (info.role !== 'user') continue;
+    const separator = info.id.lastIndexOf(':user:');
+    if (separator < 0) continue;
+    const turnId = info.id.slice(0, separator);
+    const threadOrdinals = ordinals.get(info.sessionID) ?? new Map<string, number>();
+    const ordinal = threadOrdinals.get(turnId) ?? 0;
+    threadOrdinals.set(turnId, ordinal + 1);
+    ordinals.set(info.sessionID, threadOrdinals);
+    const threadAliases = aliases.get(info.sessionID) ?? new Map<string, string>();
+    threadAliases.set(codexUserMessageId(turnId, ordinal), info.id);
+    aliases.set(info.sessionID, threadAliases);
+    const users = canonicalUsers.get(info.sessionID) ?? new Set<string>();
+    users.add(info.id);
+    canonicalUsers.set(info.sessionID, users);
+  }
+
+  return cached.flatMap(entry => {
+    const { info } = entry;
+    if (info.role !== 'assistant') return [entry];
+    const parentID = canonicalUsers.get(info.sessionID)?.has(info.parentID)
+      ? info.parentID
+      : aliases.get(info.sessionID)?.get(info.parentID) ?? info.parentID;
+    if (!info.id.endsWith(':assistant')) {
+      return parentID === info.parentID ? [entry] : [{ ...entry, info: { ...info, parentID } }];
+    }
+    const turnId = info.id.slice(0, -':assistant'.length);
+    return entry.parts.map(part => {
+      const id = codexAssistantMessageId(turnId, part.id);
+      return { info: { ...info, id, parentID }, parts: [{ ...part, messageID: id }] };
+    });
+  });
+}

--- a/app/backends/codex/codexAdapter.test.ts
+++ b/app/backends/codex/codexAdapter.test.ts
@@ -326,6 +326,44 @@ describe('CodexAdapter', () => {
     });
   });
 
+  it('preserves distinct client message IDs when supplemental input returns the active turn ID', async () => {
+    MockWebSocket.instances = [];
+    const adapter = createCodexAdapter({
+      url: 'ws://localhost:4500',
+      webSocketCtor: MockWebSocket,
+    });
+    const firstInput = { text: 'Initial task', clientUserMessageId: 'client-first' };
+    const first = adapter.sendPrompt(firstInput);
+    const socket = MockWebSocket.instances[0];
+    if (!socket) throw new Error('Expected an opened adapter socket');
+    socket.emitOpen();
+    await waitForSent(socket, 1);
+    socket.respond(1, {});
+    await waitForSent(socket, 3);
+    socket.respond(2, { thread: { id: 'thr_active' } });
+    await waitForSent(socket, 4);
+    socket.respond(3, { turn: { id: 'turn_active', status: 'inProgress', items: [] } });
+    const firstResult = await first;
+
+    const followupInput = { threadId: 'thr_active', text: 'Supplement', clientUserMessageId: 'client-followup' };
+    const followup = adapter.sendPrompt(followupInput);
+    await waitForSent(socket, 5);
+    socket.respond(4, { thread: { id: 'thr_active' } });
+    await waitForSent(socket, 6);
+    socket.respond(5, { turn: { id: 'turn_active', status: 'inProgress', items: [] } });
+    const followupResult = await followup;
+
+    expect(followupResult.turn.id).toBe(firstResult.turn.id);
+    expect(JSON.parse(socket.sent[3] ?? '{}')).toMatchObject({
+      method: 'turn/start',
+      params: { clientUserMessageId: 'client-first', input: [{ type: 'text', text: 'Initial task' }] },
+    });
+    expect(JSON.parse(socket.sent[5] ?? '{}')).toMatchObject({
+      method: 'turn/start',
+      params: { clientUserMessageId: 'client-followup', input: [{ type: 'text', text: 'Supplement' }] },
+    });
+  });
+
   it('starts the first turn on an adapter-created thread without trying to resume it', async () => {
     MockWebSocket.instances = [];
     const adapter = createCodexAdapter({

--- a/app/backends/codex/codexAdapter.ts
+++ b/app/backends/codex/codexAdapter.ts
@@ -126,7 +126,7 @@ export type CodexThreadResumeParams = {
 };
 
 type CodexThreadResumeResult = {
-  thread: CodexThread;
+  thread: CodexThreadReadResult['thread'];
 };
 
 export type CodexThreadNameSetParams = {
@@ -225,6 +225,7 @@ export type CodexCollaborationModePayload = {
 
 export type CodexTurnStartParams = {
   threadId: string;
+  clientUserMessageId?: string;
   input: CodexTurnInputItem[];
   cwd?: string;
   collaborationMode?: CodexCollaborationModePayload;
@@ -739,6 +740,7 @@ type CodexConfigMcpServerReloadResult = {};
 // turn/* types
 export type CodexTurnSteerParams = {
   threadId: string;
+  clientUserMessageId?: string;
   input: CodexTurnInputItem[];
   expectedTurnId: string;
 };
@@ -1689,6 +1691,7 @@ export class CodexAdapter implements BackendAdapter {
         : [{ type: 'text', text: input.text } satisfies CodexTurnInputItem];
     const turn = await this.startTurn({
       threadId,
+      clientUserMessageId: input.clientUserMessageId,
       input: turnInput,
       cwd: input.cwd,
       collaborationMode: input.collaborationMode,

--- a/app/backends/codex/messageEffort.test.ts
+++ b/app/backends/codex/messageEffort.test.ts
@@ -16,6 +16,27 @@ function history(threadId: string) {
 describe('Codex per-turn effort metadata', () => {
   beforeEach(() => localStorage.clear());
 
+  it('restores distinct selections for supplemental users in the same turn', () => {
+    saveCodexTurnEffort('thread', 'turn', 'high', 'turn:user:a');
+    saveCodexTurnEffort('thread', 'turn', 'low', 'turn:user:b');
+    const entries = normalizeCodexTurnsToHistory({ sessionId: 'thread', turns: [{ id: 'turn', items: [
+      { id: 'a', type: 'userMessage', content: [{ type: 'text', text: 'A' }] },
+      { id: 'answer-a', type: 'agentMessage', text: 'A' },
+      { id: 'b', type: 'userMessage', content: [{ type: 'text', text: 'B' }] },
+      { id: 'answer-b', type: 'agentMessage', text: 'B' },
+    ] }] });
+    expect(restoreCodexMessageEfforts('thread', entries).map(entry => entry.info.variant)).toEqual(['high', 'high', 'low', 'low']);
+  });
+
+  it('restores old ordinal effort metadata to wire identities by user order', () => {
+    saveCodexTurnEffort('thread', 'turn', 'high');
+    const entries = normalizeCodexTurnsToHistory({ sessionId: 'thread', turns: [{ id: 'turn', items: [
+      { id: 'wire', type: 'userMessage', content: [{ type: 'text', text: 'A' }] },
+      { id: 'answer', type: 'agentMessage', text: 'A' },
+    ] }] });
+    expect(restoreCodexMessageEfforts('thread', entries).map(entry => entry.info.variant)).toEqual(['high', 'high']);
+  });
+
   it('keeps identical turn IDs isolated by thread', () => {
     saveCodexTurnEffort('thread-a', 'turn', 'high');
     saveCodexTurnEffort('thread-b', 'turn', 'low');

--- a/app/backends/codex/messageEffort.ts
+++ b/app/backends/codex/messageEffort.ts
@@ -16,15 +16,26 @@ function loadEfforts(threadId: string): Map<string, string> {
   return efforts;
 }
 
-export function saveCodexTurnEffort(threadId: string, turnId: string, effort: string | undefined) {
+export function saveCodexTurnEffort(threadId: string, turnId: string, effort: string | undefined, userMessageId?: string) {
   if (!effort) return;
   const efforts = loadEfforts(threadId);
-  efforts.set(codexUserMessageId(turnId, 0), effort);
+  efforts.set(userMessageId ?? codexUserMessageId(turnId, 0), effort);
   storageSetJSON(snapshotKey(threadId), Object.fromEntries(efforts));
 }
 
 export function restoreCodexMessageEfforts(threadId: string, entries: CodexCanonicalHistoryEntry[]) {
   const efforts = loadEfforts(threadId);
+  const ordinals = new Map<string, number>();
+  for (const entry of entries) {
+    if (entry.info.role !== 'user') continue;
+    const separator = entry.info.id.lastIndexOf(':user:');
+    if (separator < 0) continue;
+    const turnId = entry.info.id.slice(0, separator);
+    const ordinal = ordinals.get(turnId) ?? 0;
+    ordinals.set(turnId, ordinal + 1);
+    const legacyEffort = efforts.get(codexUserMessageId(turnId, ordinal));
+    if (!efforts.has(entry.info.id) && legacyEffort) efforts.set(entry.info.id, legacyEffort);
+  }
   return entries.map(entry => {
     const userId = entry.info.role === 'user' ? entry.info.id : entry.info.parentID;
     const variant = entry.info.variant ?? efforts.get(userId);

--- a/app/backends/codex/normalize.test.ts
+++ b/app/backends/codex/normalize.test.ts
@@ -2,6 +2,30 @@ import { describe, expect, it } from 'vitest';
 import { normalizeCodexTurnItems, normalizeCodexTurnsToHistory } from './normalize';
 
 describe('normalizeCodexTurnItems', () => {
+  it('keeps wire user identities identical for batch and incremental normalization', () => {
+    const items = [
+      { id: 'wire-a', clientId: 'client-a', type: 'userMessage', content: [{ type: 'text', text: 'A' }] },
+      { id: 'wire-b', type: 'userMessage', content: [{ type: 'text', text: 'B' }] },
+    ];
+    const batch = normalizeCodexTurnItems({ sessionId: 's', turnId: 't', items });
+    const incremental = items.flatMap(item => normalizeCodexTurnItems({ sessionId: 's', turnId: 't', items: [item] }).messages);
+    expect(batch.messages.map(message => message.id)).toEqual(['t:user:client-a', 't:user:wire-b']);
+    expect(incremental.map(message => message.id)).toEqual(batch.messages.map(message => message.id));
+  });
+
+  it('keeps auxiliary item identities and parents stable across supplemental user segments', () => {
+    const tool = { id: 'tool-a', type: 'commandExecution', command: 'echo A', status: 'completed' };
+    const reasoning = { id: 'reasoning-b', type: 'reasoning', summary: [{ text: 'Think B' }] };
+    const result = normalizeCodexTurnItems({ sessionId: 's', turnId: 't', items: [
+      { id: 'user-a', type: 'userMessage', content: [{ type: 'text', text: 'A' }] }, tool,
+      { id: 'user-b', type: 'userMessage', content: [{ type: 'text', text: 'B' }] }, reasoning,
+    ] });
+    expect(result.messages.filter(message => message.role === 'assistant').map(message => [message.id, message.parentID])).toEqual([
+      ['t:assistant:tool-a', 't:user:user-a'], ['t:assistant:reasoning-b', 't:user:user-b'],
+    ]);
+    const late = normalizeCodexTurnItems({ sessionId: 's', turnId: 't', items: [tool], parentMessageId: 't:user:user-a' });
+    expect(late.messages[0]).toMatchObject({ id: 't:assistant:tool-a', parentID: 't:user:user-a' });
+  });
   it('retains each assistant item as a separate chronological message around tools', () => {
     const result = normalizeCodexTurnItems({ sessionId: 's', turnId: 't', createdAt: 100, items: [
       { id: 'u', type: 'userMessage', content: [{ type: 'text', text: 'request' }] },
@@ -13,7 +37,7 @@ describe('normalizeCodexTurnItems', () => {
     expect(new Set(replies.map(part => part.id)).size).toBe(2);
     expect(new Set(replies.map(part => part.messageID)).size).toBe(2);
     expect(result.messages.filter(message => message.role === 'assistant').map(message => message.time.created)).toEqual([101, 102, 103]);
-    expect(result.messages.filter(message => message.role === 'assistant').every(message => message.parentID === 't:user:0')).toBe(true);
+    expect(result.messages.filter(message => message.role === 'assistant').every(message => message.parentID === 't:user:u')).toBe(true);
     const reloaded = normalizeCodexTurnsToHistory({ sessionId: 's', turns: [{ id: 't', items: [
       { id: 'u', type: 'userMessage', content: [{ type: 'text', text: 'request' }] },
       { id: 'a1', type: 'agentMessage', text: 'first' },
@@ -47,7 +71,7 @@ describe('normalizeCodexTurnItems', () => {
     expect(result.parts).toHaveLength(2);
     expect(result.parts[0]).toMatchObject({
       type: 'text',
-      messageID: 'turn-1:user:0',
+      messageID: 'turn-1:user:user-item',
       text: 'hello codex',
     });
     expect(result.parts[1]).toMatchObject({
@@ -90,9 +114,9 @@ describe('normalizeCodexTurnItems', () => {
     });
 
     expect(result.messages.find((message) => message.role === 'assistant')).toMatchObject({
-      id: 'turn-time:assistant',
+      id: 'turn-time:assistant:cmd-1',
       time: { created: 120, completed: 120 },
-      parentID: 'turn-time:user:0',
+      parentID: 'turn-time:user:user-item',
     });
   });
 
@@ -116,7 +140,7 @@ describe('normalizeCodexTurnItems', () => {
       ],
     });
 
-    expect(result.messages).toHaveLength(1);
+    expect(result.messages).toHaveLength(2);
     expect(result.messages[0]?.role).toBe('assistant');
     expect(result.parts).toHaveLength(2);
     expect(result.parts[0]).toMatchObject({
@@ -455,7 +479,7 @@ describe('normalizeCodexTurnItems', () => {
       ],
     });
 
-    expect(result.parts[0]?.id).toBe('turn-stable:user:0:text');
+    expect(result.parts[0]?.id).toBe('turn-stable:user:stable-user-id:text');
     expect(result.parts[1]?.id).toBe('turn-stable:assistant:stable-agent-id:text');
     expect(result.parts[2]?.id).toBe('stable-cmd-id');
   });
@@ -509,7 +533,7 @@ describe('normalizeCodexTurnItems', () => {
       ],
     });
 
-    expect(history).toHaveLength(3);
+    expect(history).toHaveLength(4);
     expect(history[0]?.info.role).toBe('user');
     expect(history[1]?.info.role).toBe('assistant');
     expect(history.flatMap(entry => entry.parts)).toEqual(

--- a/app/backends/codex/normalize.ts
+++ b/app/backends/codex/normalize.ts
@@ -28,7 +28,7 @@ export type CodexCanonicalHistoryEntry = {
   parts: MessagePart[];
 };
 
-export function codexUserMessageId(turnId: string, index = 0) {
+export function codexUserMessageId(turnId: string, index: string | number = 0) {
   return `${turnId}:user:${index}`;
 }
 
@@ -331,43 +331,23 @@ export function normalizeCodexTurnItems(params: {
   const messages: MessageInfo[] = [];
   const parts: MessagePart[] = [];
   let parentMessageId = params.parentMessageId ?? '';
-  let assistantMessageId = codexAssistantMessageId(params.turnId);
   let userMessageIndex = 0;
-  let assistantMessage: AssistantMessageInfo | undefined;
 
-  function ensureAssistantMessage(itemTime: number) {
-    if (!assistantMessage) {
-      let completedAt: number | undefined;
-      if (isCompleted) {
-        completedAt = turnCompletedTime ?? itemTime;
-      } else if (!hasExplicitStatus) {
-        completedAt = itemTime;
-      }
-      assistantMessage = createAssistantMessage({
-        id: assistantMessageId,
-        sessionId: params.sessionId,
-        parentId: parentMessageId,
-        createdAt: itemTime,
-        completedAt,
-        model: params.model,
-      });
-      messages.push(assistantMessage);
-      return assistantMessage;
+  function addAssistantMessage(messageId: string, itemTime: number) {
+    let completedAt: number | undefined;
+    if (isCompleted) {
+      completedAt = turnCompletedTime ?? itemTime;
+    } else if (!hasExplicitStatus) {
+      completedAt = itemTime;
     }
-
-    if (!assistantMessage.parentID && parentMessageId) {
-      assistantMessage.parentID = parentMessageId;
-    }
-    if (itemTime < assistantMessage.time.created) {
-      assistantMessage.time.created = itemTime;
-    }
-    if (isCompleted || !hasExplicitStatus) {
-      const currentCompleted = numberValue(assistantMessage.time.completed, assistantMessage.time.created);
-      if (itemTime > currentCompleted) {
-        assistantMessage.time.completed = itemTime;
-      }
-    }
-    return assistantMessage;
+    messages.push(createAssistantMessage({
+      id: messageId,
+      sessionId: params.sessionId,
+      parentId: parentMessageId,
+      createdAt: itemTime,
+      completedAt,
+      model: params.model,
+    }));
   }
 
   params.items.forEach((item, index) => {
@@ -381,7 +361,7 @@ export function normalizeCodexTurnItems(params: {
       const files = extractUserFiles(item);
       if (!text && files.length === 0) return;
       const message = createUserMessage({
-        id: codexUserMessageId(params.turnId, userMessageIndex),
+        id: codexUserMessageId(params.turnId, stringValue(item.clientId).trim() || stringValue(item.id).trim() || userMessageIndex),
         sessionId: params.sessionId,
         createdAt: itemTime,
         model: params.model,
@@ -430,7 +410,9 @@ export function normalizeCodexTurnItems(params: {
       return;
     }
 
-    ensureAssistantMessage(itemTime);
+    if (type === 'enteredReviewMode' || type === 'exitedReviewMode') return;
+    const assistantMessageId = codexAssistantMessageId(params.turnId, itemId);
+    addAssistantMessage(assistantMessageId, itemTime);
 
     if (type === 'commandExecution') {
       const command = commandText(item);

--- a/app/backends/codex/threadActivity.test.ts
+++ b/app/backends/codex/threadActivity.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createCodexThreadActivity } from './threadActivity';
+
+describe('Codex thread participation', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('preserves observed and locally sent participation after reload, leaving untouched idle unknown', () => {
+    const activity = createCodexThreadActivity();
+    activity.setConnection('ws://localhost:4500/ws');
+    activity.observe('observed', { type: 'active' });
+    activity.observe('observed', { type: 'idle' });
+    activity.observe('untouched', { type: 'idle' });
+    activity.markParticipated('sent');
+    activity.observe('retrying', { type: 'retry' });
+    const restored = createCodexThreadActivity();
+    restored.setConnection('ws://localhost:4500/ws');
+    expect([...restored.participatedThreadIds.value]).toEqual(['observed', 'sent', 'retrying']);
+  });
+
+  it('isolates different endpoints and restores participation when returning', () => {
+    const activity = createCodexThreadActivity();
+    activity.setConnection('ws://localhost:4500/one/ws');
+    activity.markParticipated('same-id');
+    for (const url of ['ws://localhost:4501/one/ws', 'ws://localhost:4500/two/ws', 'ws://other:4500/one/ws']) {
+      activity.setConnection(url);
+      expect(activity.participatedThreadIds.value.size).toBe(0);
+    }
+    activity.setConnection('ws://localhost:4500/one/ws');
+    expect(activity.participatedThreadIds.value.has('same-id')).toBe(true);
+  });
+
+  it('canonicalizes the connection without storing credentials', () => {
+    const activity = createCodexThreadActivity();
+    activity.setConnection('ws://user:secret@LOCALHOST:4500/ws?token=secret#secret');
+    activity.markParticipated('thread');
+    activity.setConnection('ws://localhost:4500/ws?token=replaced');
+    expect(activity.participatedThreadIds.value.has('thread')).toBe(true);
+    expect(Object.keys(localStorage).join(' ')).not.toContain('secret');
+  });
+});

--- a/app/backends/codex/threadActivity.ts
+++ b/app/backends/codex/threadActivity.ts
@@ -1,0 +1,36 @@
+import { ref } from 'vue';
+import { normalizeCodexStatus } from './codexAdapter';
+import { StorageKeys, storageGetJSON, storageSetJSON } from '../../utils/storageKeys';
+
+export function createCodexThreadActivity() {
+  const participatedThreadIds = ref(new Set<string>());
+  let storageKey = '';
+
+  function setConnection(url: string) {
+    const endpoint = new URL(url);
+    const scope = `${endpoint.protocol}//${endpoint.host}${endpoint.pathname}`;
+    const nextKey = `${StorageKeys.state.codexThreadActivity}.${encodeURIComponent(scope)}`;
+    const changed = storageKey !== nextKey;
+    storageKey = nextKey;
+    const saved = storageGetJSON<unknown>(storageKey);
+    participatedThreadIds.value = new Set(
+      Array.isArray(saved)
+        ? saved.filter((id): id is string => typeof id === 'string' && Boolean(id.trim()))
+        : [],
+    );
+    return changed;
+  }
+
+  function markParticipated(threadId: string) {
+    if (!storageKey || !threadId.trim() || participatedThreadIds.value.has(threadId)) return;
+    participatedThreadIds.value = new Set([...participatedThreadIds.value, threadId]);
+    storageSetJSON(storageKey, [...participatedThreadIds.value]);
+  }
+
+  function observe(threadId: string, status: unknown) {
+    const normalized = normalizeCodexStatus(status);
+    if (normalized === 'busy' || normalized === 'retry') markParticipated(threadId);
+  }
+
+  return { participatedThreadIds, setConnection, observe, markParticipated };
+}

--- a/app/composables/useBackendSessionStatus.test.ts
+++ b/app/composables/useBackendSessionStatus.test.ts
@@ -10,9 +10,39 @@ describe('useBackendSessionStatus', () => {
       busyDescendantCount: ref(0),
       runningToolCount: ref(0),
       codexActiveTurnStatus: ref('in_progress'),
-      getSessionStatus: () => 'idle',
+      getSessionStatus: () => undefined,
     });
 
+    expect(runtime.isThinking.value).toBe(true);
+  });
+
+  it.each(['busy', 'retry'])('restores Codex thinking from %s session status without a live turn', (status) => {
+    const runtime = useBackendSessionStatus({
+      activeBackendKind: ref('codex'), selectedSessionId: ref('session-1'),
+      busyDescendantCount: ref(0), runningToolCount: ref(0),
+      codexActiveTurnStatus: ref(undefined), getSessionStatus: () => status,
+    });
+    expect(runtime.isThinking.value).toBe(true);
+  });
+
+  it('stops thinking when authoritative session status becomes idle despite stale turn metadata', () => {
+    const status = ref('busy');
+    const runtime = useBackendSessionStatus({
+      activeBackendKind: ref('codex'), selectedSessionId: ref('session-1'),
+      busyDescendantCount: ref(0), runningToolCount: ref(0),
+      codexActiveTurnStatus: ref('inProgress'), getSessionStatus: () => status.value,
+    });
+    expect(runtime.isThinking.value).toBe(true);
+    status.value = 'idle';
+    expect(runtime.isThinking.value).toBe(false);
+  });
+
+  it('keeps Codex thinking while a descendant is busy', () => {
+    const runtime = useBackendSessionStatus({
+      activeBackendKind: ref('codex'), selectedSessionId: ref('session-1'),
+      busyDescendantCount: ref(1), runningToolCount: ref(0),
+      codexActiveTurnStatus: ref('completed'), getSessionStatus: () => 'idle',
+    });
     expect(runtime.isThinking.value).toBe(true);
   });
 

--- a/app/composables/useBackendSessionStatus.ts
+++ b/app/composables/useBackendSessionStatus.ts
@@ -10,15 +10,16 @@ export function useBackendSessionStatus(params: {
   getSessionStatus: (sessionId: string) => string | undefined;
 }) {
   const isThinking = computed(() => {
-    if (params.activeBackendKind.value === 'codex') {
-      const status = params.codexActiveTurnStatus.value;
-      return Boolean(status && status !== 'completed' && status !== 'failed' && status !== 'interrupted');
-    }
     const selected = params.selectedSessionId.value;
     const ownStatus = selected ? params.getSessionStatus(selected) : undefined;
+    const turnStatus = params.codexActiveTurnStatus.value;
+    const codexTurnActive = params.activeBackendKind.value === 'codex'
+      && ownStatus === undefined
+      && Boolean(turnStatus && turnStatus !== 'completed' && turnStatus !== 'failed' && turnStatus !== 'interrupted');
     return Boolean(
       ownStatus === 'busy'
       || ownStatus === 'retry'
+      || codexTurnActive
       || params.busyDescendantCount.value > 0
       || params.runningToolCount.value > 0,
     );

--- a/app/composables/useCodexApi.test.ts
+++ b/app/composables/useCodexApi.test.ts
@@ -1789,6 +1789,25 @@ describe('useCodexApi', () => {
     ]);
   });
 
+  it('restores background supplemental auxiliary records under their observed user', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    await api.selectThread('other');
+    const users = ['first', 'supplement'].map(id => ({ type: 'userMessage', id, clientId: id, content: [{ type: 'text', text: id }] }));
+    const emit = (item: Record<string, unknown>, phase = 'completed') => mock.emit({ method: `item/${phase}`, params: { threadId: 'background', turnId: 'shared', item } });
+    for (const user of users) {
+      emit(user);
+      if (user.id === 'first') emit({ type: 'commandExecution', id: 'old-tool', command: 'pwd' }, 'started');
+    }
+    emit({ type: 'reasoning', id: 'new-reason', summary: ['Supplement reasoning'] });
+    emit({ type: 'commandExecution', id: 'old-tool', command: 'pwd', status: 'completed' });
+    mock.adapter.readThread = vi.fn().mockResolvedValue({ thread: { id: 'background', turns: [{ id: 'shared', status: 'completed', items: users }] } });
+    await api.selectThread('background');
+    expect(api.realtimeHistoryQueue.value.find(entry => entry.parts.some(part => part.id === 'new-reason'))?.info).toMatchObject({ parentID: 'shared:user:supplement' });
+    expect(api.realtimeHistoryQueue.value.find(entry => entry.parts.some(part => part.id === 'old-tool'))?.info).toMatchObject({ parentID: 'shared:user:first' });
+  });
+
   it('persists a delayed completed item under its notification thread instead of the active thread', async () => {
     const mock = createAdapterMock();
     const api = useCodexApi({ adapterFactory: () => mock.adapter });

--- a/app/composables/useCodexApi.test.ts
+++ b/app/composables/useCodexApi.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useCodexApi } from './useCodexApi';
+import { useCodexWorkspace } from './useCodexWorkspace';
 import type {
   CodexAdapter,
   CodexPromptResult,
   CodexThreadGoal,
+  CodexThreadListResult,
 } from '../backends/codex/codexAdapter';
 import {
   CodexJsonRpcError,
@@ -137,6 +139,256 @@ describe('useCodexApi', () => {
     localStorage.clear();
   });
 
+  it('restores the running turn and interrupt target when selecting an active thread after refresh', async () => {
+    const mock = createAdapterMock();
+    const turn = { id: 'restored-turn', status: 'inProgress', items: [] };
+    vi.mocked(mock.adapter.readThread).mockResolvedValue({ thread: { id: 'thr_existing', turns: [turn] } });
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    await api.selectThread('thr_existing');
+    expect(api.activeTurn.value).toEqual(turn);
+    mock.emit({ method: 'thread/status/changed', params: { threadId: 'thr_existing', status: 'active' } });
+    await api.interruptActiveTurn();
+    expect(mock.adapter.interruptTurn).toHaveBeenCalledWith({ threadId: 'thr_existing', turnId: 'restored-turn' });
+    expect(useCodexWorkspace(api).project.value.sandboxes['/'].sessions['thr_existing'].status).toBe('idle');
+  });
+
+  it('restores the latest running turn returned by resume', async () => {
+    const mock = createAdapterMock();
+    const turn = { id: 'resumed-turn', status: 'inProgress', items: [] };
+    vi.mocked(mock.adapter.resumeThread).mockResolvedValue({ thread: { id: 'thr_existing', turns: [turn] } });
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    await api.selectThread('thr_existing');
+    expect(api.activeTurn.value).toEqual(turn);
+  });
+
+  it('does not overwrite a realtime completion with stale resumed running turn data', async () => {
+    const mock = createAdapterMock();
+    const reply = deferred<Awaited<ReturnType<CodexAdapter['resumeThread']>>>();
+    vi.mocked(mock.adapter.resumeThread).mockImplementation(() => reply.promise);
+    const turn = { id: 'restored-turn', status: 'inProgress', items: [] };
+    vi.mocked(mock.adapter.readThread).mockResolvedValue({ thread: { id: 'thr_existing', turns: [turn] } });
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    const selecting = api.selectThread('thr_existing');
+    await vi.waitFor(() => expect(mock.adapter.resumeThread).toHaveBeenCalled());
+    mock.emit({ method: 'turn/completed', params: { threadId: 'thr_existing', turn: { ...turn, status: 'completed' } } });
+    reply.resolve({ thread: { id: 'thr_existing', turns: [turn] } });
+    await selecting;
+    expect(api.activeTurn.value?.status).toBe('completed');
+  });
+
+  it('does not restore a historical completed turn as active', async () => {
+    const mock = createAdapterMock();
+    vi.mocked(mock.adapter.readThread).mockResolvedValue({ thread: { id: 'thr_existing', turns: [{ id: 'past', status: 'completed', items: [] }] } });
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    await api.selectThread('thr_existing');
+    expect(api.activeTurn.value).toBeNull();
+  });
+
+  it('keeps a newer realtime turn when an older running turn read resolves', async () => {
+    const mock = createAdapterMock();
+    const reply = deferred<Awaited<ReturnType<CodexAdapter['readThread']>>>();
+    vi.mocked(mock.adapter.readThread).mockImplementationOnce(() => reply.promise);
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    const selecting = api.selectThread('thr_existing');
+    const newerTurn = { id: 'newer-turn', status: 'inProgress', items: [] };
+    mock.emit({ method: 'turn/started', params: { threadId: 'thr_existing', turn: newerTurn } });
+    reply.resolve({ thread: { id: 'thr_existing', turns: [{ id: 'older-turn', status: 'inProgress', items: [] }] } });
+    await selecting;
+    expect(api.activeTurn.value).toEqual(newerTurn);
+  });
+
+  it('ignores the running turn from a read that resolves after selecting another thread', async () => {
+    const mock = createAdapterMock();
+    const reply = deferred<Awaited<ReturnType<CodexAdapter['readThread']>>>();
+    vi.mocked(mock.adapter.readThread).mockImplementationOnce(() => reply.promise);
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    const firstSelection = api.selectThread('thr_existing');
+    await api.selectThread('thr_other');
+    reply.resolve({ thread: { id: 'thr_existing', turns: [{ id: 'stale-turn', status: 'inProgress', items: [] }] } });
+    await firstSelection;
+    expect(api.activeThreadId.value).toBe('thr_other');
+    expect(api.activeTurn.value).toBeNull();
+  });
+
+  it('retains green idle only for participating threads across page reload and isolates connections', async () => {
+    const mock = createAdapterMock();
+    mock.adapter.listThreads = vi.fn().mockResolvedValue({ data: [
+      { id: 'thr_existing', status: { type: 'active' } },
+      { id: 'untouched', status: { type: 'idle' } },
+    ], nextCursor: null });
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect('ws://localhost:9001/codex');
+    const workspace = useCodexWorkspace(api);
+    const sessions = () => workspace.project.value.sandboxes['/'].sessions;
+    expect(sessions()['thr_existing'].status).toBe('busy');
+    mock.adapter.listThreads = vi.fn().mockResolvedValue({ data: [
+      { id: 'thr_existing', status: { type: 'idle' } },
+      { id: 'untouched', status: { type: 'idle' } },
+    ], nextCursor: null });
+    await api.refreshThreads();
+    expect(sessions()['thr_existing'].status).toBe('idle');
+    expect(sessions()['untouched'].status).toBe('unknown');
+    api.disconnect();
+    const restored = useCodexApi({ adapterFactory: () => mock.adapter });
+    await restored.connect('ws://localhost:9001/codex');
+    expect(useCodexWorkspace(restored).project.value.sandboxes['/'].sessions['thr_existing'].status).toBe('idle');
+    await restored.connect('ws://localhost:9002/codex');
+    expect(useCodexWorkspace(restored).project.value.sandboxes['/'].sessions['thr_existing'].status).toBe('unknown');
+    restored.disconnect();
+  });
+
+  it('applies short background activity notifications without waiting for a list refresh', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    const workspace = useCodexWorkspace(api);
+    mock.emit({ method: 'thread/status/changed', params: { threadId: 'background', status: { type: 'active' } } });
+    expect(workspace.project.value.sandboxes['/'].sessions['background']?.status).toBe('busy');
+    mock.emit({ method: 'thread/status/changed', params: { threadId: 'background', status: { type: 'idle' } } });
+    expect(workspace.project.value.sandboxes['/'].sessions['background']?.status).toBe('idle');
+    api.disconnect();
+  });
+
+  it('does not replace a newer idle notification with an older busy list response', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    mock.emit({ method: 'thread/status/changed', params: { threadId: 'thr_existing', status: 'active' } });
+    const listing = deferred<CodexThreadListResult>();
+    mock.adapter.listThreads = vi.fn(() => listing.promise);
+    const refresh = api.refreshThreads();
+    mock.emit({ method: 'thread/status/changed', params: { threadId: 'thr_existing', status: 'idle' } });
+    listing.resolve({ data: [{ id: 'thr_existing', status: 'active' }], nextCursor: null });
+    await refresh;
+    expect(useCodexWorkspace(api).project.value.sandboxes['/'].sessions['thr_existing'].status).toBe('idle');
+    api.disconnect();
+  });
+
+  it('does not revive completed activity when the send response arrives last', async () => {
+    const mock = createAdapterMock();
+    const reply = deferred<CodexPromptResult>();
+    mock.adapter.sendPrompt = vi.fn(() => reply.promise);
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    const send = api.sendPrompt('Fast turn');
+    mock.emit({ method: 'turn/started', params: { threadId: 'thr_existing', turn: { id: 'fast', status: 'inProgress' } } });
+    mock.emit({ method: 'turn/completed', params: { threadId: 'thr_existing', turn: { id: 'fast', status: 'completed' } } });
+    reply.resolve({ threadId: 'thr_existing', turn: { id: 'fast', status: 'inProgress' } });
+    await send;
+    expect(api.activeTurn.value?.status).toBe('completed');
+    expect(useCodexWorkspace(api).project.value.sandboxes['/'].sessions['thr_existing'].status).toBe('idle');
+    api.disconnect();
+  });
+
+  it('does not carry a running thread or a late send into another connection', async () => {
+    const mock = createAdapterMock();
+    const reply = deferred<CodexPromptResult>();
+    mock.adapter.sendPrompt = vi.fn(() => reply.promise);
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect('ws://localhost:9001/codex');
+    mock.emit({ method: 'thread/status/changed', params: { threadId: 'thr_existing', status: 'active' } });
+    const send = api.sendPrompt('Previous connection');
+    mock.adapter.listThreads = vi.fn().mockResolvedValue({ data: [{ id: 'other', status: 'idle' }], nextCursor: null });
+    await api.connect('ws://localhost:9002/codex');
+    expect(api.threads.value.map(thread => thread.id)).toEqual(['other']);
+    reply.resolve({ threadId: 'thr_existing', turn: { id: 'late', status: 'inProgress' } });
+    await send;
+    expect(api.participatedThreadIds.value.size).toBe(0);
+    expect(api.activeThreadId.value).toBe('other');
+    api.disconnect();
+  });
+
+  it('preserves item-start order when an earlier assistant finishes after later tools', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    const now = vi.spyOn(Date, 'now').mockReturnValue(100);
+    try {
+      mock.emit({ method: 'item/started', params: { threadId: 'thr_existing', turnId: 'turn_1', item: { type: 'agentMessage', id: 'z-first' } } });
+      mock.emit({ method: 'item/started', params: { threadId: 'thr_existing', turnId: 'turn_1', item: { type: 'commandExecution', id: 'a-second', command: 'pwd' } } });
+      now.mockReturnValue(200);
+      mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_1', item: { type: 'agentMessage', id: 'z-first', text: 'Delayed response' } } });
+      const assistant = api.realtimeHistoryQueue.value.find(entry => entry.info.id === 'turn_1:assistant:z-first');
+      const tool = api.realtimeToolParts.value.find(entry => entry.info.id === 'turn_1:assistant:a-second');
+      expect(assistant?.info.time.created).toBeLessThan(tool?.info.time.created ?? 0);
+    } finally {
+      now.mockRestore();
+      api.disconnect();
+    }
+  });
+
+  it('keeps supplemental echoes, item parents and card identities stable through history reload', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    await api.sendPrompt('Same text', { effort: 'high' });
+    const firstClient = vi.mocked(mock.adapter.sendPrompt).mock.calls[0]?.[0].clientUserMessageId;
+    const firstUser = { type: 'userMessage', id: 'wire-a', clientId: firstClient, content: [{ type: 'text', text: 'Same text' }] };
+    const emit = (method: string, item: Record<string, unknown>) => mock.emit({ method, params: { threadId: 'thr_existing', turnId: 'turn_1', item } });
+    emit('item/completed', firstUser);
+    emit('item/started', { type: 'agentMessage', id: 'old-answer' });
+    emit('item/started', { type: 'commandExecution', id: 'old-tool', command: 'echo old' });
+    const reply = deferred<CodexPromptResult>();
+    mock.adapter.sendPrompt = vi.fn(() => reply.promise);
+    const pending = api.sendPrompt('Same text', { effort: 'low' });
+    const secondClient = vi.mocked(mock.adapter.sendPrompt).mock.calls[0]?.[0].clientUserMessageId;
+    expect(secondClient).not.toBe(firstClient);
+    const secondUser = { type: 'userMessage', id: 'wire-b', clientId: secondClient, content: [{ type: 'text', text: 'Same text' }] };
+    emit('item/started', secondUser);
+    emit('item/completed', secondUser);
+    expect(api.realtimeHistoryQueue.value.filter(entry => entry.info.role === 'user')).toHaveLength(2);
+    reply.resolve({ threadId: 'thr_existing', turn: { id: 'turn_1', status: 'inProgress' } });
+    await pending;
+    const oldAnswer = { type: 'agentMessage', id: 'old-answer', text: 'Old response, delayed' };
+    const oldTool = { type: 'commandExecution', id: 'old-tool', command: 'echo old', status: 'completed' };
+    const newAnswer = { type: 'agentMessage', id: 'new-answer', text: 'New response' };
+    const newTool = { type: 'commandExecution', id: 'new-tool', command: 'echo new', status: 'completed' };
+    const reasoning = { type: 'reasoning', id: 'new-reasoning', summary: [{ type: 'summary_text', text: 'New reasoning' }] };
+    for (const item of [oldAnswer, oldTool, newAnswer, newTool, reasoning]) emit('item/completed', item);
+    const identity = (entries: typeof api.canonicalHistory.value) => entries.map(entry => ({
+      id: entry.info.id,
+      parent: entry.info.role === 'assistant' ? entry.info.parentID : '',
+      variant: entry.info.variant,
+    })).sort((a, b) => a.id.localeCompare(b.id));
+    const live = identity(api.realtimeHistoryQueue.value);
+    expect(live.find(entry => entry.id === 'turn_1:assistant:old-answer')?.parent).toBe(`turn_1:user:${firstClient}`);
+    expect(live.find(entry => entry.id === 'turn_1:assistant:old-tool')?.parent).toBe(`turn_1:user:${firstClient}`);
+    expect(live.find(entry => entry.id === 'turn_1:assistant:new-answer')?.parent).toBe(`turn_1:user:${secondClient}`);
+    vi.mocked(mock.adapter.readThread).mockResolvedValue({ thread: { id: 'thr_existing', turns: [{ id: 'turn_1', status: 'completed', items: [firstUser, oldAnswer, oldTool, secondUser, newAnswer, newTool, reasoning] }] } });
+    await api.selectThread('thr_existing');
+    expect(identity(api.canonicalHistory.value)).toEqual(live);
+    emit('item/completed', firstUser);
+    emit('item/completed', { type: 'agentMessage', id: 'after-reload', text: 'Still follows the latest user' });
+    expect(api.realtimeHistoryQueue.value.find(entry => entry.info.id === 'turn_1:assistant:after-reload')?.info).toMatchObject({ parentID: `turn_1:user:${secondClient}` });
+    api.disconnect();
+  });
+
+  it('keeps supplemental users and their replies distinct within a reused active turn', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    await api.sendPrompt('Original request', { effort: 'high' });
+    const first = api.realtimeHistoryQueue.value.find(entry => entry.info.role === 'user');
+    mock.emit({ method: 'item/agentMessage/delta', params: { threadId: 'thr_existing', turnId: 'turn_1', itemId: 'answer-a', delta: 'Original reply' } });
+    await api.sendPrompt('Supplemental request', { effort: 'low' });
+    const users = api.realtimeHistoryQueue.value.filter(entry => entry.info.role === 'user');
+    expect(users).toHaveLength(2);
+    expect(users.map(entry => entry.parts.find(part => part.type === 'text')?.text)).toEqual(['Original request', 'Supplemental request']);
+    mock.emit({ method: 'item/agentMessage/delta', params: { threadId: 'thr_existing', turnId: 'turn_1', itemId: 'answer-b', delta: 'Supplemental reply' } });
+    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_1', item: { id: 'answer-a', type: 'agentMessage', text: 'Original reply completed late' } } });
+    const parent = (id: string) => api.realtimeHistoryQueue.value.find(entry => entry.info.id === `turn_1:assistant:${id}`)?.info;
+    expect(parent('answer-a')).toMatchObject({ parentID: first?.info.id });
+    expect(parent('answer-b')).toMatchObject({ parentID: users[1]?.info.id });
+    expect(users.map(entry => entry.info.variant)).toEqual(['high', 'low']);
+    api.disconnect();
+  });
+
   it('retains selected effort through the pending prompt and server echo', async () => {
     const mock = createAdapterMock();
     const reply = deferred<CodexPromptResult>();
@@ -144,8 +396,9 @@ describe('useCodexApi', () => {
     const api = useCodexApi({ adapterFactory: () => mock.adapter });
     await api.connect();
     const sending = api.sendPrompt('Explain', { effort: 'high' });
+    const clientId = vi.mocked(mock.adapter.sendPrompt).mock.lastCall?.[0].clientUserMessageId;
     expect(api.realtimeHistoryQueue.value.find(entry => entry.info.role === 'user')?.info.variant).toBe('high');
-    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_effort', item: { type: 'userMessage', id: 'u', content: [{ type: 'text', text: 'Explain' }] } } });
+    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_effort', item: { type: 'userMessage', id: 'u', clientId, content: [{ type: 'text', text: 'Explain' }] } } });
     reply.resolve({ threadId: 'thr_existing', turn: { id: 'turn_effort', status: 'inProgress' } });
     await sending;
     mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_effort', item: { type: 'agentMessage', id: 'a', text: 'Answer' } } });
@@ -158,12 +411,14 @@ describe('useCodexApi', () => {
     const mock = createAdapterMock();
     const api = useCodexApi({ adapterFactory: () => mock.adapter });
     await api.connect();
+    const clientIds = new Map<string, string | undefined>();
     for (const [id, effort] of [['turn_high', 'high'], ['turn_low', 'low']]) {
       vi.mocked(mock.adapter.sendPrompt).mockResolvedValueOnce({ threadId: 'thr_existing', turn: { id, status: 'inProgress' } });
       await api.sendPrompt('Explain', { effort });
+      clientIds.set(id, vi.mocked(mock.adapter.sendPrompt).mock.lastCall?.[0].clientUserMessageId);
     }
     vi.mocked(mock.adapter.readThread).mockResolvedValue({ thread: { id: 'thr_existing', name: 'Existing', turns: ['turn_high', 'turn_low', 'turn_unknown'].map(id => ({ id, items: [
-      { type: 'userMessage', id: 'u', content: [{ type: 'text', text: 'Explain' }] },
+      { type: 'userMessage', id: 'u', clientId: clientIds.get(id), content: [{ type: 'text', text: 'Explain' }] },
       { type: 'agentMessage', id: 'a', text: 'Answer' },
     ] })) } });
     api.disconnect();
@@ -171,8 +426,8 @@ describe('useCodexApi', () => {
     await restored.connect();
     await restored.selectThread('thr_existing');
     expect(restored.canonicalHistory.value.map(entry => entry.info.variant)).toEqual(['high', 'high', 'low', 'low', undefined, undefined]);
-    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_high', item: { type: 'userMessage', id: 'u', content: [{ type: 'text', text: 'Explain' }] } } });
-    expect(restored.realtimeHistoryQueue.value.find(entry => entry.info.id === 'turn_high:user:0')?.info.variant).toBe('high');
+    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_high', item: { type: 'userMessage', id: 'u', clientId: clientIds.get('turn_high'), content: [{ type: 'text', text: 'Explain' }] } } });
+    expect(restored.realtimeHistoryQueue.value.find(entry => entry.info.id === `turn_high:user:${clientIds.get('turn_high')}`)?.info.variant).toBe('high');
   });
 
   it('keeps restored replies attached to their original user across tool events', async () => {
@@ -183,11 +438,11 @@ describe('useCodexApi', () => {
     const original = api.canonicalHistory.value.find(entry => entry.info.role === 'assistant')!;
     mock.emit({ method: 'item/started', params: { threadId: 'thr_existing', turnId: 'turn_old', item: { id: 'command-live', type: 'commandExecution', command: 'pwd' } } });
     expect(api.realtimeToolParts.value[0]?.info).toMatchObject({
-      parentID: 'turn_old:user:0',
-      id: 'turn_old:assistant',
+      parentID: 'turn_old:user:u1',
+      id: 'turn_old:assistant:command-live',
     });
     mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_old', item: { id: 'command-live', type: 'commandExecution', command: 'pwd', status: 'completed', aggregatedOutput: '/repo' } } });
-    expect(api.realtimeHistoryQueue.value.find(entry => entry.info.role === 'assistant')?.info).toMatchObject({ parentID: 'turn_old:user:0' });
+    expect(api.realtimeHistoryQueue.value.find(entry => entry.info.role === 'assistant')?.info).toMatchObject({ parentID: 'turn_old:user:u1' });
     expect(api.canonicalHistory.value.find(entry => entry.info.id === original.info.id)).toEqual(original);
   });
 
@@ -241,13 +496,14 @@ describe('useCodexApi', () => {
     const api = useCodexApi({ adapterFactory: () => mock.adapter });
     await api.connect();
     const sending = api.sendPrompt('Continue');
+    const clientId = vi.mocked(mock.adapter.sendPrompt).mock.lastCall?.[0].clientUserMessageId;
     mock.emit({ method: 'item/started', params: { threadId: 'thr_existing', turnId: 'turn-race', item: { id: 'early-tool', type: 'commandExecution', command: 'pwd' } } });
     reply.resolve({ threadId: 'thr_existing', turn: { id: 'turn-race', status: 'inProgress' } });
     await sending;
     mock.emit({ method: 'item/commandExecution/outputDelta', params: { threadId: 'thr_existing', turnId: 'turn-race', itemId: 'early-tool', delta: '/repo' } });
-    expect(api.realtimeToolParts.value[0]?.info).toMatchObject({ parentID: 'turn-race:user:0' });
+    expect(api.realtimeToolParts.value[0]?.info).toMatchObject({ parentID: `turn-race:user:${clientId}` });
     mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn-race', item: { id: 'early-tool', type: 'commandExecution', command: 'pwd', status: 'completed' } } });
-    expect(api.realtimeHistoryQueue.value.find(entry => entry.info.role === 'assistant')?.info).toMatchObject({ parentID: 'turn-race:user:0' });
+    expect(api.realtimeHistoryQueue.value.find(entry => entry.info.role === 'assistant')?.info).toMatchObject({ parentID: `turn-race:user:${clientId}` });
   });
 
   it('publishes completed-only reasoning and collaboration notifications to live window sources', async () => {
@@ -994,6 +1250,7 @@ describe('useCodexApi', () => {
 
     expect(mock.adapter.sendPrompt).toHaveBeenLastCalledWith({
       summary: 'auto',
+      clientUserMessageId: expect.stringMatching(/^client-user:/u),
       text: '',
       threadId: 'thr_existing',
       input: [{ type: 'image', url: 'data:image/png;base64,AA==' }],
@@ -1010,6 +1267,7 @@ describe('useCodexApi', () => {
 
     expect(mock.adapter.sendPrompt).toHaveBeenLastCalledWith({
       summary: 'auto',
+      clientUserMessageId: expect.stringMatching(/^client-user:/u),
       text: 'Hello custom model.',
       threadId: 'thr_existing',
       model: 'mimo/mimo-v2.5',
@@ -1029,6 +1287,7 @@ describe('useCodexApi', () => {
 
     expect(mock.adapter.sendPrompt).toHaveBeenLastCalledWith({
       summary: 'auto',
+      clientUserMessageId: expect.stringMatching(/^client-user:/u),
       text: 'Hello explicit custom model.',
       threadId: 'thr_existing',
       model: 'mimo/mimo-v2.5',
@@ -1698,6 +1957,7 @@ describe('useCodexApi', () => {
 
     expect(mock.adapter.sendPrompt).toHaveBeenCalledWith({
       summary: 'auto',
+      clientUserMessageId: expect.stringMatching(/^client-user:/u),
       threadId: 'thr_existing',
       text: 'Summarize this repo.',
     });
@@ -1717,6 +1977,7 @@ describe('useCodexApi', () => {
 
     expect(mock.adapter.sendPrompt).toHaveBeenLastCalledWith({
       summary: 'auto',
+      clientUserMessageId: expect.stringMatching(/^client-user:/u),
       threadId: 'thr_existing',
       text: 'Continue here.',
       cwd: '/home/codex/repo',
@@ -1737,6 +1998,7 @@ describe('useCodexApi', () => {
 
     expect(mock.adapter.sendPrompt).toHaveBeenLastCalledWith({
       summary: 'auto',
+      clientUserMessageId: expect.stringMatching(/^client-user:/u),
       text: 'Start on the selected provider.',
       model: 'mimo/mimo-v2.5',
       cwd: '/repo',
@@ -2285,17 +2547,19 @@ describe('useCodexApi', () => {
     expect(api.realtimeHistoryQueue.value).toEqual([]);
 
     await api.sendPrompt('Hello immediately.');
+    const clientId = vi.mocked(mock.adapter.sendPrompt).mock.lastCall?.[0].clientUserMessageId;
+    const userId = `turn_1:user:${clientId}`;
 
     const userEntries = api.realtimeHistoryQueue.value.filter((e) => e.info.role === 'user');
     expect(userEntries).toHaveLength(1);
     expect(userEntries[0]?.info.role).toBe('user');
-    expect(userEntries[0]?.info.id).toContain(':user:0');
-    expect(userEntries[0]?.info.id).toBe('turn_1:user:0');
+    expect(clientId).toMatch(/^client-user:/u);
+    expect(userEntries[0]?.info.id).toBe(userId);
     expect(userEntries.some((entry) => entry.info.id.includes('pending-turn:'))).toBe(false);
     expect(
       Object.keys(api.realtimeMessageAliases.value).some((key) => key.includes('pending-turn:')),
     ).toBe(true);
-    expect(Object.values(api.realtimeMessageAliases.value)).toContain('turn_1:user:0');
+    expect(Object.values(api.realtimeMessageAliases.value)).toContain(userId);
     expect(userEntries[0]?.parts).toHaveLength(1);
     expect(userEntries[0]?.parts[0]).toMatchObject({ type: 'text', text: 'Hello immediately.' });
   });
@@ -2346,8 +2610,9 @@ describe('useCodexApi', () => {
     const api = useCodexApi({ adapterFactory: () => mock.adapter });
     await api.connect();
     await api.sendPrompt('Look', { input: [{ type: 'image', url: 'data:image/png;base64,AA==' }] });
+    const clientId = vi.mocked(mock.adapter.sendPrompt).mock.lastCall?.[0].clientUserMessageId;
     mock.adapter.readFile = vi.fn().mockRejectedValue(new Error('File temporarily unavailable'));
-    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_1', item: { id: 'echo', type: 'userMessage', content: [{ type: 'localImage', path: '/tmp/upload.png' }] } } });
+    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_1', item: { id: 'echo', clientId, type: 'userMessage', content: [{ type: 'localImage', path: '/tmp/upload.png' }] } } });
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(api.realtimeHistoryQueue.value.flatMap(e => e.parts).filter(p => p.type === 'file')).toEqual([expect.objectContaining({ url: 'data:image/png;base64,AA==' })]);
     api.disconnect();
@@ -2358,9 +2623,10 @@ describe('useCodexApi', () => {
     const api = useCodexApi({ adapterFactory: () => mock.adapter });
     await api.connect();
     await api.sendPrompt('Look', { input: [{ type: 'text', text: 'Look' }, { type: 'image', url: 'data:image/png;base64,AA==' }, { type: 'image', url: 'data:image/png;base64,AA==' }] });
+    const clientId = vi.mocked(mock.adapter.sendPrompt).mock.lastCall?.[0].clientUserMessageId;
     const initial = api.realtimeHistoryQueue.value.find(e => e.info.role === 'user')?.parts.filter(p => p.type === 'file');
     expect(initial).toHaveLength(2);
-    mock.emit({ method: 'item/completed', params: { threadId: api.activeThreadId.value, turnId: 'turn_1', item: { type: 'userMessage', id: 'echo', content: [{ type: 'text', text: 'Look' }, ...[0, 1].map(i => kind === 'image' ? { type: 'image', url: 'data:image/png;base64,AA==' } : { type: 'localImage', path: '/tmp/sent-' + i + '.png' })] } } });
+    mock.emit({ method: 'item/completed', params: { threadId: api.activeThreadId.value, turnId: 'turn_1', item: { type: 'userMessage', id: 'echo', clientId, content: [{ type: 'text', text: 'Look' }, ...[0, 1].map(i => kind === 'image' ? { type: 'image', url: 'data:image/png;base64,AA==' } : { type: 'localImage', path: '/tmp/sent-' + i + '.png' })] } } });
     const files = api.realtimeHistoryQueue.value.find(e => e.info.role === 'user')?.parts.filter(p => p.type === 'file');
     expect(files).toHaveLength(2);
     expect(files?.map(p => p.id)).toEqual(initial?.map(p => p.id));
@@ -2380,6 +2646,7 @@ describe('useCodexApi', () => {
     api.activeTurn.value = { id: 'turn_old', status: 'completed' } as never;
 
     await api.sendPrompt('Fresh turn please.');
+    const clientId = vi.mocked(mock.adapter.sendPrompt).mock.lastCall?.[0].clientUserMessageId;
 
     expect(
       Object.keys(api.realtimeMessageAliases.value).some((key) => key.startsWith('turn_old:')),
@@ -2389,7 +2656,7 @@ describe('useCodexApi', () => {
     ).toBe(true);
     expect(
       api.realtimeHistoryQueue.value.find((entry) => entry.info.role === 'user')?.info.id,
-    ).toBe('turn_2:user:0');
+    ).toBe(`turn_2:user:${clientId}`);
   });
 
   it('removes provisional realtime user history if sendPrompt fails', async () => {
@@ -2416,6 +2683,8 @@ describe('useCodexApi', () => {
 
     await api.connect();
     const pendingSend = api.sendPrompt('Race test.');
+    const clientId = vi.mocked(mock.adapter.sendPrompt).mock.lastCall?.[0].clientUserMessageId;
+    const userId = `turn_race:user:${clientId}`;
     mock.emit({ method: 'item/agentMessage/delta', params: { delta: 'Early' } });
     expect(resolveSend).not.toBeNull();
     resolveSend!({
@@ -2428,13 +2697,13 @@ describe('useCodexApi', () => {
       (entry) => entry.info.role === 'user',
     );
     expect(userEntries).toHaveLength(1);
-    expect(userEntries[0]?.info.id).toBe('turn_race:user:0');
+    expect(userEntries[0]?.info.id).toBe(userId);
     expect(userEntries[0]?.parts[0]).toMatchObject({
-      id: 'turn_race:user:0:text',
+      id: `${userId}:text`,
       text: 'Race test.',
     });
     expect(userEntries.some((entry) => entry.info.id.includes('pending-turn:'))).toBe(false);
-    expect(Object.values(api.realtimeMessageAliases.value)).toContain('turn_race:user:0');
+    expect(Object.values(api.realtimeMessageAliases.value)).toContain(userId);
   });
 
   it('keeps successive streamed assistant items independently through completion', async () => {
@@ -3675,6 +3944,7 @@ describe('useCodexApi', () => {
 
     await api.connect();
     const pendingSend = api.sendPrompt('Pending thread switch');
+    const clientId = vi.mocked(mock.adapter.sendPrompt).mock.lastCall?.[0].clientUserMessageId;
 
     expect(
       api.realtimeHistoryQueue.value.some((entry) => entry.info.id.includes('pending-turn:')),
@@ -3697,7 +3967,7 @@ describe('useCodexApi', () => {
     await pendingSend;
 
     expect(
-      api.realtimeHistoryQueue.value.some((entry) => entry.info.id === 'turn_after_switch:user:0'),
+      api.realtimeHistoryQueue.value.some((entry) => entry.info.id === `turn_after_switch:user:${clientId}`),
     ).toBe(false);
   });
 

--- a/app/composables/useCodexApi.ts
+++ b/app/composables/useCodexApi.ts
@@ -870,6 +870,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
 
   const assistantTranscriptIds = new Map<string, number>();
   const assistantContexts = new Map<string, { parentId: string; createdAt: number }>();
+  const observedTurnUsers = new Map<string, Set<string>>();
   let latestAssistantCreatedAt = 0;
 
   function updateAssistantItem(sessionId: string, turnId: string, itemId: string, text: string, completed: boolean, createdAt?: number) {
@@ -1269,7 +1270,10 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       parentMessageId: turnId ? codexUserMessageId(turnId, 0) : undefined,
     });
     const entries = bundle.messages.map((info) => ({
-      info,
+      info: info.role === 'assistant'
+        ? createCodexAssistantInfo(threadId, info.id, info.time.created,
+          [...(observedTurnUsers.get(liveTurnKey(threadId, turnId)) ?? [])].at(-1) || info.parentID)
+        : info,
       parts: bundle.parts.filter((part) => part.messageID === info.id),
     }));
     saveCodexAuxiliaryHistory(
@@ -1316,6 +1320,17 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     }
     const userItem = isRecord(notificationParams?.item) ? notificationParams.item : null;
     if ((notification.method === 'item/started' || notification.method === 'item/completed')
+      && notificationThreadId && notificationTurnId && userItem?.type === 'userMessage') {
+      const identity = typeof userItem.clientId === 'string' && userItem.clientId.trim()
+        ? userItem.clientId.trim() : typeof userItem.id === 'string' ? userItem.id.trim() : '';
+      if (identity) {
+        const key = liveTurnKey(notificationThreadId, notificationTurnId);
+        const users = observedTurnUsers.get(key) ?? new Set<string>();
+        users.add(codexUserMessageId(notificationTurnId, identity));
+        observedTurnUsers.set(key, users);
+      }
+    }
+    if ((notification.method === 'item/started' || notification.method === 'item/completed')
       && userItem?.type === 'userMessage' && typeof userItem.clientId === 'string'
       && notificationThreadId === activeThreadId.value) {
       const turnId = notificationTurnId || activeTurn.value?.id;
@@ -1351,6 +1366,10 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       notificationThreadId &&
       notificationThreadId !== activeThreadId.value
     ) {
+      if (notification.method === 'item/started' && userItem && userItem.type !== 'userMessage' && typeof userItem.id === 'string') {
+        const parentId = [...(observedTurnUsers.get(liveTurnKey(notificationThreadId, notificationTurnId)) ?? [])].at(-1);
+        if (parentId) createCodexAssistantInfo(notificationThreadId, codexAssistantMessageId(notificationTurnId, userItem.id), Date.now(), parentId);
+      }
       if (notification.method === 'item/completed' && isRecord(notificationParams?.item)) {
         persistCompletedAuxiliaryNotification(
           notificationThreadId,
@@ -2065,6 +2084,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     activeTurn.value = null;
     liveTurnGenerations.clear();
     assistantContexts.clear();
+    observedTurnUsers.clear();
     latestAssistantCreatedAt = 0;
     liveThreadStatuses.clear();
     serverRequests.value = [];

--- a/app/composables/useCodexApi.ts
+++ b/app/composables/useCodexApi.ts
@@ -1,7 +1,10 @@
 import { codexReasoningText } from '../backends/codex/reasoning';
+import { createCodexThreadActivity } from '../backends/codex/threadActivity';
+import { migrateCodexAuxiliaryHistory } from '../backends/codex/auxiliaryHistoryIdentity';
 import { computed, ref, watch } from 'vue';
 import {
   CodexAdapter,
+  extractStatusType,
   normalizeCodexMcpServerInfo,
   type CodexAccount,
   type CodexAccountRateLimitBucket,
@@ -534,6 +537,16 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   const bridgeToken = ref(initialOptions.bridgeToken ?? getPersistedCodexBridgeToken());
   const errorMessage = ref('');
   const threads = ref<CodexThread[]>([]);
+  const threadActivity = createCodexThreadActivity();
+  let threadStatusRevision = 0;
+  const liveThreadStatuses = new Map<string, { revision: number; status: unknown }>();
+  watch(
+    () => threads.value.map((thread) => [thread.id, thread.status] as const),
+    (states) => {
+      for (const [id, threadStatus] of states) threadActivity.observe(id, threadStatus);
+    },
+    { flush: 'sync' },
+  );
   const activeThreadId = ref(loadPersistedActiveThread());
   watch(activeThreadId, (newId, oldId) => {
     if (newId && newId !== oldId) {
@@ -760,7 +773,22 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     });
   }
 
-  function upsertThread(thread: CodexThread, refreshGitInfo = true) {
+  function reconcileThreadStatus(thread: CodexThread, revision: number): CodexThread {
+    const live = liveThreadStatuses.get(thread.id);
+    const existing = threads.value.find((item) => item.id === thread.id);
+    return {
+      ...thread,
+      status: live && live.revision > revision ? live.status : (thread.status ?? existing?.status),
+    };
+  }
+
+  function updateThreadStatus(threadId: string, threadStatus: unknown) {
+    liveThreadStatuses.set(threadId, { revision: ++threadStatusRevision, status: threadStatus });
+    upsertThread({ id: threadId, status: threadStatus }, false);
+  }
+
+  function upsertThread(thread: CodexThread, refreshGitInfo = true, revision = threadStatusRevision) {
+    thread = reconcileThreadStatus(thread, revision);
     const existing = threads.value.find((item) => item.id === thread.id);
     const monotonic = monotonicTimestamps(existing, thread);
     const normalizedThread = normalizeThreadCwd({
@@ -841,6 +869,8 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   }
 
   const assistantTranscriptIds = new Map<string, number>();
+  const assistantContexts = new Map<string, { parentId: string; createdAt: number }>();
+  let latestAssistantCreatedAt = 0;
 
   function updateAssistantItem(sessionId: string, turnId: string, itemId: string, text: string, completed: boolean, createdAt?: number) {
     const messageId = codexAssistantMessageId(turnId, itemId || 'pending');
@@ -913,8 +943,18 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       ...realtimeToolParts.value.map(entry => entry.info),
     ].find(info => info?.id === messageId && info.sessionID === sessionId && info.role === 'assistant');
     if (existing?.role === 'assistant') {
-      return { ...existing, parentID: parentId || existing.parentID };
+      return { ...existing, parentID: realtimeMessageAliases.value[existing.parentID] || existing.parentID || parentId };
     }
+    const parentKey = `${sessionId}:${messageId}`;
+    const context = assistantContexts.get(parentKey);
+    parentId = context?.parentId || parentId;
+    if (context) createdAt = context.createdAt;
+    else {
+      createdAt = Math.max(createdAt, latestAssistantCreatedAt + 1);
+      latestAssistantCreatedAt = createdAt;
+      assistantContexts.set(parentKey, { parentId, createdAt });
+    }
+    parentId = realtimeMessageAliases.value[parentId] || parentId;
     const model = parseSelectedCodexModel(selectedModel.value);
     const parent = [...realtimeHistoryQueue.value, ...canonicalHistory.value]
       .find(entry => entry.info.id === parentId && entry.info.sessionID === sessionId);
@@ -944,15 +984,39 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     const targetSessionId = sessionId?.trim() || activeThreadId.value || '';
     const entries = [...canonicalHistory.value, ...realtimeHistoryQueue.value];
     if (turnId) {
-      const assistantId = codexAssistantMessageId(turnId);
-      const existing = entries.find(entry => entry.info.id === assistantId && entry.info.sessionID === targetSessionId);
-      if (existing?.info.role === 'assistant' && existing.info.parentID) return existing.info.parentID;
-      const user = entries.find(entry => entry.info.id === codexUserMessageId(turnId, 0) && entry.info.sessionID === targetSessionId);
+      const user = entries.filter(entry => entry.info.role === 'user'
+        && entry.info.id.startsWith(`${turnId}:user:`)
+        && entry.info.sessionID === targetSessionId)
+        .sort((left, right) => left.info.time.created - right.info.time.created).at(-1);
       if (user) return user.info.id;
     }
     return entries.reverse().find(entry => entry.info.role === 'user' && (
       entry.info.sessionID === targetSessionId || entry.info.sessionID === 'codex-pending'
     ))?.info.id || '';
+  }
+
+  function finalizeRealtimeUser(provisionalId: string, messageId: string, sessionId: string, variant?: string) {
+    realtimeHistoryQueue.value = dedupeRealtimeHistoryQueue(realtimeHistoryQueue.value.map(entry => {
+      if (entry.info.id === messageId) return { ...entry, info: { ...entry.info, variant: variant ?? entry.info.variant } };
+      if (entry.info.id !== provisionalId) return entry;
+      return {
+        info: { ...entry.info, id: messageId, sessionID: sessionId, variant: variant ?? entry.info.variant },
+        parts: entry.parts.map(part => ({
+          ...part,
+          id: part.id.startsWith(`${provisionalId}:`) ? `${messageId}${part.id.slice(provisionalId.length)}` : part.id,
+          sessionID: sessionId,
+          messageID: messageId,
+        })),
+      };
+    }));
+    realtimeMessageAliases.value = { ...realtimeMessageAliases.value, [provisionalId]: messageId };
+    const reparent = (info: MessageInfo): MessageInfo => info.role === 'assistant' && info.parentID === provisionalId
+      ? { ...info, parentID: messageId } : info;
+    realtimeHistoryQueue.value = realtimeHistoryQueue.value.map(entry => ({ ...entry, info: reparent(entry.info) }));
+    realtimeToolParts.value = realtimeToolParts.value.map(entry => ({ ...entry, info: reparent(entry.info) }));
+    if (realtimeReasoningPart.value) realtimeReasoningPart.value = { ...realtimeReasoningPart.value, info: reparent(realtimeReasoningPart.value.info) };
+    if (realtimeStreamingPart.value) realtimeStreamingPart.value = { ...realtimeStreamingPart.value, info: reparent(realtimeStreamingPart.value.info) };
+    if (realtimeCompletedPart.value) realtimeCompletedPart.value = { ...realtimeCompletedPart.value, info: reparent(realtimeCompletedPart.value.info) };
   }
 
   function buildRealtimeUserParts(
@@ -1022,7 +1086,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
 
   function setRealtimeReasoningCompleted(completedAt = Date.now(), turnId?: string) {
     if (!realtimeReasoningPart.value || realtimeReasoningPart.value.part.time.end != null) return;
-    if (turnId && realtimeReasoningPart.value.part.messageID !== codexAssistantMessageId(turnId)) return;
+    if (turnId && !realtimeReasoningPart.value.part.messageID.startsWith(`${turnId}:assistant:`)) return;
     const current = realtimeReasoningPart.value;
     realtimeReasoningPart.value = {
       ...current,
@@ -1123,12 +1187,12 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       (current) => current.info.id === entry.info.id,
     );
     if (existingIndex === -1) {
-      const knownVariant = canonicalHistory.value.find(current =>
+      const known = canonicalHistory.value.find(current =>
         current.info.id === entry.info.id && current.info.sessionID === entry.info.sessionID,
-      )?.info.variant;
+      );
       realtimeHistoryQueue.value = dedupeRealtimeHistoryQueue([
         ...realtimeHistoryQueue.value,
-        knownVariant && !entry.info.variant ? { ...entry, info: { ...entry.info, variant: knownVariant } } : entry,
+        known ? { ...entry, info: { ...entry.info, time: known.info.time, variant: entry.info.variant ?? known.info.variant } } : entry,
       ]);
       return;
     }
@@ -1140,7 +1204,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     });
     const nextQueue = [...realtimeHistoryQueue.value];
     nextQueue[existingIndex] = {
-      info: { ...entry.info, variant: entry.info.variant ?? existing.info.variant },
+      info: { ...entry.info, time: existing.info.time, variant: entry.info.variant ?? existing.info.variant },
       parts: Array.from(partsById.values()),
     };
     realtimeHistoryQueue.value = dedupeRealtimeHistoryQueue(nextQueue);
@@ -1250,11 +1314,22 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       if (isInvalidatedTurnId(notificationThreadId, notificationTurnId)) return;
       recordObservedTurnId(notificationThreadId, notificationTurnId);
     }
+    const userItem = isRecord(notificationParams?.item) ? notificationParams.item : null;
+    if ((notification.method === 'item/started' || notification.method === 'item/completed')
+      && userItem?.type === 'userMessage' && typeof userItem.clientId === 'string'
+      && notificationThreadId === activeThreadId.value) {
+      const turnId = notificationTurnId || activeTurn.value?.id;
+      if (turnId) {
+        finalizeRealtimeUser(codexUserMessageId(`pending-turn:${userItem.clientId}`), codexUserMessageId(turnId, userItem.clientId), notificationThreadId);
+      }
+    }
     if (notification.method === 'turn/started' || notification.method === 'turn/completed') {
       const turn = extractTurn(notification.params);
       const threadId = notificationThreadId || activeThreadId.value;
       const turnId = turn?.id || notificationTurnId;
       if (threadId && turnId) {
+        threadActivity.markParticipated(threadId);
+        updateThreadStatus(threadId, notification.method === 'turn/started' ? 'active' : 'idle');
         const key = liveTurnKey(threadId, turnId);
         if (notification.method === 'turn/started') {
           liveTurnGenerations.set(key, request.generation);
@@ -1301,12 +1376,20 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     }
 
     if (
-      notification.method === 'thread/status/changed' ||
       notification.method === 'thread/archived' ||
       notification.method === 'thread/unarchived' ||
       notification.method === 'thread/closed'
     ) {
       void refreshThreads();
+      return;
+    }
+
+    if (notification.method === 'thread/status/changed') {
+      if (notificationThreadId && extractStatusType(notificationParams?.status)) {
+        updateThreadStatus(notificationThreadId, notificationParams?.status);
+      } else {
+        void refreshThreads();
+      }
       return;
     }
 
@@ -1471,6 +1554,16 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     if (notification.method === 'item/started') {
       const params = isRecord(notification.params) ? notification.params : null;
       const item = isRecord(params?.item) ? params.item : null;
+      const sessionId = notificationThreadId || activeThreadId.value || 'codex-thread';
+      const turnId = notificationTurnId || activeTurn.value?.id || `${sessionId}:realtime`;
+      if (item?.type === 'userMessage') {
+        mergeRealtimeHistoryBundle(normalizeCodexTurnItems({ sessionId, turnId, items: [item] }), request, turnId);
+        return;
+      }
+      if (item?.type === 'agentMessage' && typeof item.id === 'string') {
+        createCodexAssistantInfo(sessionId, codexAssistantMessageId(turnId, item.id), Date.now(), currentRealtimeParentId(sessionId, turnId));
+        return;
+      }
       if (item?.type === 'enteredReviewMode') {
         reviewState.value = 'reviewing';
         reviewResult.value = '';
@@ -1668,6 +1761,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
         const threadId = notificationThreadId || activeThreadId.value || 'codex-thread';
         const messageId = codexAssistantMessageId(
           notificationTurnId || activeTurn.value?.id || `reasoning:${threadId}`,
+          itemId,
         );
         const existing = realtimeReasoningPart.value?.part;
         const accumulated = reasoningStreams.value[itemId]?.summary || reasoningStreams.value[itemId]?.raw || delta;
@@ -1901,6 +1995,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   async function connect(nextUrl = url.value, onPhase?: (phase: CodexConnectPhase) => void) {
     teardownConnection(true);
     url.value = nextUrl.trim();
+    if (threadActivity.setConnection(url.value)) threads.value = [];
     status.value = 'connecting';
     errorMessage.value = '';
     adapter = makeAdapter();
@@ -1969,6 +2064,9 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     initialized.value = false;
     activeTurn.value = null;
     liveTurnGenerations.clear();
+    assistantContexts.clear();
+    latestAssistantCreatedAt = 0;
+    liveThreadStatuses.clear();
     serverRequests.value = [];
     permissionRequests.value = [];
     elicitationRequests.value = [];
@@ -2116,6 +2214,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   }
 
   async function refreshConfiguredProviderThreads() {
+    const statusRevision = threadStatusRevision;
     const request = captureConnection();
     if (!request) return;
     const { sourceAdapter } = request;
@@ -2152,7 +2251,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     }
     const enrichedThreads = await Promise.all([...merged.values()].map(enrichThreadWithGitInfo));
     if (isCurrentConnection(request)) {
-      threads.value = enrichedThreads.sort(
+      threads.value = enrichedThreads.map((thread) => reconcileThreadStatus(thread, statusRevision)).sort(
         (left, right) =>
           (right.updatedAt ?? right.createdAt ?? 0) - (left.updatedAt ?? left.createdAt ?? 0),
       );
@@ -2163,6 +2262,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     params: CodexThreadListParams = {},
     includeConfiguredProviders = true,
   ) {
+    const statusRevision = threadStatusRevision;
     const request = captureConnection();
     const normalizedThreads = await fetchThreadList(params, includeConfiguredProviders, request);
     if (!request || !isCurrentConnection(request) || !normalizedThreads) return;
@@ -2176,7 +2276,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     }
     const enrichedThreads = await Promise.all(normalizedThreads.map(enrichThreadWithGitInfo));
     if (!isCurrentConnection(request)) return;
-    threads.value = enrichedThreads;
+    threads.value = enrichedThreads.map((thread) => reconcileThreadStatus(thread, statusRevision));
     if (!loadingThread.value) {
       if (
         activeThreadId.value &&
@@ -2277,8 +2377,11 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   }
 
   async function upsertThreadWithGitInfo(thread: CodexThread) {
+    const request = captureConnection();
+    const statusRevision = threadStatusRevision;
     const enrichedThread = await enrichThreadWithGitInfo(thread);
-    upsertThread(enrichedThread, false);
+    if (!request || !isCurrentConnection(request)) return;
+    upsertThread(enrichedThread, false, statusRevision);
   }
 
   function mergeThreadReadResult(
@@ -2349,7 +2452,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       canonicalHistory.value.flatMap((entry) => entry.parts.map((part) => part.id)),
     );
     const serverInfo = new Map(canonicalHistory.value.map((entry) => [entry.info.id, entry.info]));
-    const missingEntries = loadCodexAuxiliaryHistory(threadId)
+    const missingEntries = migrateCodexAuxiliaryHistory(loadCodexAuxiliaryHistory(threadId), canonicalHistory.value)
       .map((entry) => ({
         info: serverInfo.get(entry.info.id) ?? entry.info,
         parts: entry.parts.filter((part) => !serverParts.has(part.id)),
@@ -2383,22 +2486,34 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     realtimeToolParts.value = [];
     loadingThread.value = true;
     errorMessage.value = '';
+    const restoreRunningTurn = (turns: CodexTurn[] | undefined, previousTurn: CodexTurn | null) => {
+      if (activeTurn.value !== previousTurn || !turns) return;
+      activeTurn.value = turns.findLast((turn) => turn.status === 'inProgress' || turn.status === 'in_progress') ?? null;
+    };
     try {
+      let statusRevision = threadStatusRevision;
       let read = await readThreadForHistory(threadId, sourceAdapter);
       if (!isCurrentSelection()) return;
-      upsertThread(read.thread);
+      restoreRunningTurn(read.thread.turns, null);
+      upsertThread(read.thread, true, statusRevision);
       setTranscriptFromTurns(read.thread.turns ?? []);
       const hydratedHistory = await hydrateThreadImages(canonicalHistory.value, sourceAdapter);
       if (!isCurrentSelection()) return;
       canonicalHistory.value = hydratedHistory;
       try {
+        const previousTurn = activeTurn.value;
+        statusRevision = threadStatusRevision;
         const resumed = await sourceAdapter.resumeThread({ threadId });
         if (!isCurrentSelection()) return;
-        upsertThread(resumed.thread);
+        restoreRunningTurn(resumed.thread.turns, previousTurn);
+        upsertThread(resumed.thread, true, statusRevision);
         if ((read.thread.turns?.length ?? 0) === 0) {
+          const previousTurn = activeTurn.value;
+          statusRevision = threadStatusRevision;
           read = await readThreadForHistory(threadId, sourceAdapter);
           if (!isCurrentSelection()) return;
-          upsertThread(read.thread);
+          restoreRunningTurn(read.thread.turns, previousTurn);
+          upsertThread(read.thread, true, statusRevision);
           setTranscriptFromTurns(read.thread.turns ?? []);
           const resumedHistory = await hydrateThreadImages(canonicalHistory.value);
           if (!isCurrentSelection()) return;
@@ -2436,6 +2551,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     const sourceAdapter = adapter;
     if (!sourceAdapter) return;
     const selectionGeneration = threadSelectionGeneration;
+    const statusRevision = threadStatusRevision;
     const read = await readThreadForHistory(threadId, sourceAdapter);
     if (
       adapter !== sourceAdapter ||
@@ -2448,7 +2564,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       sessionId: threadId, turns: read.thread.turns ?? [],
     }), sourceAdapter);
     if (adapter !== sourceAdapter || threadSelectionGeneration !== selectionGeneration || activeThreadId.value !== threadId) return;
-    upsertThread(read.thread);
+    upsertThread(read.thread, true, statusRevision);
     setTranscriptFromTurns(read.thread.turns ?? []);
     const imageUrls = new Map(hydrated.flatMap(entry => entry.parts.filter(part => part.type === 'file').map(part => [part.id, part.url])));
     canonicalHistory.value = canonicalHistory.value.map(entry => ({ ...entry, parts: entry.parts.map(part =>
@@ -2529,6 +2645,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     liveTurnGenerations.delete(liveTurnKey(threadId, turnId));
     if (activeThreadId.value !== threadId || activeTurn.value !== turn) return;
     activeTurn.value = { ...turn, status: 'interrupted' };
+    updateThreadStatus(threadId, 'idle');
     pending.value = false;
   }
 
@@ -2853,7 +2970,8 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     errorMessage.value = '';
     pushTranscript('user', prompt);
 
-    const pendingTurnId = `pending-turn:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`;
+    const clientUserMessageId = `client-user:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+    const pendingTurnId = `pending-turn:${clientUserMessageId}`;
     const targetThreadId = options.forceNewThread ? '' : (options.threadId ?? activeThreadId.value);
     const userMessageId = codexUserMessageId(pendingTurnId, 0);
     const sessionId = targetThreadId || 'codex-pending';
@@ -2881,63 +2999,34 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       const model =
         options.model?.trim() || parseSelectedCodexModel(selectedModel.value).modelID || undefined;
       const cwd = resolvePromptCwd(options.cwd, targetThreadId);
-      const input: CodexPromptInput = { text: prompt, summary: 'auto' };
+      const input: CodexPromptInput = { text: prompt, summary: 'auto', clientUserMessageId };
       if (inputItems.length > 0) input.input = inputItems;
       if (targetThreadId) input.threadId = targetThreadId;
       if (model) input.model = model;
       if (options.effort) input.effort = options.effort;
       if (options.collaborationMode) input.collaborationMode = options.collaborationMode;
       if (cwd) input.cwd = cwd;
-      const result = await adapter.sendPrompt(input);
+      const statusRevision = threadStatusRevision;
+      const request = captureConnection();
+      if (!request) throw new Error('Codex is not connected.');
+      const result = await request.sourceAdapter.sendPrompt(input);
+      if (!isCurrentConnection(request)) return result;
       activeThreadId.value = result.threadId;
-      if (result.thread) upsertThread(result.thread);
-      activeTurn.value = result.turn;
+      if (result.thread) upsertThread(result.thread, true, statusRevision);
+      threadActivity.markParticipated(result.threadId);
+      upsertThread({
+        id: result.threadId,
+        status: ['completed', 'failed', 'interrupted'].includes(result.turn.status ?? '') ? 'idle' : 'active',
+      }, false, statusRevision);
+      if (activeTurn.value?.id !== result.turn.id || (liveThreadStatuses.get(result.threadId)?.revision ?? 0) <= statusRevision) {
+        activeTurn.value = result.turn;
+      }
 
       const finalizedTurnId = result.turn.id || pendingTurnId;
-      saveCodexTurnEffort(result.threadId, finalizedTurnId, options.effort);
       recordObservedTurnId(result.threadId, finalizedTurnId);
-      const finalizedUserMessageId = codexUserMessageId(finalizedTurnId, 0);
-      if (realtimeHistoryQueue.value.length > 0) {
-        let updated = false;
-        const nextQueue = realtimeHistoryQueue.value.map((entry) => {
-          if (entry.info.id === finalizedUserMessageId) {
-            return { ...entry, info: { ...entry.info, variant: options.effort } };
-          }
-          if (entry.info.id !== userMessageId) return entry;
-          updated = true;
-          return {
-            info: { ...entry.info, id: finalizedUserMessageId, sessionID: result.threadId },
-            parts: entry.parts.map((part) => ({
-              ...part,
-              id: part.id.startsWith(`${userMessageId}:`)
-                ? `${finalizedUserMessageId}${part.id.slice(userMessageId.length)}`
-                : part.id,
-              sessionID: result.threadId,
-              messageID: finalizedUserMessageId,
-            })),
-          };
-        });
-        if (updated) {
-          realtimeHistoryQueue.value = dedupeRealtimeHistoryQueue(nextQueue);
-        }
-      }
-      realtimeMessageAliases.value = {
-        ...realtimeMessageAliases.value,
-        [userMessageId]: finalizedUserMessageId,
-      };
-
-      const reparent = (info: MessageInfo): MessageInfo => info.role === 'assistant' && info.parentID === userMessageId
-        ? { ...info, parentID: finalizedUserMessageId }
-        : info;
-      realtimeHistoryQueue.value = realtimeHistoryQueue.value.map(entry => ({ ...entry, info: reparent(entry.info) }));
-      realtimeToolParts.value = realtimeToolParts.value.map(entry => ({ ...entry, info: reparent(entry.info) }));
-      if (realtimeReasoningPart.value) {
-        realtimeReasoningPart.value = { ...realtimeReasoningPart.value, info: reparent(realtimeReasoningPart.value.info) };
-      }
-
-      if (realtimeStreamingPart.value) {
-        realtimeStreamingPart.value = { ...realtimeStreamingPart.value, info: reparent(realtimeStreamingPart.value.info) };
-      }
+      const finalizedUserMessageId = codexUserMessageId(finalizedTurnId, clientUserMessageId);
+      saveCodexTurnEffort(result.threadId, finalizedTurnId, options.effort, finalizedUserMessageId);
+      finalizeRealtimeUser(userMessageId, finalizedUserMessageId, result.threadId, options.effort);
 
       return result;
     } catch (error) {
@@ -3679,6 +3768,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     bridgeToken,
     errorMessage,
     threads,
+    participatedThreadIds: threadActivity.participatedThreadIds,
     activeThreadId,
     activeTurn,
     transcript,

--- a/app/composables/useCodexMessageBridge.test.ts
+++ b/app/composables/useCodexMessageBridge.test.ts
@@ -50,6 +50,17 @@ function liveHistory() {
 }
 
 describe('useCodexMessageBridge', () => {
+  it('removes a rejected optimistic user when it disappears from the realtime queue', async () => {
+    const params = bridgeFixture();
+    const user = liveHistory().find(entry => entry.info.role === 'user');
+    if (!user) throw new Error('Expected user fixture');
+    params.codexApi.realtimeHistoryQueue.value = [{ ...user, info: { ...user.info, id: 'pending-turn:failed:user:0' }, parts: [] }];
+    await nextTick();
+    params.codexApi.realtimeHistoryQueue.value = [];
+    await nextTick();
+    expect(params.msg.removeMessage).toHaveBeenCalledExactlyOnceWith('pending-turn:failed:user:0');
+  });
+
   it('publishes only the changed tool across queue and tool watchers', async () => {
     const params = bridgeFixture();
     const entries = liveHistory();
@@ -83,7 +94,7 @@ describe('useCodexMessageBridge', () => {
       info: entry.info.role === 'assistant' ? { ...entry.info, parentID: 'correct-user' } : entry.info,
     }));
     await nextTick();
-    expect(params.msg.updateMessage).toHaveBeenCalledTimes(2);
+    expect(params.msg.updateMessage).toHaveBeenCalledTimes(3);
     expect(params.msg.updateMessage.mock.calls.map(([info]) => info.id)).toEqual(
       params.codexApi.realtimeHistoryQueue.value.filter(entry => entry.info.role === 'assistant').map(entry => entry.info.id),
     );

--- a/app/composables/useCodexMessageBridge.ts
+++ b/app/composables/useCodexMessageBridge.ts
@@ -186,6 +186,14 @@ export function useCodexMessageBridge(params: {
       return;
     }
     lastRealtimeQueueSignature.value = signature;
+    const queuedIds = new Set(params.codexApi.realtimeHistoryQueue.value.map(entry => entry.info.id));
+    for (const id of publishedMessages.keys()) {
+      if (id.startsWith('pending-turn:') && !queuedIds.has(id)
+        && !params.codexApi.realtimeMessageAliases.value[id]) {
+        params.msg.removeMessage(id);
+        publishedMessages.delete(id);
+      }
+    }
     if (params.codexApi.realtimeHistoryQueue.value.length === 0) return;
     for (const [provisionalId, finalizedId] of Object.entries(params.codexApi.realtimeMessageAliases.value)) {
       if (!provisionalId || !finalizedId || provisionalId === finalizedId) continue;

--- a/app/composables/useCodexWorkspace.test.ts
+++ b/app/composables/useCodexWorkspace.test.ts
@@ -5,6 +5,21 @@ import { pinnedSessionStoreKey } from '../utils/pinnedSessions';
 import type { CodexThread } from '../backends/codex/codexAdapter';
 
 describe('useCodexWorkspace', () => {
+  it('shows green idle only for threads involved in this backend connection', () => {
+    const threads = ref<CodexThread[]>([
+      { id: 'involved', cwd: '/repo', status: { type: 'idle' } },
+      { id: 'untouched', cwd: '/repo', status: { type: 'idle' } },
+    ]);
+    const participatedThreadIds = ref(new Set(['involved']));
+    const workspace = useCodexWorkspace({ threads, visibleThreads: computed(() => threads.value),
+      activeThreadId: ref('involved'), canonicalHistory: ref([]), participatedThreadIds });
+    expect(workspace.project.value.sandboxes['/repo'].sessions['involved'].status).toBe('idle');
+    expect(workspace.project.value.sandboxes['/repo'].sessions['untouched'].status).toBe('unknown');
+    participatedThreadIds.value = new Set(['untouched']);
+    expect(workspace.project.value.sandboxes['/repo'].sessions['involved'].status).toBe('unknown');
+    expect(workspace.project.value.sandboxes['/repo'].sessions['untouched'].status).toBe('idle');
+  });
+
   it('normalizes Codex threads into a Vis project and sessions', () => {
     const threads: CodexThread[] = [
       { id: 'thread-1', name: 'Implement bridge', cwd: '/repo', gitInfo: { root: '/repo', branch: 'main' }, createdAt: 10, updatedAt: 20, status: 'running' },

--- a/app/composables/useCodexWorkspace.ts
+++ b/app/composables/useCodexWorkspace.ts
@@ -1,5 +1,5 @@
 import { computed, type ComputedRef, type Ref } from 'vue';
-import { extractStatusType, type CodexThread } from '../backends/codex/codexAdapter';
+import { extractStatusType, normalizeCodexStatus, type CodexThread } from '../backends/codex/codexAdapter';
 import { CODEX_PROJECT_ID } from '../backends/codex/bridgeUrl';
 import type { CodexCanonicalHistoryEntry } from '../backends/codex/normalize';
 import type { ProjectState, SessionState } from '../types/worker-state';
@@ -23,6 +23,7 @@ export type CodexWorkspaceApi = {
   homeDir?: Ref<string>;
   pinnedStore?: Ref<LocalPinnedSessionStore>;
   hiddenThreadIds?: Ref<Set<string>>;
+  participatedThreadIds?: Ref<Set<string>>;
 };
 
 function isCodexThreadPinned(
@@ -85,12 +86,9 @@ function threadTitle(thread: CodexThread) {
   return thread.name?.trim() || thread.preview?.trim() || thread.id;
 }
 
-function threadStatus(thread: CodexThread): SessionState['status'] {
-  const type = extractStatusType(thread.status);
-  if (type === 'active' || type === 'running' || type === 'inProgress' || type === 'busy')
-    return 'busy';
-  if (type === 'systemError' || type === 'retry') return 'retry';
-  return 'unknown' as SessionState['status'];
+function threadStatus(thread: CodexThread, participatedThreadIds: ReadonlySet<string>): SessionState['status'] {
+  if (extractStatusType(thread.status) === 'idle' && participatedThreadIds.has(thread.id)) return 'idle';
+  return normalizeCodexStatus(thread.status) as SessionState['status'];
 }
 
 function codexThreadToSession(
@@ -99,11 +97,12 @@ function codexThreadToSession(
   pinnedStore: LocalPinnedSessionStore = {},
   hiddenThreadIds: Set<string> = new Set(),
   sessionDirectory = threadSandboxDirectory(thread, fallbackDirectory),
+  participatedThreadIds: ReadonlySet<string> = new Set(),
 ): SessionState {
   return {
     id: thread.id,
     title: threadTitle(thread),
-    status: threadStatus(thread),
+    status: threadStatus(thread, participatedThreadIds),
     directory: sessionDirectory,
     gitInfo: thread.gitInfo ?? null,
     timeCreated: threadTimestamp(thread.createdAt),
@@ -126,6 +125,7 @@ export function createCodexProjectState(
   fallbackDirectory = CODEX_DEFAULT_DIRECTORY,
   pinnedStore: LocalPinnedSessionStore = {},
   hiddenThreadIds: Set<string> = new Set(),
+  participatedThreadIds: ReadonlySet<string> = new Set(),
 ): ProjectState {
   const primaryDirectory = CODEX_DEFAULT_DIRECTORY;
   const sandboxes: ProjectState['sandboxes'] = {};
@@ -148,6 +148,7 @@ export function createCodexProjectState(
       pinnedStore,
       hiddenThreadIds,
       directory,
+      participatedThreadIds,
     );
     sandboxes[directory] = sandbox;
   }
@@ -180,6 +181,7 @@ export function useCodexWorkspace(
       fallbackDirectory.value,
       api.pinnedStore?.value ?? options.pinnedStore?.value,
       api.hiddenThreadIds?.value,
+      api.participatedThreadIds?.value,
     ),
   );
   const projects = computed<Record<string, ProjectState>>(() => ({

--- a/app/utils/storageKeys.ts
+++ b/app/utils/storageKeys.ts
@@ -197,6 +197,7 @@ export const StorageKeys = {
     codexPanelConnected: 'state.codexPanelConnected.v1',
     codexAuxiliaryHistory: 'state.codexAuxiliaryHistory.v1',
     codexTurnEfforts: 'state.codexTurnEfforts.v1',
+    codexThreadActivity: 'state.codexThreadActivity.v1',
     forgePtyId: 'state.forgePtyId.v1',
     acpArchivedSessions: 'state.acpArchivedSessions.v1',
     acpMessageAttribution: 'state.acpMessageAttribution.v1',


### PR DESCRIPTION
修复 Codex 运行状态与补充消息历史不一致的问题：刷新后恢复“思考中”和可中断的运行回合；参与过运行的会话空闲时保留绿色标记，并按后端连接隔离。

运行中发送补充消息时，为每条用户消息保留稳定身份，为助手消息保留首次归属及顺序，避免覆盖上一条请求、回复挂错卡片，以及刷新后重新分组。兼容既有辅助历史与思考强度缓存，并移除发送失败的临时卡片。

验证：293 项相关回归测试、类型检查、lint 和构建通过。浏览器验证使用生产组件与模拟 app-server 协议，覆盖补充消息、延迟完成、刷新、失败回滚、状态恢复及响应式显示；未调用真实模型。构建仍有既有的大体积分包提示。
