### PR TITLE
fix(ci)：消除间歇性测试与构建失败

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -197,7 +197,16 @@ jobs:
         run: node -e "if (process.arch !== 'x64') process.exit(1)"
 
       - name: Build Electron app for x64
-        run: pnpm build && pnpm exec electron-builder --publish never --win --x64
+        shell: pwsh
+        run: |
+          pnpm build
+          foreach ($attempt in 1..3) {
+            pnpm exec electron-builder --publish never --win --x64
+            if ($LASTEXITCODE -eq 0) { break }
+            if ($attempt -eq 3) { exit $LASTEXITCODE }
+            Write-Host "electron-builder failed (attempt $attempt); retrying after backoff."
+            Start-Sleep -Seconds (15 * $attempt)
+          }
 
       - name: Smoke unpacked app
         env:
@@ -266,7 +275,16 @@ jobs:
         run: node -e "if (process.arch !== 'arm64') process.exit(1)"
 
       - name: Build Electron app for arm64
-        run: pnpm build && pnpm exec electron-builder --publish never --win --arm64
+        shell: pwsh
+        run: |
+          pnpm build
+          foreach ($attempt in 1..3) {
+            pnpm exec electron-builder --publish never --win --arm64
+            if ($LASTEXITCODE -eq 0) { break }
+            if ($attempt -eq 3) { exit $LASTEXITCODE }
+            Write-Host "electron-builder failed (attempt $attempt); retrying after backoff."
+            Start-Sleep -Seconds (15 * $attempt)
+          }
 
       - name: Smoke unpacked app
         env:

--- a/app/visBridgeDaemon.e2e.test.ts
+++ b/app/visBridgeDaemon.e2e.test.ts
@@ -11,6 +11,7 @@ import {
   runCli,
   runCommandRequest,
   startFixture,
+  stopDaemonInProcess,
   waitForTextFile,
 } from './visBridgeDaemonTestHarness';
 
@@ -127,11 +128,12 @@ describe('vis_bridge daemon CLI', { timeout: 15_000 }, () => {
     );
 
     try {
-      const stopping = runCli(['stop'], fixture.env);
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      // The daemon closes command admission before its 202 acknowledgement
+      // reaches the client, so completing the body now must never spawn.
+      await stopDaemonInProcess(fixture);
       if (!socket.destroyed) socket.write(payload.slice(1));
-      await stopping;
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      // Give a wrongly admitted command ample time to spawn and write its pid.
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
 
       await expect(readFile(pidPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     } finally {

--- a/app/visBridgeDaemonTestHarness.ts
+++ b/app/visBridgeDaemonTestHarness.ts
@@ -136,6 +136,40 @@ export function runCli(arguments_: string[], env: NodeJS.ProcessEnv) {
   return execFileAsync(process.execPath, [entryPath, ...arguments_], { cwd: workspacePath, env });
 }
 
+export async function stopDaemonInProcess(fixture: DaemonFixture) {
+  const statePath = path.join(fixture.directory, 'state', 'daemon.json');
+  const state: unknown = JSON.parse(await readFile(statePath, 'utf8'));
+  if (!state || typeof state !== 'object') throw new Error('Expected daemon state.');
+  const { controlPort, controlToken, instanceId } = state as Record<string, unknown>;
+  if (
+    typeof controlPort !== 'number' ||
+    typeof controlToken !== 'string' ||
+    typeof instanceId !== 'string'
+  ) {
+    throw new Error('Daemon state is missing control credentials.');
+  }
+  await new Promise<void>((resolve, reject) => {
+    const stopRequest = request({
+      host: '127.0.0.1',
+      port: controlPort,
+      path: '/stop',
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${controlToken}`,
+        'x-vis-bridge-instance': instanceId,
+      },
+    }, (response) => {
+      response.resume();
+      response.once('end', () => {
+        if (response.statusCode === 202) resolve();
+        else reject(new Error(`vis_bridge daemon rejected stop (${response.statusCode ?? 'unknown'}).`));
+      });
+    });
+    stopRequest.once('error', reject);
+    stopRequest.end();
+  });
+}
+
 export function startFixture(fixture: DaemonFixture) {
   return runCli(
     ['start', '--port', String(fixture.port), '--config', fixture.configPath],

--- a/app/workers/sse-shared-worker.test.ts
+++ b/app/workers/sse-shared-worker.test.ts
@@ -1863,7 +1863,9 @@ describe('SSE SharedWorker hydration', () => {
     );
   });
 
-  it('schedules one authoritative bootstrap after buffered state overflows', { timeout: 15_000 }, async () => {
+  // Overflowing the 2000-packet production cap is CPU-bound and slows down
+  // sharply on contended CI runners, so this needs generous headroom.
+  it('schedules one authoritative bootstrap after buffered state overflows', { timeout: 60_000 }, async () => {
     const projects = deferred<unknown>();
     mocks.adapter.listProjects.mockReturnValueOnce(projects.promise).mockResolvedValueOnce([
       project(['/a']),
@@ -1881,7 +1883,7 @@ describe('SSE SharedWorker hydration', () => {
     expect(secondBootstrap?.projects.project?.sandboxes['/a']?.sessions).toEqual({});
   });
 
-  it('restarts from authoritative state after the packet count reaches its cap', { timeout: 15_000 }, async () => {
+  it('restarts from authoritative state after the packet count reaches its cap', { timeout: 60_000 }, async () => {
     const projects = deferred<unknown>();
     mocks.adapter.listProjects.mockReturnValueOnce(projects.promise).mockResolvedValueOnce([
       project(['/a']),


### PR DESCRIPTION
## 根因（近 60 次 CI 运行 9 次失败，4 个独立来源）

1. **sse-shared-worker 两个缓冲区溢出测试超时**（4 次失败）：测试需发送 2001 个真实包溢出生产 2000 包上限，CPU 密集；CI 满载实测 15.35s 撞上 15s 超时。
2. **visBridgeDaemon e2e shutdown 竞态**（最新 commit 仍失败）：旧测试盲等 150ms 后补发请求体，慢 runner 上 stop CLI 尚未到达 daemon，命令被错误准入执行（CI 报错签名 `promise resolved "'5275'"`）。
3. **bridgeUpdateHandoff Windows 握手失败**（09-08 三次）：已由 227f76ad7 修复，本 PR 不涉及。
4. **Electron win x64 NSIS 资源下载 500**（一次）：electron-builder 下载瞬时 5xx。

## 修复

- 两个溢出测试超时 15s → 60s（4 倍余量）。
- shutdown 竞态测试改为进程内控制请求：收到 202 即准入已关（事件循环保证），彻底消除竞态窗口；新增 `stopDaemonInProcess` harness 辅助函数。
- Windows electron-builder 两个步骤加 3 次退避重试（下载缓存跨重试复用，`pnpm build` 不重跑）。

## 验证

- 破坏-恢复 RED 证据：临时移除 `accepting = false`，新测试以 CI 相同签名失败；恢复后 5/5 通过。
- pnpm lint exit 0；全量 2460 测试通过；生产构建 exit 0。