### PR TITLE
fix(codex): 持久化模型信息并修复历史卡片撤销与差异

### DIFF
--- a/app/backends/codex/auxiliaryHistory.ts
+++ b/app/backends/codex/auxiliaryHistory.ts
@@ -1,5 +1,5 @@
 import type { MessageInfo, ReasoningPart, ToolPart } from '../../types/sse';
-import { StorageKeys, storageGetJSON, storageRemove, storageSetJSON } from '../../utils/storageKeys';
+import { readCodexAuxiliarySnapshot, removeCodexAuxiliarySnapshot, writeCodexAuxiliarySnapshot } from './auxiliaryStorage';
 import type { CodexCanonicalHistoryEntry } from './normalize';
 
 type AuxiliaryPart = ReasoningPart | ToolPart;
@@ -45,10 +45,6 @@ function isAuxiliaryPart(value: unknown, threadId: string): value is AuxiliaryPa
   return isRecord(value.state.input);
 }
 
-function snapshotKey(threadId: string) {
-  return `${StorageKeys.state.codexAuxiliaryHistory}.${encodeURIComponent(threadId)}`;
-}
-
 function isTerminalTool(part: AuxiliaryPart) {
   return part.type === 'tool' && (part.state.status === 'completed' || part.state.status === 'error');
 }
@@ -84,7 +80,7 @@ export function mergeCodexAuxiliaryHistory(
 }
 
 export function loadCodexAuxiliaryHistory(threadId: string) {
-  const snapshot = storageGetJSON<unknown>(snapshotKey(threadId));
+  const snapshot = readCodexAuxiliarySnapshot(threadId);
   if (!isRecord(snapshot)
     || snapshot.version !== 1
     || snapshot.threadId !== threadId
@@ -104,9 +100,9 @@ export function saveCodexAuxiliaryHistory(threadId: string, entries: ReadonlyArr
   const auxiliaryEntries = mergeCodexAuxiliaryHistory(threadId, entries);
   if (auxiliaryEntries.length === 0) return;
   const snapshot: AuxiliaryHistorySnapshot = { version: 1, threadId, entries: auxiliaryEntries };
-  storageSetJSON(snapshotKey(threadId), snapshot);
+  writeCodexAuxiliarySnapshot(threadId, snapshot);
 }
 
 export function clearCodexAuxiliaryHistory(threadId: string) {
-  storageRemove(snapshotKey(threadId));
+  removeCodexAuxiliarySnapshot(threadId);
 }

--- a/app/backends/codex/auxiliaryStorage.ts
+++ b/app/backends/codex/auxiliaryStorage.ts
@@ -1,0 +1,210 @@
+import { StorageKeys, storageGetJSON, storageKey, storageRemove, storageSetJSON } from '../../utils/storageKeys';
+
+const DATABASE = 'opencode.codexAuxiliaryHistory';
+const STORE = 'snapshots';
+const PREFIX = `${storageKey(StorageKeys.state.codexAuxiliaryHistory)}.`;
+const snapshots = new Map<string, string | null>();
+const generations = new Map<string, number>();
+const pending = new Set<Promise<void>>();
+let database: IDBDatabase | null = null;
+let initialization: Promise<void> | null = null;
+let channel: BroadcastChannel | null = null;
+
+function keyFor(threadId: string) {
+  return `${StorageKeys.state.codexAuxiliaryHistory}.${encodeURIComponent(threadId)}`;
+}
+
+function useIndexedDB() {
+  return typeof window !== 'undefined'
+    && !window.electronAPI?.persistentStorage
+    && typeof indexedDB !== 'undefined';
+}
+
+function reportFailure(error: unknown) {
+  console.error('[Codex] Auxiliary history persistence failed; cached data retained',
+    error instanceof Error ? error.message : String(error));
+}
+
+function track(operation: Promise<void>) {
+  const handled = operation.catch(reportFailure);
+  pending.add(handled);
+  void handled.then(() => pending.delete(handled));
+}
+
+function openDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DATABASE, 1);
+    request.onupgradeneeded = () => request.result.createObjectStore(STORE);
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => console.error('[Codex] Auxiliary history database upgrade blocked by another tab');
+    request.onsuccess = () => resolve(request.result);
+  });
+}
+
+function synchronizeKey(key: string): Promise<void> {
+  const connection = database;
+  if (!connection) return Promise.resolve();
+  const generation = generations.get(key);
+  return new Promise((resolve, reject) => {
+    const transaction = connection.transaction(STORE, 'readonly');
+    const request = transaction.objectStore(STORE).get(key);
+    transaction.onabort = () => reject(transaction.error);
+    transaction.oncomplete = () => {
+      const value: unknown = request.result;
+      if (connection === database && generation === generations.get(key)
+        && (typeof value === 'string' || value === undefined)) {
+        snapshots.set(key, value ?? null);
+      }
+      resolve();
+    };
+  });
+}
+
+function closeConnection() {
+  channel?.close();
+  channel = null;
+  database?.close();
+  database = null;
+  initialization = null;
+}
+
+function listenForChanges() {
+  if (typeof BroadcastChannel === 'undefined') return;
+  channel = new BroadcastChannel(DATABASE);
+  channel.onmessage = (event: MessageEvent<unknown>) => {
+    if (typeof event.data === 'string' && event.data.startsWith(PREFIX)) {
+      track(synchronizeKey(event.data));
+    }
+  };
+}
+
+function hydrateAndMigrate(connection: IDBDatabase): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const transaction = connection.transaction(STORE, 'readwrite');
+    const store = transaction.objectStore(STORE);
+    const loaded = new Map<string, string>();
+    const migrated = new Map<string, string>();
+    const cursor = store.openCursor();
+    transaction.onabort = () => reject(transaction.error);
+    transaction.oncomplete = () => {
+      try {
+        for (const [key, value] of loaded) {
+          if (!snapshots.has(key)) snapshots.set(key, value);
+        }
+        for (const [key, value] of migrated) {
+          if (window.localStorage.getItem(key) === value) window.localStorage.removeItem(key);
+        }
+        resolve();
+      } catch (error) {
+        reject(error);
+      }
+    };
+    cursor.onsuccess = () => {
+      const entry = cursor.result;
+      if (entry) {
+        const value: unknown = entry.value;
+        if (typeof entry.key === 'string' && typeof value === 'string') loaded.set(entry.key, value);
+        entry.continue();
+        return;
+      }
+      try {
+        // Read legacy values while holding the IDB write transaction, not before waiting for another tab.
+        for (let index = 0; index < window.localStorage.length; index += 1) {
+          const key = window.localStorage.key(index);
+          if (!key?.startsWith(PREFIX)) continue;
+          const value = window.localStorage.getItem(key);
+          if (value === null) continue;
+          store.put(value, key);
+          migrated.set(key, value);
+          loaded.set(key, value);
+        }
+      } catch (error) {
+        transaction.abort();
+        reject(error);
+      }
+    };
+  });
+}
+
+export function initializeCodexAuxiliaryStorage(): Promise<void> {
+  if (!useIndexedDB()) return Promise.resolve();
+  if (initialization) return initialization;
+  initialization = (async () => {
+    const connection = await openDatabase();
+    try {
+      await hydrateAndMigrate(connection);
+      database = connection;
+      connection.onversionchange = closeConnection;
+      listenForChanges();
+    } catch (error) {
+      connection.close();
+      throw error;
+    }
+  })().catch((error: unknown) => {
+    initialization = null;
+    throw error;
+  });
+  return initialization;
+}
+
+function persist(key: string, value: string | null): Promise<void> {
+  const connection = database;
+  if (!connection) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const transaction = connection.transaction(STORE, 'readwrite');
+    transaction.oncomplete = () => {
+      if (database === connection) channel?.postMessage(key);
+      resolve();
+    };
+    transaction.onabort = () => reject(transaction.error);
+    const store = transaction.objectStore(STORE);
+    if (value === null) store.delete(key);
+    else store.put(value, key);
+  });
+}
+
+function update(key: string, value: string | null) {
+  generations.set(key, (generations.get(key) ?? 0) + 1);
+  snapshots.set(key, value);
+  track(database ? persist(key, value) : initializeCodexAuxiliaryStorage().then(() => persist(key, value)));
+}
+
+export function readCodexAuxiliarySnapshot(threadId: string): unknown {
+  const key = keyFor(threadId);
+  if (!useIndexedDB() || !snapshots.has(storageKey(key))) return storageGetJSON<unknown>(key);
+  const raw = snapshots.get(storageKey(key));
+  if (!raw) return null;
+  try {
+    const value: unknown = JSON.parse(raw);
+    return value;
+  } catch (error) {
+    reportFailure(error);
+    return null;
+  }
+}
+
+export function writeCodexAuxiliarySnapshot(threadId: string, snapshot: unknown): void {
+  const key = keyFor(threadId);
+  if (!useIndexedDB()) {
+    if (!storageSetJSON(key, snapshot)) console.error('[Codex] Auxiliary history storage write failed');
+    return;
+  }
+  const serialized = JSON.stringify(snapshot);
+  if (serialized !== undefined) update(storageKey(key), serialized);
+}
+
+export function removeCodexAuxiliarySnapshot(threadId: string): void {
+  const key = keyFor(threadId);
+  if (!useIndexedDB()) {
+    storageRemove(key);
+    return;
+  }
+  update(storageKey(key), null);
+}
+
+export async function flushCodexAuxiliaryStorage(): Promise<void> {
+  await initialization;
+  while (pending.size > 0) await Promise.all(pending);
+}
+
+if (import.meta.hot) import.meta.hot.dispose(closeConnection);

--- a/app/backends/codex/codexAdapter.ts
+++ b/app/backends/codex/codexAdapter.ts
@@ -75,6 +75,8 @@ export type CodexThread = {
   preview?: string;
   ephemeral?: boolean;
   modelProvider?: string;
+  model?: string | null;
+  reasoningEffort?: string | null;
   createdAt?: number;
   updatedAt?: number;
   status?: unknown;

--- a/app/backends/codex/messageModels.test.ts
+++ b/app/backends/codex/messageModels.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createCodexMessageModels } from './messageModels';
+import { normalizeCodexTurnsToHistory } from './normalize';
+import { StorageKeys, storageSetJSON } from '../../utils/storageKeys';
+
+function history(model = { providerID: 'codex', modelID: 'codex' }) {
+  return normalizeCodexTurnsToHistory({ sessionId: 'thread', model, turns: [{ id: 'turn', startedAt: 1, items: [
+    { type: 'userMessage', id: 'first', content: [{ type: 'text', text: 'First' }] },
+    { type: 'agentMessage', id: 'answer-first', text: 'First answer' },
+    { type: 'userMessage', id: 'second', content: [{ type: 'text', text: 'Second' }] },
+    { type: 'agentMessage', id: 'answer-second', text: 'Second answer' },
+  ] }] });
+}
+
+describe('Codex message model snapshots', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('maps the official wire provider back to the built-in UI catalog for uncached history', () => {
+    const models = createCodexMessageModels(() => 'ws://example.test/rpc');
+    expect(models.restore('thread', history({ providerID: 'openai', modelID: 'gpt-6-astra' }))[0]?.info)
+      .toMatchObject({ model: { providerID: 'codex', modelID: 'gpt-6-astra' } });
+    expect(models.restore('thread', history({ providerID: 'custom', modelID: 'gpt-6-astra' }))[0]?.info)
+      .toMatchObject({ model: { providerID: 'custom', modelID: 'gpt-6-astra' } });
+  });
+
+  it('keeps supplemental models distinct and restores assistants from their user snapshot', () => {
+    const models = createCodexMessageModels(() => 'ws://example.test/rpc');
+    for (const entry of history({ providerID: 'codex', modelID: 'first-model' }).slice(0, 1)) models.save('thread', entry.info);
+    for (const entry of history({ providerID: 'custom', modelID: 'second-model' }).slice(2, 3)) models.save('thread', entry.info);
+    const fresh = createCodexMessageModels(() => 'ws://example.test/rpc');
+    expect(fresh.restore('thread', history()).map(({ info }) => info.role === 'user' ? info.model : { providerID: info.providerID, modelID: info.modelID })).toEqual([
+      { providerID: 'codex', modelID: 'first-model' }, { providerID: 'codex', modelID: 'first-model' },
+      { providerID: 'custom', modelID: 'second-model' }, { providerID: 'custom', modelID: 'second-model' },
+    ]);
+  });
+
+  it('isolates threads and endpoints while excluding credentials from the key', () => {
+    const models = createCodexMessageModels(() => 'ws://name:secret@example.test/rpc?token=hidden');
+    for (const entry of history({ providerID: 'custom', modelID: 'saved-model' })) models.save('thread', entry.info);
+    const other = createCodexMessageModels(() => 'ws://other.test/rpc');
+    expect(other.restore('thread', history())).toEqual(history());
+    expect(models.restore('other-thread', history())).toEqual(history());
+    expect(Object.keys(localStorage).join()).not.toMatch(/secret|hidden|name/);
+  });
+
+  it('does not replace a saved model with an unknown placeholder', () => {
+    const models = createCodexMessageModels(() => 'ws://example.test/rpc');
+    for (const entry of history({ providerID: 'codex', modelID: 'saved-model' })) models.save('thread', entry.info);
+    for (const entry of history()) models.save('thread', entry.info);
+    expect(models.restore('thread', history())[0]?.info).toMatchObject({ model: { modelID: 'saved-model' } });
+  });
+
+  it('ignores malformed stored models and preserves known live metadata before acknowledgement', () => {
+    const models = createCodexMessageModels(() => 'ws://example.test/rpc');
+    storageSetJSON(`${StorageKeys.state.codexMessageModels}.${encodeURIComponent('ws://example.test/rpc')}.thread`, {
+      'turn:user:first': { providerID: 42, modelID: 'invalid' },
+    });
+    const known = history({ providerID: 'custom', modelID: 'live-model' });
+    expect(models.restore('thread', history(), known)[0]?.info).toMatchObject({ model: { providerID: 'custom', modelID: 'live-model' } });
+  });
+});

--- a/app/backends/codex/messageModels.ts
+++ b/app/backends/codex/messageModels.ts
@@ -1,0 +1,61 @@
+import type { MessageInfo } from '../../types/sse';
+import { storageGetJSON, storageSetJSON, StorageKeys } from '../../utils/storageKeys';
+import type { CodexCanonicalHistoryEntry } from './normalize';
+
+type MessageModel = { readonly providerID: string; readonly modelID: string };
+
+function readModel(value: unknown): MessageModel | undefined {
+  if (!value || typeof value !== 'object' || !('providerID' in value) || !('modelID' in value)) return;
+  if (typeof value.providerID !== 'string' || typeof value.modelID !== 'string') return;
+  const providerID = value.providerID.trim();
+  const modelID = value.modelID.trim();
+  if (!providerID || !modelID || modelID === 'codex' || modelID === 'unknown') return;
+  return { providerID, modelID };
+}
+
+export function createCodexMessageModels(connectionUrl: () => string) {
+  function key(threadId: string) {
+    const endpoint = new URL(connectionUrl());
+    const scope = `${endpoint.protocol}//${endpoint.host}${endpoint.pathname}`;
+    return `${StorageKeys.state.codexMessageModels}.${encodeURIComponent(scope)}.${encodeURIComponent(threadId)}`;
+  }
+
+  function load(threadId: string) {
+    const saved = storageGetJSON<unknown>(key(threadId));
+    const models = new Map<string, MessageModel>();
+    if (!saved || typeof saved !== 'object' || Array.isArray(saved)) return models;
+    for (const [id, value] of Object.entries(saved)) {
+      const model = readModel(value);
+      if (model) models.set(id, model);
+    }
+    return models;
+  }
+
+  function save(threadId: string, user: MessageInfo) {
+    if (user.role !== 'user') return;
+    const model = readModel(user.model);
+    if (!model) return;
+    const models = load(threadId);
+    models.set(user.id, model);
+    storageSetJSON(key(threadId), Object.fromEntries(models));
+  }
+
+  function restore(threadId: string, entries: readonly CodexCanonicalHistoryEntry[], known: readonly CodexCanonicalHistoryEntry[] = []) {
+    const models = load(threadId);
+    for (const { info } of known) {
+      if (info.role !== 'user' || info.sessionID !== threadId || models.has(info.id)) continue;
+      const model = readModel(info.model);
+      if (model) models.set(info.id, model);
+    }
+    return entries.map(entry => {
+      const wireModel = readModel(entry.info.role === 'user' ? entry.info.model : entry.info);
+      const model = models.get(entry.info.role === 'user' ? entry.info.id : entry.info.parentID)
+        ?? (wireModel?.providerID === 'openai' ? { ...wireModel, providerID: 'codex' } : undefined);
+      if (!model) return entry;
+      const info = entry.info.role === 'user' ? { ...entry.info, model } : { ...entry.info, ...model };
+      return { ...entry, info };
+    });
+  }
+
+  return { save, restore };
+}

--- a/app/backends/codex/normalize.ts
+++ b/app/backends/codex/normalize.ts
@@ -10,6 +10,7 @@ import type {
   UserMessageInfo,
 } from '../../types/sse';
 import { codexReasoningText } from './reasoning';
+import { codexAgentName } from '../../utils/codexAgentName';
 
 type CodexRecord = Record<string, unknown>;
 
@@ -505,6 +506,31 @@ export function normalizeCodexTurnItems(params: {
         output: error || result,
         createdAt: itemTime,
         status,
+      }));
+      return;
+    }
+
+    if (type === 'subAgentActivity') {
+      const childId = stringValue(item.agentThreadId);
+      const agentPath = stringValue(item.agentPath);
+      const agentName = codexAgentName(agentPath);
+      const kind = stringValue(item.kind);
+      const status = kind === 'completed' || kind === 'interrupted' ? kind : 'running';
+      parts.push(createToolPart({
+        id: itemId,
+        sessionId: params.sessionId,
+        messageId: assistantMessageId,
+        tool: 'task',
+        title: agentName || 'Codex agent',
+        input: { operation: kind, prompt: agentName },
+        output: [kind, agentName].filter(Boolean).join('\n'),
+        createdAt: itemTime,
+        status: 'completed',
+        metadata: {
+          sessionId: childId, sessionIds: childId ? [childId] : [],
+          agentPath, senderThreadId: params.sessionId,
+          agentsStates: childId ? { [childId]: { status } } : {},
+        },
       }));
       return;
     }

--- a/app/backends/codex/rollbackTarget.ts
+++ b/app/backends/codex/rollbackTarget.ts
@@ -1,0 +1,9 @@
+import { normalizeCodexTurnsToHistory } from './normalize';
+import type { CodexTurn } from './codexAdapter';
+
+export function codexRollbackCount(sessionId: string, turns: readonly CodexTurn[], messageId: string): number {
+  const index = turns.findIndex(turn => normalizeCodexTurnsToHistory({ sessionId, turns: [turn] })
+    .some(entry => entry.info.role === 'user' && entry.info.id === messageId));
+  if (index < 0) throw new Error('Codex rollback target is no longer present in this thread.');
+  return turns.length - index;
+}

--- a/app/backends/codex/subAgentActivity.test.ts
+++ b/app/backends/codex/subAgentActivity.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeCodexTurnItems } from './normalize';
+import { codexSubagentWindowEntries } from '../../utils/codexSubagentWindowEntries';
+import { resolveThreadSubagentSessions } from '../../utils/threadSubagents';
+
+describe('Codex subAgentActivity compatibility', () => {
+  it.each(['started', 'interacted', 'interrupted', 'completed'])('restores reviewer identity and activity for %s', kind => {
+    const bundle = normalizeCodexTurnItems({ sessionId: 'parent', turnId: 'turn', items: [{
+      type: 'subAgentActivity', id: `activity-${kind}`, kind,
+      agentThreadId: 'review-child', agentPath: '/root/code_review',
+    }] });
+    const part = bundle.parts.find(part => part.type === 'tool');
+    const info = bundle.messages.find(info => info.role === 'assistant');
+    expect(part).toMatchObject({ tool: 'task', state: { metadata: { sessionId: 'review-child' } } });
+    expect(resolveThreadSubagentSessions(bundle.parts, 'parent')).toEqual([
+      { sessionId: 'review-child', label: 'code_review' },
+    ]);
+    if (!part || !info) throw new Error('Missing reviewer activity');
+    const entries = codexSubagentWindowEntries(info, part);
+    expect(entries[0]?.info).toMatchObject({ sessionID: 'review-child', agent: 'code_review' });
+    expect(entries[0]?.part.text).toContain('code_review');
+    expect(entries[0]?.part.text).not.toContain('/root/');
+    expect(Boolean(entries[0]?.part.time?.end)).toBe(kind === 'completed' || kind === 'interrupted');
+  });
+});

--- a/app/backends/codex/subagentStreams.test.ts
+++ b/app/backends/codex/subagentStreams.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import type { AssistantMessageInfo, MessagePart } from '../../types/sse';
+import { createCodexSubagentStreams } from './subagentStreams';
+
+function setup() {
+  let selected = 'parent';
+  const events: { info: AssistantMessageInfo; part: MessagePart }[] = [];
+  const stream = createCodexSubagentStreams({ getSelectedParent: () => selected, publish: (info, part) => events.push({ info, part }) });
+  stream.registerHistory({ id: 'parent', turns: [{ id: 'parent-turn', items: [{ id: 'spawn', type: 'subAgentActivity', agentThreadId: 'child', agentPath: '/root/reviewer' }] }] });
+  const send = (method: string, params: Record<string, unknown>) => stream.handle({ method, params: { threadId: 'child', turnId: 'turn', ...params } });
+  return { events, stream, send, select: (id: string) => { selected = id; } };
+}
+
+describe('Codex descendant streams', () => {
+  it('catches up only the latest child turn on a live subscription, without replaying history on refresh', () => {
+    const {stream,events} = setup();
+    const thread = {id:'child',turns:[
+      {id:'old',status:'completed',items:[{type:'agentMessage',id:'old-answer',text:'Old'}]},
+      {id:'new',status:'completed',items:[{type:'agentMessage',id:'answer',text:'Finished before subscription'}]},
+    ]};
+    stream.registerHistory(thread);
+    expect(events).toHaveLength(0);
+    stream.registerHistory(thread,undefined,true);
+    stream.registerHistory(thread,undefined,true);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.part).toMatchObject({text:'Finished before subscription',time:{end:expect.any(Number)}});
+  });
+  it('updates live window metadata when the child model arrives after its first text', () => {
+    const {stream,send,events} = setup();
+    send('item/agentMessage/delta',{itemId:'answer',delta:'Checking'});
+    stream.registerHistory({id:'child',model:'child-model',modelProvider:'codex',turns:[]});
+    expect(events.at(-1)?.info.modelID).toBe('child-model');
+    expect(events.at(-1)?.part).toMatchObject({text:'Checking'});
+  });
+  it('requests a live subscription when a historical child is used again', () => {
+    const discoveries: boolean[] = [];
+    const stream = createCodexSubagentStreams({getSelectedParent:()=> 'parent', publish:()=>{}, onDiscover:(_id,live)=>discoveries.push(live)});
+    const item = {type:'subAgentActivity',agentThreadId:'child',agentPath:'/root/reviewer',kind:'interacted'};
+    stream.registerHistory({id:'parent',turns:[{items:[item]}]});
+    stream.handle({method:'item/completed',params:{threadId:'parent',item}});
+    stream.handle({method:'item/completed',params:{threadId:'parent',item}});
+    expect(discoveries).toEqual([false,true]);
+  });
+  it('publishes live reasoning, command output and text with child identity', () => {
+    const { send, events } = setup();
+    send('turn/started', { turn: { id: 'turn', model: 'child-model', modelProvider: 'local' } });
+    send('item/reasoning/summaryTextDelta', { itemId: 'think', delta: 'Inspecting' });
+    send('item/started', { item: { id: 'shell', type: 'commandExecution', command: 'pwd' } });
+    send('item/commandExecution/outputDelta', { itemId: 'shell', delta: '/project' });
+    send('item/agentMessage/delta', { itemId: 'answer', delta: 'Done' });
+    expect(events.map(event => event.part.type)).toEqual(['reasoning', 'tool', 'tool', 'text']);
+    expect(events.at(-1)?.info).toMatchObject({ sessionID: 'child', modelID: 'child-model', providerID: 'local', agent: 'reviewer' });
+    expect(events[2]?.part).toMatchObject({ state: { status: 'running', metadata: { output: '/project' } } });
+    expect(events.at(-1)?.part).toMatchObject({ text: 'Done' });
+    expect(events.at(-1)?.part).not.toHaveProperty('time.end');
+  });
+  it('ignores unrelated sessions, historical replay and old selection', () => {
+    const { send, events, stream, select } = setup();
+    stream.registerHistory({ id: 'child', turns: [{ id: 'turn', status: 'completed', items: [{ id: 'old', type: 'agentMessage', text: 'Old' }] }] });
+    send('item/completed', { item: { id: 'old', type: 'agentMessage', text: 'Old' } });
+    send('item/agentMessage/delta', { threadId: 'unrelated', itemId: 'other', delta: 'No' });
+    select('different');
+    send('item/agentMessage/delta', { itemId: 'new', delta: 'No' });
+    expect(events).toEqual([]);
+  });
+  it('discovers grandchildren from live collaboration and thread source metadata', () => {
+    const { send, events } = setup();
+    send('item/started', { item: { id: 'spawn2', type: 'collabAgentToolCall', receiverThreadIds: ['grandchild'], senderThreadId: 'child' } });
+    send('thread/started', { thread: { id: 'grandchild', agentNickname: 'Checker', model: 'real-model', source: { subAgent: { thread_spawn: { parent_thread_id: 'child' } } } } });
+    send('item/agentMessage/delta', { threadId: 'grandchild', itemId: 'answer', delta: 'Found' });
+    expect(events.at(-1)?.info).toMatchObject({ sessionID: 'grandchild', modelID: 'real-model', agent: 'Checker' });
+  });
+  it('discovers each child once and accepts source-only links with canonical model metadata', () => {
+    const discovered: string[] = [];
+    const events: { info: AssistantMessageInfo; part: MessagePart }[] = [];
+    const stream = createCodexSubagentStreams({ getSelectedParent: () => 'parent', onDiscover: id => discovered.push(id), publish: (info, part) => events.push({ info, part }) });
+    const thread = { id: 'source-child', source: { subAgent: { thread_spawn: { parent_thread_id: 'parent' } } } };
+    stream.handle({ method: 'thread/started', params: { thread } });
+    stream.registerHistory(thread, { modelID: 'actual-model', providerID: 'actual-provider' });
+    stream.handle({ method: 'item/agentMessage/delta', params: { threadId: 'source-child', turnId: 'turn', itemId: 'answer', delta: 'Hi' } });
+    expect(discovered).toEqual(['source-child']);
+    expect(events.at(-1)?.info).toMatchObject({ modelID: 'actual-model', providerID: 'actual-provider' });
+  });
+  it('keeps task path names, namespaces tool IDs and marks history discovery', () => {
+    const discoveries: [string, boolean][] = [];
+    const events: { info: AssistantMessageInfo; part: MessagePart }[] = [];
+    const stream = createCodexSubagentStreams({ getSelectedParent: () => 'parent', onDiscover: (id, live) => discoveries.push([id, live]), publish: (info, part) => events.push({ info, part }) });
+    stream.registerHistory({ id: 'parent', turns: [{ items: [{ type: 'subAgentActivity', agentThreadId: 'child', agentPath: '/root/code_reviewer' }] }] });
+    stream.registerHistory({ id: 'child', agentNickname: 'Nickname' });
+    stream.handle({ method: 'item/started', params: { threadId: 'child', turnId: 'turn', item: { id: 'shell', type: 'commandExecution', command: 'pwd' } } });
+    expect(discoveries).toEqual([['child', false]]);
+    expect(events[0]?.info.agent).toBe('code_reviewer');
+    expect(events[0]?.part).toMatchObject({ id: 'child:shell', callID: 'child:shell' });
+  });
+  it('closes running child tools when thread becomes idle', () => {
+    const { send, events } = setup();
+    send('item/started', { item: { id: 'shell', type: 'commandExecution', command: 'pwd' } });
+    send('thread/status/changed', { turnId: undefined, status: { type: 'idle' } });
+    expect(events.at(-1)?.part).toMatchObject({ state: { status: 'completed' } });
+    expect(events.at(-1)?.info.time.completed).toEqual(expect.any(Number));
+  });
+  it('completes active parts and deduplicates completed items', () => {
+    const { send, events } = setup();
+    send('item/agentMessage/delta', { itemId: 'answer', delta: 'Done' });
+    send('turn/completed', { turn: { id: 'turn', status: 'completed' } });
+    const completed = events.at(-1);
+    send('item/completed', { item: { id: 'answer', type: 'agentMessage', text: 'Done' } });
+    expect(events).toHaveLength(2);
+    expect(completed?.info.time.completed).toEqual(expect.any(Number));
+    expect(completed?.part).toMatchObject({ time: { end: expect.any(Number) } });
+    expect(completed?.info.modelID).toBe('');
+  });
+});

--- a/app/backends/codex/subagentStreams.ts
+++ b/app/backends/codex/subagentStreams.ts
@@ -1,0 +1,188 @@
+import type { AssistantMessageInfo, MessagePart } from '../../types/sse';
+import type { CodexJsonRpcNotification } from './jsonRpcProtocol';
+import { normalizeCodexTurnItems, type CodexNormalizeModel } from './normalize';
+
+type Wire = Readonly<Record<string, unknown>>;
+type LiveItem = { wire: Wire; turnId: string; created: number; done: boolean; signature?: string };
+type Child = { modelID: string; providerID: string; agent: string; agentPath: string; live: boolean; items: Map<string, LiveItem> };
+const MAX_CHILDREN = 128;
+const MAX_ITEMS = 256;
+const MAX_TEXT = 200_000;
+function record(value: unknown): Wire {
+  return value !== null && typeof value === 'object' && !Array.isArray(value) ? Object.fromEntries(Object.entries(value)) : {};
+}
+function text(value: unknown) { return typeof value === 'string' ? value : ''; }
+function list(value: unknown): unknown[] { return Array.isArray(value) ? value : []; }
+function agentName(value: unknown) { return text(value).split('/').filter(Boolean).at(-1) || ''; }
+
+export function createCodexSubagentStreams(options: {
+  readonly getSelectedParent: () => string | null;
+  readonly publish: (info: AssistantMessageInfo, part: MessagePart) => void;
+  readonly onDiscover?: (threadId: string, live: boolean) => void;
+}) {
+  const children = new Map<string, Child>();
+  let selected = options.getSelectedParent();
+  function reset() { children.clear(); selected = options.getSelectedParent(); }
+  function sync() { if (selected !== options.getSelectedParent()) reset(); }
+  function known(id: string) { return Boolean(selected) && (id === selected || children.has(id)); }
+  function discover(id: string, metadata: Wire = {}, live = true) {
+    if (!id || id === selected) return;
+    let child = children.get(id);
+    const fresh = !child;
+    if (!child) {
+      if (children.size >= MAX_CHILDREN) return;
+      child = { modelID: '', providerID: '', agent: '', agentPath: '', live: false, items: new Map() };
+      children.set(id, child);
+    }
+    child.modelID = text(metadata.modelID) || text(metadata.model) || child.modelID;
+    child.providerID = text(metadata.providerID) || text(metadata.modelProvider) || child.providerID;
+    child.agentPath = agentName(metadata.agentPath) || agentName(metadata.agent_path) || child.agentPath;
+    child.agent = child.agentPath || agentName(metadata.agentNickname) || agentName(metadata.agentRole) || child.agent;
+    const activate = live && !child.live;
+    child.live ||= live;
+    if (fresh || activate) options.onDiscover?.(id, live);
+  }
+  function discoverItem(owner: string, item: Wire, live = true) {
+    if (!known(owner)) return;
+    switch (item.type) {
+      case 'subAgentActivity': discover(text(item.agentThreadId), { agentPath: item.agentPath }, live); return;
+      case 'collabToolCall':
+      case 'collabAgentToolCall': {
+        if (text(item.senderThreadId) && item.senderThreadId !== owner) return;
+        const ids = list(item.receiverThreadIds);
+        for (const id of ids.length ? ids : [item.newThreadId, item.receiverThreadId]) discover(text(id), {}, live);
+        return;
+      }
+      default: return;
+    }
+  }
+  function threadMetadata(thread: Wire, live = true) {
+    const id = text(thread.id);
+    const source = record(thread.source);
+    const subagent = record(source.subAgent);
+    const spawn = record(subagent.thread_spawn ?? subagent.threadSpawn);
+    const parent = text(thread.parentThreadId) || text(spawn.parent_thread_id) || text(spawn.parentThreadId);
+    if (known(parent) || children.has(id)) discover(id, { ...spawn, ...thread }, live);
+    return id;
+  }
+  function remember(child: Child, key: string, item: LiveItem) {
+    if (!child.items.has(key) && child.items.size >= MAX_ITEMS) {
+      const oldest = child.items.keys().next().value;
+      if (oldest !== undefined) child.items.delete(oldest);
+    }
+    child.items.set(key, item);
+  }
+  function registerHistory(value: unknown, model?: CodexNormalizeModel, catchUp = false) {
+    sync();
+    const thread = record(value);
+    const id = threadMetadata({ ...thread, ...model }, false);
+    if (!known(id)) return;
+    const liveChild = children.get(id);
+    if (liveChild) {
+      for (const item of liveChild.items.values()) if (item.signature) emit(id, liveChild, item);
+    }
+    const turns = list(thread.turns);
+    for (const rawTurn of turns) {
+      const turn = record(rawTurn);
+      for (const rawItem of list(turn.items)) {
+        const item = record(rawItem);
+        discoverItem(id, item, false);
+        const child = children.get(id);
+        const itemId = text(item.id);
+        const turnId = text(turn.id);
+        if (child && itemId && turnId) {
+          const key = `${turnId}:${itemId}`;
+          const previous = child.items.get(key);
+          if (!previous || (catchUp && !previous.signature)) {
+            remember(child, key, { wire: item, turnId, created: previous?.created ?? Date.now(), done: turn.status !== 'inProgress' && turn.status !== 'running' });
+          }
+          const current = child.items.get(key);
+          if (catchUp && rawTurn === turns.at(-1) && current) emit(id, child, current);
+        }
+      }
+    }
+  }
+  function emit(id: string, child: Child, item: LiveItem) {
+    const signature = JSON.stringify([item.wire, item.done, child.modelID, child.providerID, child.agent]);
+    if (signature === item.signature) return;
+    item.signature = signature;
+    const bundle = normalizeCodexTurnItems({ sessionId: id, turnId: item.turnId, items: [item.wire], createdAt: item.created, turnStatus: item.done ? 'completed' : 'inProgress' });
+    for (const part of bundle.parts) {
+      const info = bundle.messages.find(message => message.id === part.messageID);
+      if (info?.role !== 'assistant') continue;
+      let stamped: MessagePart = part.type === 'text' || part.type === 'reasoning'
+        ? { ...part, time: { start: item.created, ...(item.done ? { end: Date.now() } : {}) } } : part;
+      if (part.type === 'tool' && part.state.status === 'completed' && !item.done) {
+        stamped = { ...part, state: { status: 'running', input: part.state.input, title: part.state.title,
+          metadata: { ...part.state.metadata, output: part.state.output }, time: { start: item.created } } };
+      }
+      if (stamped.type === 'tool') stamped = { ...stamped, id: `${id}:${stamped.id}`, callID: `${id}:${stamped.callID}` };
+      options.publish({ ...info, modelID: child.modelID, providerID: child.providerID, agent: child.agent,
+        time: { created: item.created, ...(item.done ? { completed: Date.now() } : {}) } }, stamped);
+    }
+  }
+  function handle(notification: CodexJsonRpcNotification): boolean {
+    sync();
+    const params = record(notification.params);
+    if (notification.method === 'thread/started') {
+      const id = threadMetadata(record(params.thread));
+      return children.has(id);
+    }
+    const id = text(params.threadId);
+    if (!known(id)) return false;
+    const wireItem = record(params.item);
+    discoverItem(id, wireItem);
+    const child = children.get(id);
+    if (!child) return false;
+    const turn = record(params.turn);
+    const turnId = text(params.turnId) || text(turn.id);
+    discover(id, { ...params, ...turn, ...wireItem }, false);
+    if (notification.method === 'turn/started') return true;
+    const status = text(record(params.status).type) || text(params.status);
+    const terminalStatus = notification.method === 'thread/status/changed' && ['idle', 'systemError', 'notLoaded'].includes(status);
+    if (notification.method === 'turn/completed' || notification.method === 'thread/closed' || notification.method === 'thread/archived' || terminalStatus) {
+      for (const item of child.items.values()) {
+        if (item.done || (turnId && item.turnId !== turnId)) continue;
+        item.done = true;
+        item.wire = { ...item.wire, status: text(turn.status) === 'failed' || status === 'systemError' ? 'failed' : 'completed' };
+        if (item.signature) emit(id, child, item);
+      }
+      return true;
+    }
+    const itemId = text(params.itemId) || text(wireItem.id);
+    if (!turnId || !itemId) return true;
+    const key = `${turnId}:${itemId}`;
+    const previous = child.items.get(key);
+    if (previous?.done) return true;
+    const item: LiveItem = previous ?? { wire: { id: itemId }, turnId, created: Date.now(), done: false };
+    const delta = text(params.delta);
+    switch (notification.method) {
+      case 'item/started':
+      case 'item/completed':
+        item.done = notification.method === 'item/completed';
+        item.wire = { ...item.wire, ...wireItem, status: text(wireItem.status) || (item.done ? 'completed' : 'inProgress') };
+        break;
+      case 'item/agentMessage/delta':
+        item.wire = { ...item.wire, type: 'agentMessage', text: (text(item.wire.text) + delta).slice(-MAX_TEXT) };
+        break;
+      case 'item/reasoning/summaryTextDelta':
+      case 'item/reasoning/textDelta': {
+        const field = notification.method === 'item/reasoning/summaryTextDelta' ? 'summary' : 'text';
+        const index = typeof params.summaryIndex === 'number' ? params.summaryIndex : typeof params.contentIndex === 'number' ? params.contentIndex : 0;
+        if (!Number.isInteger(index) || index < 0 || index > 255) return true;
+        const blocks = list(item.wire[field]).map(text);
+        blocks[index] = (text(blocks[index]) + delta).slice(-MAX_TEXT);
+        item.wire = { ...item.wire, type: 'reasoning', [field]: blocks };
+        break;
+      }
+      case 'item/commandExecution/outputDelta':
+        item.wire = { ...item.wire, type: 'commandExecution', status: 'inProgress', aggregatedOutput: (text(item.wire.aggregatedOutput) + delta).slice(-MAX_TEXT) };
+        break;
+      default: return true;
+    }
+    remember(child, key, item);
+    emit(id, child, item);
+    return true;
+  }
+  return { handle, registerHistory, reset };
+}

--- a/app/components/ThreadBlock.test.ts
+++ b/app/components/ThreadBlock.test.ts
@@ -93,6 +93,7 @@ function mount(
     root: MessageInfo;
     currentSessionId?: string;
     backendKind?: 'codex' | 'opencode';
+    isLatestRoot?: boolean;
   },
   onShowThreadHistory: (payload: { entries: unknown[] }) => void,
 ) {
@@ -112,6 +113,7 @@ function mount(
             isRevertedPreview: false,
             currentSessionId: props.currentSessionId,
             backendKind: props.backendKind,
+            isLatestRoot: props.isLatestRoot,
             deferredTransitionKey: 'test',
             onShowThreadHistory,
           });
@@ -125,6 +127,15 @@ function mount(
 }
 
 describe('ThreadBlock history wiring', () => {
+  it.each([false, true])('shows revert on Codex cards while limiting fork to latest=%s', async (isLatestRoot) => {
+    const user = makeUserMessage('main', 'u1', 1);
+    useMessages().loadHistory([{ info: user, parts: [] }]);
+    const view = mount({ root: user, currentSessionId: 'main', backendKind: 'codex', isLatestRoot }, vi.fn());
+    await flushRender();
+    expect(view.root.querySelector('.ib-footer .ib-action-danger')).not.toBeNull();
+    expect([...view.root.querySelectorAll('button')].some(button => button.textContent?.trim() === 'FORK')).toBe(isLatestRoot);
+    view.app.unmount();
+  });
   afterEach(() => {
     document.body.innerHTML = '';
     useMessages().reset();

--- a/app/components/ThreadBlock.vue
+++ b/app/components/ThreadBlock.vue
@@ -352,7 +352,6 @@ function showThreadDiff(root: MessageInfo) {
 
 function canRevertThread(root: MessageInfo): boolean {
   if (props.sessionRevert) return false;
-  if (props.backendKind === 'codex' && !props.isLatestRoot) return false;
   return root.role === 'user' && Boolean(root.sessionID);
 }
 
@@ -377,7 +376,7 @@ async function confirmFork() {
 
 async function confirmRevert(root: MessageInfo) {
   if (root.role !== 'user' || !root.sessionID || !root.id) return;
-  const confirmed = showConfirm ? await showConfirm(t('threadBlock.confirmRevert')) : true;
+  const confirmed = showConfirm ? await showConfirm(t(props.backendKind === 'codex' ? 'threadBlock.confirmCodexRevert' : 'threadBlock.confirmRevert')) : true;
   if (!confirmed) return;
   emit('revert-message', { sessionId: root.sessionID, messageId: root.id });
 }

--- a/app/composables/useBackendSessionActions.test.ts
+++ b/app/composables/useBackendSessionActions.test.ts
@@ -103,6 +103,12 @@ function createActions(
 }
 
 describe('useBackendSessionActions mutation skeleton', () => {
+  it('passes the selected Codex message to rollback instead of always reverting one turn', async () => {
+    const rollbackThread = vi.fn().mockResolvedValue({});
+    const { actions } = createActions({ activeBackendKind: 'codex', codexApi: { rollbackThread } });
+    await actions.handleRevertMessage({ sessionId: 'session-1', messageId: 'old-turn:user:client-id' });
+    expect(rollbackThread).toHaveBeenCalledWith('session-1', 'old-turn:user:client-id');
+  });
   it('Given an opencode deleteSession rejection, When deleteSession runs, Then it reverts the pinned override and surfaces the delete error', async () => {
     const { actions, mocks } = createActions({
       openCodeApi: { deleteSession: vi.fn().mockRejectedValue(new Error('boom')) },

--- a/app/composables/useBackendSessionActions.ts
+++ b/app/composables/useBackendSessionActions.ts
@@ -66,7 +66,7 @@ export type CodexApiLike = {
   unhideThread: (sessionId: string) => void;
   setThreadName: (sessionId: string, name: string) => Promise<unknown>;
   forkThread: (sessionId: string) => Promise<{ id?: string }>;
-  rollbackThread: (sessionId: string, numTurns?: number) => Promise<{ id?: string }>;
+  rollbackThread: (sessionId: string, target?: number | string) => Promise<{ id?: string }>;
   startThreadCompaction: (sessionId: string) => Promise<unknown>;
   selectThread: (sessionId: string) => Promise<unknown>;
 };
@@ -107,7 +107,7 @@ export function useBackendSessionActions(params: {
     previousOverride?: number,
   ) => void;
   switchSessionSelection: (projectId: string, sessionId: string) => Promise<void>;
-  reloadSelectedSessionState: (sessionId?: string) => Promise<void>;
+  reloadSelectedSessionState: (sessionId?: string, oldId?: string, forceReset?: boolean) => Promise<void>;
   seedForkedSessionComposerDraft: (
     payload: { sessionId: string; messageId: string },
     session: BackendSessionInfo,
@@ -537,12 +537,12 @@ export function useBackendSessionActions(params: {
     try {
       params.setSendStatusKey('app.status.reverting');
       if (params.activeBackendKind.value === 'codex') {
-        const thread = await params.codexApi.rollbackThread(payload.sessionId, 1);
+        const thread = await params.codexApi.rollbackThread(payload.sessionId, payload.messageId);
         if (thread?.id) {
           params.selectedProjectId.value = params.codexProjectId;
           params.selectedSessionId.value = thread.id;
           await params.codexApi.selectThread(thread.id);
-          await params.reloadSelectedSessionState(thread.id);
+          await params.reloadSelectedSessionState(thread.id, undefined, true);
         }
       } else {
         await params.openCodeApi.revertSession({

--- a/app/composables/useBackendSessionReload.test.ts
+++ b/app/composables/useBackendSessionReload.test.ts
@@ -147,7 +147,7 @@ describe('useBackendSessionReload', () => {
     expect(msg.loadHistory).toHaveBeenCalledWith([{ id: 'history-1' }]);
   });
 
-  it('does NOT call msg.reset on Codex page refresh (no oldId)', async () => {
+  it.each([false, true])('resets Codex same-session history only when explicitly requested: %s', async (forceReset) => {
     const msg = {
       saveSessionState: vi.fn(),
       reset: vi.fn(),
@@ -189,11 +189,11 @@ describe('useBackendSessionReload', () => {
       focusInput: vi.fn(),
     });
 
-    await reload.reloadSelectedSessionState('thread-1', undefined);
+    await reload.reloadSelectedSessionState('thread-1', undefined, forceReset);
 
     expect(msg.saveSessionState).not.toHaveBeenCalled();
     expect(selectThread).not.toHaveBeenCalled();
-    expect(msg.reset).not.toHaveBeenCalled();
+    expect(msg.reset).toHaveBeenCalledTimes(forceReset ? 1 : 0);
     expect(msg.loadHistory).toHaveBeenCalledWith([{ id: 'history-1' }, { id: 'history-2' }]);
   });
 

--- a/app/composables/useBackendSessionReload.ts
+++ b/app/composables/useBackendSessionReload.ts
@@ -88,7 +88,7 @@ export function useBackendSessionReload(params: {
     );
   }
 
-  async function reloadSelectedSessionState(newId?: string, oldId?: string) {
+  async function reloadSelectedSessionState(newId?: string, oldId?: string, forceReset = false) {
     const reloadRequestId = ++params.sessionReloadRequestId.value;
     params.isLoadingHistory.value = false;
     const previousCacheContext = loadedMessageCacheContext;
@@ -128,7 +128,7 @@ export function useBackendSessionReload(params: {
             if (reloadRequestId !== params.sessionReloadRequestId.value) return;
             nextHistory = params.codexHistory.value;
           }
-          if (isSessionSwitch) {
+          if (isSessionSwitch || forceReset) {
             params.msg.reset();
           }
           params.resetFollow();

--- a/app/composables/useCodexApi.test.ts
+++ b/app/composables/useCodexApi.test.ts
@@ -134,6 +134,59 @@ function createAdapterMock() {
 }
 
 describe('useCodexApi', () => {
+  it('does not unsubscribe a newer child subscription when an older resume finishes late', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({adapterFactory:()=>mock.adapter});
+    await api.connect();
+    const parent = api.activeThreadId.value;
+    let finishOld: ((value: {thread: {id: string}}) => void) | undefined;
+    const oldResume = new Promise<{thread:{id:string}}>(resolve => {finishOld=resolve;});
+    let childResumes = 0;
+    mock.adapter.readThread = vi.fn(async ({threadId}) => ({thread:{id:threadId,turns:[]}}));
+    mock.adapter.resumeThread = vi.fn(({threadId}) => threadId === 'child' && childResumes++ === 0
+      ? oldResume : Promise.resolve({thread:{id:threadId,turns:[]}}));
+    const spawn = () => mock.emit({method:'item/completed',params:{threadId:parent,turnId:'parent-turn',item:{id:'spawn',type:'subAgentActivity',kind:'started',agentThreadId:'child',agentPath:'/root/reviewer'}}});
+    spawn();
+    await vi.waitFor(() => expect(childResumes).toBe(1));
+    await api.selectThread('other');
+    await api.selectThread(parent);
+    spawn();
+    await vi.waitFor(() => expect(childResumes).toBe(2));
+    vi.mocked(mock.adapter.unsubscribeThread).mockClear();
+    finishOld?.({thread:{id:'child'}});
+    await oldResume;
+    await Promise.resolve();
+    expect(mock.adapter.unsubscribeThread).not.toHaveBeenCalled();
+    api.disconnect();
+  });
+  it('subscribes linked children and forwards their real work without replacing parent history', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    const parent = api.activeThreadId.value;
+    mock.adapter.readThread = vi.fn().mockResolvedValue({thread:{id:'review-child',model:'review-model',modelProvider:'codex',turns:[]}});
+    mock.adapter.resumeThread = vi.fn().mockResolvedValue({thread:{id:'review-child',model:'review-model',modelProvider:'codex',turns:[]}});
+    mock.emit({method:'item/completed',params:{threadId:parent,turnId:'parent-turn',item:{id:'spawn',type:'subAgentActivity',kind:'started',agentThreadId:'review-child',agentPath:'/root/review_agent_protocol'}}});
+    await vi.waitFor(() => expect(mock.adapter.resumeThread).toHaveBeenCalledWith({threadId:'review-child'}));
+    mock.emit({method:'item/agentMessage/delta',params:{threadId:'review-child',turnId:'review-turn',itemId:'answer',delta:'Reviewing changes'}});
+    expect(api.realtimeSubagentPart.value).toMatchObject({parentThreadId:parent,info:{sessionID:'review-child',agent:'review_agent_protocol',modelID:'review-model'},part:{type:'text',text:'Reviewing changes'}});
+    expect(api.activeThreadId.value).toBe(parent);
+    expect(api.realtimeHistoryQueue.value.every(entry => entry.info.sessionID === parent)).toBe(true);
+    api.disconnect();
+  });
+  it('bridges subAgentActivity notifications and restores reviewer history after hydration', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    const item = { type: 'subAgentActivity', id: 'review-start', kind: 'started', agentThreadId: 'child-review', agentPath: '/root/code_review' };
+    mock.emit({ method: 'item/started', params: { threadId: 'thr_existing', turnId: 'turn-review', item } });
+    expect(api.realtimeToolParts.value[0]?.part).toMatchObject({ tool: 'task', state: { metadata: { sessionId: 'child-review' } } });
+    mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn-review', item } });
+    expect(api.realtimeCompletedPart.value?.part).toMatchObject({ tool: 'task', state: { metadata: { agentPath: '/root/code_review' } } });
+    mock.adapter.readThread = vi.fn().mockResolvedValue({ thread: { id: 'thr_existing', turns: [{ id: 'turn-review', items: [item] }] } });
+    await api.selectThread('thr_existing');
+    expect(api.canonicalHistory.value.flatMap(entry => entry.parts)).toContainEqual(expect.objectContaining({ tool: 'task' }));
+  });
   it('rolls back the selected historical message and all later turns, without counting supplemental users twice', async () => {
     const mock = createAdapterMock();
     const api = useCodexApi({ adapterFactory: () => mock.adapter });

--- a/app/composables/useCodexApi.test.ts
+++ b/app/composables/useCodexApi.test.ts
@@ -134,6 +134,20 @@ function createAdapterMock() {
 }
 
 describe('useCodexApi', () => {
+  it('rolls back the selected historical message and all later turns, without counting supplemental users twice', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    mock.adapter.readThread = vi.fn().mockResolvedValue({ thread: { id: 'thr_existing', turns: ['a', 'b', 'c'].map(id => ({ id, items: [
+      { type: 'userMessage', id: 'first', content: [{ type: 'text', text: id }] },
+      { type: 'userMessage', id: 'supplement', content: [{ type: 'text', text: 'Supplement' }] },
+    ] })) } });
+    await api.rollbackThread('thr_existing', 'b:user:supplement');
+    expect(mock.adapter.rollbackThread).toHaveBeenCalledWith({ threadId: 'thr_existing', numTurns: 2 });
+    vi.mocked(mock.adapter.rollbackThread).mockClear();
+    await expect(api.rollbackThread('thr_existing', 'missing:user:first')).rejects.toThrow();
+    expect(mock.adapter.rollbackThread).not.toHaveBeenCalled();
+  });
   it('preserves the sent model and provider through echoes, completion hydration and a fresh page instance', async () => {
     const mock = createAdapterMock();
     const api = useCodexApi({ adapterFactory: () => mock.adapter });

--- a/app/composables/useCodexApi.test.ts
+++ b/app/composables/useCodexApi.test.ts
@@ -134,6 +134,36 @@ function createAdapterMock() {
 }
 
 describe('useCodexApi', () => {
+  it('preserves the sent model and provider through echoes, completion hydration and a fresh page instance', async () => {
+    const mock = createAdapterMock();
+    const api = useCodexApi({ adapterFactory: () => mock.adapter });
+    await api.connect();
+    api.selectModel('codex/gpt-6-astra');
+    await api.sendPrompt('Keep model metadata', { effort: 'medium' });
+    const clientId = vi.mocked(mock.adapter.sendPrompt).mock.calls[0]?.[0]?.clientUserMessageId;
+    const items = [
+      { type: 'userMessage', id: 'wire-user', clientId, content: [{ type: 'text', text: 'Keep model metadata' }] },
+      { type: 'agentMessage', id: 'answer', text: 'Answer' },
+    ];
+    const turn = { id: 'turn_1', status: 'completed', items };
+    mock.adapter.readThread = vi.fn().mockResolvedValue({ thread: { id: 'thr_existing', modelProvider: 'openai', turns: [turn] } });
+    api.selectModel('other/different-model');
+    for (const item of items) mock.emit({ method: 'item/completed', params: { threadId: 'thr_existing', turnId: 'turn_1', item } });
+    const expectedModel = { providerID: 'codex', modelID: 'gpt-6-astra' };
+    expect(api.realtimeHistoryQueue.value.find(entry => entry.info.role === 'user')?.info).toMatchObject({ model: expectedModel });
+    expect(api.realtimeHistoryQueue.value.find(entry => entry.info.role === 'assistant')?.info).toMatchObject(expectedModel);
+    api.selectModel('');
+    mock.emit({ method: 'turn/completed', params: { threadId: 'thr_existing', turn } });
+    await vi.waitFor(() => expect(api.canonicalHistory.value.find(entry => entry.info.role === 'user')?.info).toMatchObject({ model: expectedModel }));
+    api.disconnect();
+    const fresh = useCodexApi({ adapterFactory: () => mock.adapter });
+    await fresh.connect();
+    await fresh.selectThread('thr_existing');
+    expect(fresh.canonicalHistory.value.find(entry => entry.info.role === 'user')?.info).toMatchObject({ model: expectedModel, variant: 'medium' });
+    expect(fresh.canonicalHistory.value.find(entry => entry.info.role === 'assistant')?.info).toMatchObject(expectedModel);
+    const childHistory = await fresh.readSubagentHistory('thr_existing');
+    expect(childHistory.find(entry => entry.info.role === 'assistant')?.info).toMatchObject(expectedModel);
+  });
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();

--- a/app/composables/useCodexApi.ts
+++ b/app/composables/useCodexApi.ts
@@ -93,6 +93,7 @@ import {
 } from '../backends/codex/auxiliaryHistory';
 import { restoreCodexMessageEfforts, saveCodexTurnEffort } from '../backends/codex/messageEffort';
 import { createCodexMessageModels } from '../backends/codex/messageModels';
+import { codexRollbackCount } from '../backends/codex/rollbackTarget';
 import type { ConfigMergeStrategy } from '../backends/types';
 import { getPersistedCodexBridgeToken, getPersistedCodexBridgeUrl } from '../backends/registry';
 import type {
@@ -2686,9 +2687,15 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     return result.thread;
   }
 
-  async function rollbackThread(threadId: string, numTurns = 1) {
+  async function rollbackThread(threadId: string, target: number | string = 1) {
     if (!adapter) throw new Error('Codex is not connected.');
-    const result = await adapter.rollbackThread({ threadId, numTurns });
+    const request = captureConnection();
+    if (!request) throw new Error('Codex is not connected.');
+    const numTurns = typeof target === 'number' ? target : codexRollbackCount(threadId,
+      (await readThreadForHistory(threadId, request.sourceAdapter)).thread.turns ?? [], target);
+    if (!isCurrentConnection(request)) throw new Error('Codex connection changed.');
+    const result = await request.sourceAdapter.rollbackThread({ threadId, numTurns });
+    if (!isCurrentConnection(request)) return result.thread;
     invalidateRecentTurnIds(threadId, numTurns);
     clearCodexAuxiliaryHistory(threadId);
     realtimeHistoryQueue.value = realtimeHistoryQueue.value.filter(

--- a/app/composables/useCodexApi.ts
+++ b/app/composables/useCodexApi.ts
@@ -93,6 +93,7 @@ import {
   saveCodexAuxiliaryHistory,
 } from '../backends/codex/auxiliaryHistory';
 import { restoreCodexMessageEfforts, saveCodexTurnEffort } from '../backends/codex/messageEffort';
+import { initializeCodexAuxiliaryStorage } from '../backends/codex/auxiliaryStorage';
 import { createCodexMessageModels } from '../backends/codex/messageModels';
 import { codexRollbackCount } from '../backends/codex/rollbackTarget';
 import type { ConfigMergeStrategy } from '../backends/types';
@@ -2079,15 +2080,16 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
 
     if (import.meta.env.DEV) console.time('codex-connect');
 
-    onPhase?.('home');
-    await refreshHomeDir(false, request);
-    if (!isCurrentConnection(request)) return;
-    unsubscribeNotifications = sourceAdapter.onNotification((notification) =>
-      handleNotification(notification, request),
-    );
-    unsubscribeServerRequests = sourceAdapter.onServerRequest(handleServerRequest);
-
     try {
+      await initializeCodexAuxiliaryStorage();
+      if (!isCurrentConnection(request)) return;
+      onPhase?.('home');
+      await refreshHomeDir(false, request);
+      if (!isCurrentConnection(request)) return;
+      unsubscribeNotifications = sourceAdapter.onNotification((notification) =>
+        handleNotification(notification, request),
+      );
+      unsubscribeServerRequests = sourceAdapter.onServerRequest(handleServerRequest);
       onPhase?.('handshake');
       await sourceAdapter.initialize();
       if (!isCurrentConnection(request)) return;

--- a/app/composables/useCodexApi.ts
+++ b/app/composables/useCodexApi.ts
@@ -92,6 +92,7 @@ import {
   saveCodexAuxiliaryHistory,
 } from '../backends/codex/auxiliaryHistory';
 import { restoreCodexMessageEfforts, saveCodexTurnEffort } from '../backends/codex/messageEffort';
+import { createCodexMessageModels } from '../backends/codex/messageModels';
 import type { ConfigMergeStrategy } from '../backends/types';
 import { getPersistedCodexBridgeToken, getPersistedCodexBridgeUrl } from '../backends/registry';
 import type {
@@ -601,6 +602,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   const threadGoalThreadId = ref<string | null>(null);
   const threadGoalLoading = ref(false);
   const selectedModel = ref<string>('');
+  const messageModels = createCodexMessageModels(() => url.value);
   const skills = ref<CodexSkill[]>([]);
   const skillsLoading = ref(false);
   const plugins = ref<CodexPluginWithMarketplace[]>([]);
@@ -841,14 +843,14 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     for (const turn of turns) recordObservedTurnId(activeThreadId.value, turn.id);
     const selectedModelInfo = parseSelectedCodexModel(selectedModel.value);
     const modelName = selectedModelInfo.modelID || selectedModelInfo.providerID;
-    canonicalHistory.value = restoreCodexMessageEfforts(activeThreadId.value, normalizeCodexTurnsToHistory({
+    canonicalHistory.value = messageModels.restore(activeThreadId.value, restoreCodexMessageEfforts(activeThreadId.value, normalizeCodexTurnsToHistory({
       sessionId: activeThreadId.value ?? 'codex-thread',
       turns,
       model: {
         providerID: activeThread?.modelProvider || selectedModelInfo.providerID,
         modelID: selectedModelInfo.modelID || undefined,
       },
-    }));
+    })), [...canonicalHistory.value, ...realtimeHistoryQueue.value]);
     const textEntries = canonicalHistory.value.flatMap((entry) => {
       const role = entry.info.role === 'assistant' ? 'assistant' : 'user';
       return entry.parts
@@ -965,8 +967,8 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       role: 'assistant',
       time: { created: createdAt },
       parentID: parentId,
-      modelID: model.modelID || 'codex',
-      providerID: model.providerID,
+      modelID: parent?.info.role === 'user' ? parent.info.model.modelID : model.modelID || 'codex',
+      providerID: parent?.info.role === 'user' ? parent.info.model.providerID : model.providerID,
       variant: parent?.info.variant,
       mode: 'codex',
       agent: 'codex',
@@ -1183,6 +1185,8 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   function mergeRealtimeHistoryEntry(entry: CodexCanonicalHistoryEntry) {
     if (entry.info.role === 'assistant') {
       entry = { ...entry, info: createCodexAssistantInfo(entry.info.sessionID, entry.info.id, entry.info.time.created, entry.info.parentID) };
+    } else {
+      entry = messageModels.restore(entry.info.sessionID, [entry], [...canonicalHistory.value, ...realtimeHistoryQueue.value])[0] ?? entry;
     }
     const existingIndex = realtimeHistoryQueue.value.findIndex(
       (current) => current.info.id === entry.info.id,
@@ -2557,11 +2561,11 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     const sourceAdapter = adapter;
     if (!sourceAdapter) throw new Error('Codex is not connected.');
     const read = await readThreadForHistory(threadId, sourceAdapter);
-    const entries = restoreCodexMessageEfforts(threadId, normalizeCodexTurnsToHistory({
+    const entries = messageModels.restore(threadId, restoreCodexMessageEfforts(threadId, normalizeCodexTurnsToHistory({
       sessionId: threadId,
       turns: read.thread.turns ?? [],
       model: { providerID: read.thread.modelProvider },
-    }));
+    })));
     const hydrated = await hydrateThreadImages(entries, sourceAdapter);
     if (adapter !== sourceAdapter) throw new Error('Codex connection changed.');
     return hydrated;
@@ -3006,7 +3010,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       variant: options.effort,
       model: {
         providerID: selectedModelInfo.providerID,
-        modelID: selectedModelInfo.modelID || 'unknown',
+        modelID: options.model?.trim() || selectedModelInfo.modelID || 'unknown',
       },
     };
     const userParts = buildRealtimeUserParts(sessionId, userMessageId, prompt, inputItems, now);
@@ -3045,6 +3049,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       const finalizedTurnId = result.turn.id || pendingTurnId;
       recordObservedTurnId(result.threadId, finalizedTurnId);
       const finalizedUserMessageId = codexUserMessageId(finalizedTurnId, clientUserMessageId);
+      messageModels.save(result.threadId, { ...userInfo, id: finalizedUserMessageId, sessionID: result.threadId });
       saveCodexTurnEffort(result.threadId, finalizedTurnId, options.effort, finalizedUserMessageId);
       finalizeRealtimeUser(userMessageId, finalizedUserMessageId, result.threadId, options.effort);
 

--- a/app/composables/useCodexApi.ts
+++ b/app/composables/useCodexApi.ts
@@ -1,4 +1,5 @@
 import { codexReasoningText } from '../backends/codex/reasoning';
+import { createCodexSubagentStreams } from '../backends/codex/subagentStreams';
 import { createCodexThreadActivity } from '../backends/codex/threadActivity';
 import { migrateCodexAuxiliaryHistory } from '../backends/codex/auxiliaryHistoryIdentity';
 import { computed, ref, watch } from 'vue';
@@ -99,6 +100,7 @@ import { getPersistedCodexBridgeToken, getPersistedCodexBridgeUrl } from '../bac
 import type {
   FilePart,
   MessageInfo,
+  AssistantMessageInfo,
   MessagePart,
   ReasoningPart,
   TextPart,
@@ -637,6 +639,52 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   const realtimeHistoryQueue = ref<CodexCanonicalHistoryEntry[]>([]);
   const realtimeMessageAliases = ref<Record<string, string>>({});
   const realtimeCompletedPart = ref<CodexRealtimePartRecord<ToolPart> | null>(null);
+  const realtimeSubagentPart = ref<{ parentThreadId: string; info: AssistantMessageInfo; part: MessagePart } | null>(null);
+  const subscribedSubagents = new Set<string>();
+  let subagentStreamGeneration = 0;
+  const subagentStreams = createCodexSubagentStreams({
+    getSelectedParent: () => activeThreadId.value,
+    publish: (info, part) => { realtimeSubagentPart.value = { parentThreadId: activeThreadId.value, info, part }; },
+    onDiscover: (threadId, live) => { void subscribeSubagent(threadId, live); },
+  });
+
+  async function subscribeSubagent(threadId: string, live: boolean) {
+    const request = captureConnection();
+    const parentId = activeThreadId.value;
+    const generation = subagentStreamGeneration;
+    if (!request || !parentId) return;
+    const current = () => isCurrentConnection(request) && activeThreadId.value === parentId && generation === subagentStreamGeneration;
+    try {
+      const read = await request.sourceAdapter.readThread({ threadId, includeTurns: true });
+      if (!current() || read.thread.id !== threadId) return;
+      subagentStreams.registerHistory(read.thread);
+      if (!live && extractStatusType(read.thread.status) !== 'active') return;
+      subscribedSubagents.add(threadId);
+      const resumed = await request.sourceAdapter.resumeThread({ threadId });
+      if (!current()) {
+        if (isCurrentConnection(request) && activeThreadId.value !== threadId && !subscribedSubagents.has(threadId)) {
+          await request.sourceAdapter.unsubscribeThread({ threadId });
+        }
+        return;
+      }
+      subagentStreams.registerHistory(resumed.thread, undefined, live);
+    } catch {
+      if (current()) console.warn('[codex] Unable to subscribe to subagent activity', threadId);
+    }
+  }
+
+  function resetSubagentStreams() {
+    subagentStreamGeneration += 1;
+    subagentStreams.reset();
+    realtimeSubagentPart.value = null;
+    for (const threadId of subscribedSubagents) {
+      if (adapter && threadId !== activeThreadId.value) void adapter.unsubscribeThread({ threadId }).catch(() => {
+        console.warn('[codex] Unable to unsubscribe from subagent activity', threadId);
+      });
+    }
+    subscribedSubagents.clear();
+  }
+  watch(activeThreadId, resetSubagentStreams, { flush: 'sync' });
   const realtimeStreamingPart = ref<CodexRealtimePartRecord<TextPart> | null>(null);
   const realtimeReasoningPart = ref<CodexRealtimePartRecord<ReasoningPart> | null>(null);
   const realtimeToolParts = ref<Array<CodexRealtimePartRecord<ToolPart>>>([]);
@@ -839,6 +887,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   }
 
   function setTranscriptFromTurns(turns: CodexTurn[] = []) {
+    subagentStreams.registerHistory({ id: activeThreadId.value, turns });
     assistantTranscriptIds.clear();
     const activeThread = threads.value.find((thread) => thread.id === activeThreadId.value);
     for (const turn of turns) recordObservedTurnId(activeThreadId.value, turn.id);
@@ -1323,6 +1372,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
       if (isInvalidatedTurnId(notificationThreadId, notificationTurnId)) return;
       recordObservedTurnId(notificationThreadId, notificationTurnId);
     }
+    subagentStreams.handle(notification);
     const userItem = isRecord(notificationParams?.item) ? notificationParams.item : null;
     if ((notification.method === 'item/started' || notification.method === 'item/completed')
       && notificationThreadId && notificationTurnId && userItem?.type === 'userMessage') {
@@ -2072,6 +2122,10 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
   }
 
   function teardownConnection(resetStatus: boolean) {
+    subagentStreamGeneration += 1;
+    subagentStreams.reset();
+    subscribedSubagents.clear();
+    realtimeSubagentPart.value = null;
     connectionGeneration += 1;
     threadSelectionGeneration += 1;
     accountRefreshGeneration += 1;
@@ -2565,7 +2619,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     const entries = messageModels.restore(threadId, restoreCodexMessageEfforts(threadId, normalizeCodexTurnsToHistory({
       sessionId: threadId,
       turns: read.thread.turns ?? [],
-      model: { providerID: read.thread.modelProvider },
+      model: { providerID: read.thread.modelProvider, modelID: read.thread.model ?? undefined },
     })));
     const hydrated = await hydrateThreadImages(entries, sourceAdapter);
     if (adapter !== sourceAdapter) throw new Error('Codex connection changed.');
@@ -2696,6 +2750,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     if (!isCurrentConnection(request)) throw new Error('Codex connection changed.');
     const result = await request.sourceAdapter.rollbackThread({ threadId, numTurns });
     if (!isCurrentConnection(request)) return result.thread;
+    if (activeThreadId.value === threadId) resetSubagentStreams();
     invalidateRecentTurnIds(threadId, numTurns);
     clearCodexAuxiliaryHistory(threadId);
     realtimeHistoryQueue.value = realtimeHistoryQueue.value.filter(
@@ -3808,6 +3863,7 @@ export function useCodexApi(initialOptions: CodexApiOptions = {}) {
     realtimeHistoryQueue,
     realtimeMessageAliases,
     realtimeCompletedPart,
+    realtimeSubagentPart,
     realtimeStreamingPart,
     realtimeReasoningPart,
     realtimeToolParts,

--- a/app/composables/useCodexMessageBridge.diffs.test.ts
+++ b/app/composables/useCodexMessageBridge.diffs.test.ts
@@ -1,0 +1,166 @@
+import { effectScope, nextTick, ref } from 'vue';
+import { afterEach, describe, expect, it } from 'vitest';
+import { normalizeCodexTurnsToHistory } from '../backends/codex/normalize';
+import { useCodexMessageBridge } from './useCodexMessageBridge';
+import { useMessages } from './useMessages';
+
+type BridgeParams = Parameters<typeof useCodexMessageBridge>[0];
+const scopes: ReturnType<typeof effectScope>[] = [];
+afterEach(() => { scopes.splice(0).forEach(scope => scope.stop()); useMessages().reset(); });
+function fixture() {
+  const msg = useMessages();
+  msg.reset();
+  const params: BridgeParams = {
+    activeBackendKind: ref('codex'), selectedSessionId: ref('thread-1'), codexPendingSessionLock: ref(''),
+    history: ref([]), msg, syncRealtimeToolWindows: () => {}, updateReasoningExpiry: () => {},
+    codexApi: {
+      realtimeHistoryQueue: ref([]), realtimeMessageAliases: ref({}), realtimeStreamingPart: ref(null),
+      realtimeReasoningPart: ref(null), realtimeToolParts: ref([]), tokenUsage: ref(null), diffState: ref(null),
+    },
+  };
+  const scope = effectScope();
+  scopes.push(scope);
+  scope.run(() => useCodexMessageBridge(params));
+  return { ...params, msg };
+}
+function history(turns: string[], patches = false) {
+  return normalizeCodexTurnsToHistory({ sessionId: 'thread-1', turns: turns.map(id => ({ id, items: [
+    { id: `wire-${id}`, clientId: `client-${id}`, type: 'userMessage', content: [{ type: 'text', text: id }] },
+    ...(patches ? [{ id: `edit-${id}`, type: 'fileChange', status: 'completed', changes: [
+      { path: `${id}.ts`, diff: `@@ -1 +1 @@\n-old\n+${id}` },
+      { path: `${id}.css`, diff: `@@ -1 +1 @@\n-old\n+${id}` },
+    ] }] : []),
+  ] })) });
+}
+const patch = (turnId: string) => ({ threadId: 'thread-1', turnId, diff: `diff --git a/${turnId}.ts b/${turnId}.ts\n@@ -1 +1 @@\n-old\n+${turnId}` });
+const userId = (turn: string) => `${turn}:user:client-${turn}`;
+
+describe('Codex card diff restoration', () => {
+  it('keeps edits separate between two user cards inside one Codex turn', async () => {
+    // Given
+    const p = fixture();
+    // When
+    p.history.value = normalizeCodexTurnsToHistory({ sessionId: 'thread-1', turns: [{ id: 'shared', items: [
+      { id: 'a', type: 'userMessage', content: [{ type: 'text', text: 'first' }] },
+      { id: 'edit-a', type: 'fileChange', status: 'completed', changes: [{ path: 'a.ts', diff: '@@ -1 +1 @@\n-a\n+b' }] },
+      { id: 'b', type: 'userMessage', content: [{ type: 'text', text: 'second' }] },
+      { id: 'edit-b', type: 'fileChange', status: 'completed', changes: [{ path: 'b.ts', diff: '@@ -1 +1 @@\n-c\n+d' }] },
+    ] }] });
+    p.codexApi.diffState.value = patch('shared');
+    await nextTick();
+    // Then
+    expect(p.msg.getDiffs('shared:user:a')?.map(diff => diff.file)).toEqual(['a.ts']);
+    expect(p.msg.getDiffs('shared:user:b')?.map(diff => diff.file)).toEqual(['b.ts']);
+  });
+
+  it('does not attach an ambiguous whole-turn notification to one of several user cards', async () => {
+    // Given
+    const p = fixture();
+    p.history.value = normalizeCodexTurnsToHistory({ sessionId: 'thread-1', turns: [{ id: 'shared', items: [
+      { id: 'a', type: 'userMessage', content: [{ type: 'text', text: 'first' }] },
+      { id: 'b', type: 'userMessage', content: [{ type: 'text', text: 'second' }] },
+    ] }] });
+    await nextTick();
+    // When
+    p.codexApi.diffState.value = patch('shared');
+    await nextTick();
+    // Then
+    expect(p.msg.getDiffs('shared:user:a') ?? []).toEqual([]);
+    expect(p.msg.getDiffs('shared:user:b') ?? []).toEqual([]);
+  });
+
+  it('does not republish removed realtime cards when rollback reloads history', async () => {
+    // Given
+    const p = fixture();
+    p.history.value = history(['first', 'second']);
+    p.codexApi.realtimeHistoryQueue.value = history(['first', 'second']);
+    p.codexApi.diffState.value = patch('second');
+    await nextTick();
+    // When
+    p.msg.reset();
+    p.history.value = history(['first']);
+    await nextTick();
+    // Then
+    expect(p.msg.roots.value.map(root => root.id)).toEqual([userId('first')]);
+  });
+
+  it('leaves OpenCode messages unchanged when Codex history and diffs arrive', async () => {
+    // Given
+    const p = fixture();
+    p.activeBackendKind.value = 'opencode';
+    p.msg.loadHistory(history(['opencode']));
+    // When
+    p.history.value = history(['first'], true);
+    p.codexApi.diffState.value = patch('first');
+    await nextTick();
+    // Then
+    expect(p.msg.roots.value.map(root => root.id)).toEqual([userId('opencode')]);
+  });
+
+  it('attaches a turn notification to its realtime client user before history reload', async () => {
+    // Given
+    const p = fixture();
+    p.codexApi.realtimeHistoryQueue.value = history(['first', 'second']);
+    await nextTick();
+    // When
+    p.codexApi.diffState.value = patch('first');
+    await nextTick();
+    // Then
+    expect(p.msg.getDiffs(userId('first'))?.map(diff => diff.file)).toEqual(['first.ts']);
+    expect(p.msg.getDiffs(userId('second')) ?? []).toEqual([]);
+  });
+
+  it('restores each historical multiedit on its owning user without a live notification', async () => {
+    // Given
+    const p = fixture();
+    // When
+    p.history.value = history(['first', 'second'], true);
+    await nextTick();
+    // Then
+    expect(p.msg.getDiffs(userId('first'))?.map(diff => diff.file)).toEqual(['first.ts', 'first.css']);
+    expect(p.msg.getDiffs(userId('second'))?.map(diff => diff.file)).toEqual(['second.ts', 'second.css']);
+  });
+
+  it('preserves earlier notifications when the latest turn and loaded history change', async () => {
+    // Given
+    const p = fixture();
+    p.history.value = history(['first', 'second']);
+    p.codexApi.diffState.value = patch('first');
+    await nextTick();
+    p.codexApi.diffState.value = patch('second');
+    await nextTick();
+    // When
+    p.history.value = history(['first', 'second']);
+    await nextTick();
+    // Then
+    expect(p.msg.getDiffs(userId('first'))?.map(diff => diff.file)).toEqual(['first.ts']);
+    expect(p.msg.getDiffs(userId('second'))?.map(diff => diff.file)).toEqual(['second.ts']);
+  });
+
+  it('ignores a notification from a different session even if the turn ID matches', async () => {
+    // Given
+    const p = fixture();
+    p.history.value = history(['first']);
+    await nextTick();
+    // When
+    p.codexApi.diffState.value = { ...patch('first'), threadId: 'other' };
+    await nextTick();
+    // Then
+    expect(p.msg.getDiffs(userId('first')) ?? []).toEqual([]);
+  });
+
+  it('forgets removed turn notifications after rollback replaces history', async () => {
+    // Given
+    const p = fixture();
+    p.history.value = history(['first', 'second']);
+    p.codexApi.diffState.value = patch('second');
+    await nextTick();
+    p.history.value = history(['first']);
+    await nextTick();
+    // When
+    p.history.value = history(['first', 'second']);
+    await nextTick();
+    // Then
+    expect(p.msg.getDiffs(userId('second')) ?? []).toEqual([]);
+  });
+});

--- a/app/composables/useCodexMessageBridge.diffs.test.ts
+++ b/app/composables/useCodexMessageBridge.diffs.test.ts
@@ -20,8 +20,8 @@ function fixture() {
   };
   const scope = effectScope();
   scopes.push(scope);
-  scope.run(() => useCodexMessageBridge(params));
-  return { ...params, msg };
+  const bridge = scope.run(() => useCodexMessageBridge(params));
+  return { ...params, msg, bridge };
 }
 function history(turns: string[], patches = false) {
   return normalizeCodexTurnsToHistory({ sessionId: 'thread-1', turns: turns.map(id => ({ id, items: [
@@ -36,6 +36,16 @@ const patch = (turnId: string) => ({ threadId: 'thread-1', turnId, diff: `diff -
 const userId = (turn: string) => `${turn}:user:client-${turn}`;
 
 describe('Codex card diff restoration', () => {
+  it('restores diffs after explicit raw history reload even when publication signatures are unchanged', async () => {
+    const p = fixture();
+    p.history.value = history(['first'], true);
+    await nextTick();
+    p.msg.reset();
+    p.msg.loadHistory(p.history.value);
+    p.bridge?.reapplyCodexSharedBackfill();
+    await nextTick();
+    expect(p.msg.getDiffs(userId('first'))?.map(diff => diff.file)).toEqual(['first.ts', 'first.css']);
+  });
   it('keeps edits separate between two user cards inside one Codex turn', async () => {
     // Given
     const p = fixture();

--- a/app/composables/useCodexMessageBridge.test.ts
+++ b/app/composables/useCodexMessageBridge.test.ts
@@ -20,6 +20,7 @@ function bridgeFixture() {
     codexApi: {
       realtimeHistoryQueue: ref<CodexCanonicalHistoryEntry[]>([]),
       realtimeMessageAliases: ref<Record<string, string>>({}),
+      realtimeSubagentPart: ref<{ parentThreadId: string; info: AssistantMessageInfo; part: MessagePart } | null>(null),
       realtimeCompletedPart: ref<{ info: AssistantMessageInfo | UserMessageInfo; part: MessagePart } | null>(null),
       realtimeStreamingPart: ref<{ info: AssistantMessageInfo | UserMessageInfo; part: MessagePart } | null>(null),
       realtimeReasoningPart: ref<{ info: AssistantMessageInfo | UserMessageInfo; part: ReasoningPart } | null>(null),
@@ -237,6 +238,28 @@ describe('useCodexMessageBridge', () => {
 
 
 describe('Codex automatic streaming windows', () => {
+  it('routes child text, reasoning and shell to windows without changing parent messages', () => {
+    const p = bridgeFixture();
+    const entries = normalizeCodexTurnsToHistory({sessionId: 'child', turns: [{id:'child-turn',items:[
+      {id:'text',type:'agentMessage',text:'Reviewing'},
+      {id:'reason',type:'reasoning',summary:['Checking correctness']},
+      {id:'shell',type:'commandExecution',command:'git diff',status:'completed',aggregatedOutput:'diff output'},
+    ]}]});
+    for (const entry of entries) {
+      if (entry.info.role !== 'assistant') continue;
+      for (const part of entry.parts) p.codexApi.realtimeSubagentPart.value = {parentThreadId:'thread-1',info:entry.info,part};
+    }
+    expect(p.onLiveSubagent).toHaveBeenCalledTimes(1);
+    expect(p.onLiveReasoning).toHaveBeenCalledTimes(1);
+    expect(p.syncRealtimeToolWindows).toHaveBeenCalledTimes(1);
+    expect(p.msg.updateMessage).not.toHaveBeenCalled();
+    expect(p.msg.updatePart).not.toHaveBeenCalled();
+    const last = p.codexApi.realtimeSubagentPart.value;
+    if (!last) throw new Error('Missing child fixture');
+    p.codexApi.realtimeSubagentPart.value = {...last};
+    p.codexApi.realtimeSubagentPart.value = {...last,parentThreadId:'unrelated'};
+    expect(p.syncRealtimeToolWindows).toHaveBeenCalledTimes(1);
+  });
   it('opens reasoning only for live updates, deduplicates queue/stream and retains close delay', async () => {
     const p = bridgeFixture();
     const entries = normalizeCodexTurnsToHistory({sessionId: 'thread-1', turns: [{id: 'turn-r', items: [{id: 'reason', type: 'reasoning', summary: ['Thinking']}]}]});

--- a/app/composables/useCodexMessageBridge.ts
+++ b/app/composables/useCodexMessageBridge.ts
@@ -2,7 +2,7 @@ import { computed, ref, watch, type Ref } from 'vue';
 import type { BackendKind } from '../backends/types';
 import type { CodexCanonicalHistoryEntry } from '../backends/codex/normalize';
 import { codexSubagentWindowEntries } from '../utils/codexSubagentWindowEntries';
-import type { MessageDiffEntry } from '../types/message';
+import { useCodexMessageDiffs } from './useCodexMessageDiffs';
 import type { AssistantMessageInfo, MessagePart, ReasoningPart, TextPart, ToolPart, UserMessageInfo } from '../types/sse';
 
 type SharedMessageStore = {
@@ -23,18 +23,6 @@ type CodexMessageBridgeApi = {
   diffState: Ref<{ threadId: string; turnId: string; diff: string } | null>;
 };
 
-function parseCodexDiffEntries(diffText: string): MessageDiffEntry[] {
-  const trimmed = diffText.trim();
-  if (!trimmed) return [];
-  const chunks = trimmed.split(/(?=^diff --git )/m).map((chunk) => chunk.trim()).filter(Boolean);
-  if (chunks.length === 0) return [{ file: 'changes.diff', diff: trimmed }];
-  return chunks.map((chunk, index) => {
-    const match = chunk.match(/^diff --git a\/(.+?) b\/(.+)$/m);
-    const file = match?.[2] || match?.[1] || `changes-${index + 1}.diff`;
-    return { file, diff: chunk };
-  });
-}
-
 function buildRealtimeQueueSignature(queue: CodexCanonicalHistoryEntry[]) {
   return JSON.stringify(queue);
 }
@@ -51,6 +39,10 @@ export function useCodexMessageBridge(params: {
   onLiveReasoning?: (info: AssistantMessageInfo | UserMessageInfo, part: ReasoningPart) => void;
   onLiveSubagent?: (info: AssistantMessageInfo, part: TextPart) => void;
 }) {
+  const messageDiffs = useCodexMessageDiffs({
+    history: params.history, queue: params.codexApi.realtimeHistoryQueue,
+    diffState: params.codexApi.diffState, selectedSessionId: params.selectedSessionId,
+  });
   const lastRealtimeQueueSignature = ref('');
   const publishedMessages = new Map<string, string>();
   const publishedParts = new Map<string, string>();
@@ -71,7 +63,8 @@ export function useCodexMessageBridge(params: {
     }
   }
 
-  function updateMessage(info: AssistantMessageInfo | UserMessageInfo) {
+  function updateMessage(rawInfo: AssistantMessageInfo | UserMessageInfo) {
+    const info = messageDiffs.enrich(rawInfo);
     const signature = JSON.stringify(info);
     if (publishedMessages.get(info.id) === signature) return;
     publishedMessages.set(info.id, signature);
@@ -138,38 +131,24 @@ export function useCodexMessageBridge(params: {
     });
   }
 
-  function applyCodexDiffStateToSharedMessages(state: { threadId: string; turnId: string; diff: string } | null) {
-    if (!state?.turnId || !state.diff.trim()) return;
-    const userInfo = findCodexHistoryMessage((info): info is UserMessageInfo => info.role === 'user' && info.id.startsWith(`${state.turnId}:user:`));
-    if (!userInfo) return;
-    params.msg.updateMessage({
-      ...userInfo,
-      summary: {
-        ...userInfo.summary,
-        diffs: parseCodexDiffEntries(state.diff).map((entry) => ({
-          file: entry.file,
-          patch: entry.diff,
-          additions: 0,
-          deletions: 0,
-        })),
-      },
-    });
-  }
-
   function reapplyCodexSharedBackfill() {
     if (params.activeBackendKind.value !== 'codex') return;
     if (!params.selectedSessionId.value) return;
     applyCodexTokenUsageToSharedMessages(params.codexApi.tokenUsage.value);
-    applyCodexDiffStateToSharedMessages(params.codexApi.diffState.value);
+    for (const entry of [...params.history.value, ...params.codexApi.realtimeHistoryQueue.value]) {
+      if (entry.info.role === 'user' && publishedMessages.has(entry.info.id) && matchesActiveCodexRealtimeSession(entry.info.sessionID)) updateMessage(entry.info);
+    }
   }
 
-  watch(params.history, (history) => {
+  watch(params.history, (history, previous) => {
     if (params.activeBackendKind.value !== 'codex') return;
     if (!params.selectedSessionId.value) return;
-    params.msg.loadHistory(history);
+    messageDiffs.pruneRemovedTurns(history, previous);
+    const enriched = history.map(entry => ({ ...entry, info: messageDiffs.enrich(entry.info) }));
+    params.msg.loadHistory(enriched);
     publishedMessages.clear();
     publishedParts.clear();
-    for (const entry of history) {
+    for (const entry of enriched) {
       publishedMessages.set(entry.info.id, JSON.stringify(entry.info));
       for (const part of entry.parts) publishedParts.set(part.id, JSON.stringify(part));
     }
@@ -207,6 +186,7 @@ export function useCodexMessageBridge(params: {
         updatePart(part);
       }
     }
+    reapplyCodexSharedBackfill();
     params.syncRealtimeToolWindows(realtimeEntries);
   });
 
@@ -257,10 +237,10 @@ export function useCodexMessageBridge(params: {
     applyCodexTokenUsageToSharedMessages(usage);
   }, { deep: true });
 
-  watch(params.codexApi.diffState, (state) => {
+  watch(params.codexApi.diffState, () => {
     if (params.activeBackendKind.value !== 'codex') return;
     if (!params.selectedSessionId.value) return;
-    applyCodexDiffStateToSharedMessages(state);
+    reapplyCodexSharedBackfill();
   }, { deep: true });
 
   return {

--- a/app/composables/useCodexMessageBridge.ts
+++ b/app/composables/useCodexMessageBridge.ts
@@ -63,10 +63,10 @@ export function useCodexMessageBridge(params: {
     }
   }
 
-  function updateMessage(rawInfo: AssistantMessageInfo | UserMessageInfo) {
+  function updateMessage(rawInfo: AssistantMessageInfo | UserMessageInfo, force = false) {
     const info = messageDiffs.enrich(rawInfo);
     const signature = JSON.stringify(info);
-    if (publishedMessages.get(info.id) === signature) return;
+    if (!force && publishedMessages.get(info.id) === signature) return;
     publishedMessages.set(info.id, signature);
     params.msg.updateMessage(info);
   }
@@ -131,12 +131,12 @@ export function useCodexMessageBridge(params: {
     });
   }
 
-  function reapplyCodexSharedBackfill() {
+  function reapplyCodexSharedBackfill(force = false) {
     if (params.activeBackendKind.value !== 'codex') return;
     if (!params.selectedSessionId.value) return;
     applyCodexTokenUsageToSharedMessages(params.codexApi.tokenUsage.value);
     for (const entry of [...params.history.value, ...params.codexApi.realtimeHistoryQueue.value]) {
-      if (entry.info.role === 'user' && publishedMessages.has(entry.info.id) && matchesActiveCodexRealtimeSession(entry.info.sessionID)) updateMessage(entry.info);
+      if (entry.info.role === 'user' && publishedMessages.has(entry.info.id) && matchesActiveCodexRealtimeSession(entry.info.sessionID)) updateMessage(entry.info, force);
     }
   }
 
@@ -245,7 +245,7 @@ export function useCodexMessageBridge(params: {
 
   return {
     matchesActiveCodexRealtimeSession,
-    reapplyCodexSharedBackfill,
+    reapplyCodexSharedBackfill: () => reapplyCodexSharedBackfill(true),
     resetRealtimeQueueSignature() {
       resetPublishedState();
     },

--- a/app/composables/useCodexMessageBridge.ts
+++ b/app/composables/useCodexMessageBridge.ts
@@ -13,6 +13,7 @@ type SharedMessageStore = {
 };
 
 type CodexMessageBridgeApi = {
+  realtimeSubagentPart?: Ref<{ parentThreadId: string; info: AssistantMessageInfo; part: MessagePart } | null>;
   realtimeHistoryQueue: Ref<CodexCanonicalHistoryEntry[]>;
   realtimeMessageAliases: Ref<Record<string, string>>;
   realtimeCompletedPart?: Ref<{ info: AssistantMessageInfo | UserMessageInfo; part: MessagePart } | null>;
@@ -57,6 +58,7 @@ export function useCodexMessageBridge(params: {
     if (part.type === 'reasoning') {
       if (part.text.trim()) params.onLiveReasoning?.(info, part);
     } else if (info.role === 'assistant') {
+      if (params.codexApi.realtimeSubagentPart && 'metadata' in part.state && part.state.metadata?.agentPath) return;
       for (const child of codexSubagentWindowEntries(info, part)) {
         params.onLiveSubagent?.(child.info, child.part);
       }
@@ -191,6 +193,22 @@ export function useCodexMessageBridge(params: {
   });
 
   watch([params.selectedSessionId, params.activeBackendKind], resetPublishedState, { flush: 'sync' });
+
+  if (params.codexApi.realtimeSubagentPart) {
+    watch(params.codexApi.realtimeSubagentPart, (entry) => {
+      if (!entry || params.activeBackendKind.value !== 'codex'
+        || entry.parentThreadId !== params.selectedSessionId.value
+        || entry.info.sessionID === entry.parentThreadId) return;
+      const { info, part } = entry;
+      const key = `${info.sessionID}:${part.id}`;
+      const signature = JSON.stringify(entry);
+      if (liveWindowParts.get(key) === signature) return;
+      liveWindowParts.set(key, signature);
+      if (part.type === 'reasoning') params.onLiveReasoning?.(info, part);
+      else if (part.type === 'text') params.onLiveSubagent?.(info, part);
+      else if (part.type === 'tool') params.syncRealtimeToolWindows([{ info, parts: [part] }]);
+    }, { flush: 'sync' });
+  }
 
   watch(params.codexApi.realtimeStreamingPart, (streaming) => {
     if (params.activeBackendKind.value !== 'codex') return;

--- a/app/composables/useCodexMessageDiffs.ts
+++ b/app/composables/useCodexMessageDiffs.ts
@@ -1,0 +1,92 @@
+import { computed, shallowRef, watch, type Ref } from 'vue';
+import type { CodexCanonicalHistoryEntry } from '../backends/codex/normalize';
+import type { FileDiff, MessageInfo, ToolPart } from '../types/sse';
+
+type TurnDiff = { threadId: string; turnId: string; diff: string };
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+function filePatch(file: string, patch: string): FileDiff {
+  return { file, patch, additions: 0, deletions: 0 };
+}
+function parseTurnDiff(text: string): FileDiff[] {
+  return text.trim().split(/(?=^diff --git )/m).filter(chunk => chunk.trim()).map((chunk, index) => {
+    const match = chunk.match(/^diff --git a\/(.+?) b\/(.+)$/m);
+    return filePatch(match?.[2] || match?.[1] || `changes-${index + 1}.diff`, chunk.trim());
+  });
+}
+function toolDiffs(part: ToolPart): FileDiff[] {
+  if (!['edit', 'multiedit'].includes(part.tool) || part.state.status !== 'completed') return [];
+  const { metadata, input } = part.state;
+  const results: unknown[] = Array.isArray(metadata.results)
+    ? metadata.results : [{ path: input.filePath, filediff: metadata.filediff }];
+  return results.flatMap(result => {
+    if (!record(result) || !record(result.filediff)) return [];
+    const patch = result.filediff.patch;
+    if (typeof patch !== 'string' || !/^(?:@@|diff --git |--- )/m.test(patch)) return [];
+    return [filePatch(typeof result.path === 'string' ? result.path : 'changes.diff', patch)];
+  });
+}
+function turnKey(info: MessageInfo): string | null {
+  const separator = info.id.indexOf(':user:');
+  return info.role === 'user' && separator >= 0 ? info.id.slice(0, separator) : null;
+}
+
+export function useCodexMessageDiffs(params: {
+  readonly history: Ref<CodexCanonicalHistoryEntry[]>;
+  readonly queue: Ref<CodexCanonicalHistoryEntry[]>;
+  readonly diffState: Ref<TurnDiff | null>;
+  readonly selectedSessionId: Ref<string>;
+}) {
+  const notifications = shallowRef(new Map<string, TurnDiff>());
+  watch(params.selectedSessionId, () => { notifications.value = new Map(); }, { flush: 'sync' });
+  watch(params.diffState, state => {
+    if (!state || state.threadId !== params.selectedSessionId.value) return;
+    const next = new Map(notifications.value);
+    if (state.diff.trim()) next.set(state.turnId, state);
+    else next.delete(state.turnId);
+    notifications.value = next;
+  }, { deep: true, flush: 'sync', immediate: true });
+
+  function pruneRemovedTurns(history: CodexCanonicalHistoryEntry[], previous: CodexCanonicalHistoryEntry[]) {
+    const retained = new Set(history.map(entry => turnKey(entry.info)));
+    const next = new Map(notifications.value);
+    for (const entry of previous) {
+      const key = turnKey(entry.info);
+      if (key && !retained.has(key)) next.delete(key);
+    }
+    notifications.value = next;
+  }
+
+  const diffsByUser = computed(() => {
+    const entries = new Map([...params.history.value, ...params.queue.value]
+      .filter(entry => entry.info.sessionID === params.selectedSessionId.value)
+      .map(entry => [entry.info.id, entry]));
+    const result = new Map<string, FileDiff[]>();
+    const usersByTurn = new Map<string, string[]>();
+    for (const { info } of entries.values()) {
+      const turn = turnKey(info);
+      if (turn) usersByTurn.set(turn, [...(usersByTurn.get(turn) ?? []), info.id]);
+    }
+    for (const { info, parts } of entries.values()) {
+      if (info.role !== 'assistant' || !entries.has(info.parentID)) continue;
+      const diffs = parts.flatMap(part => part.type === 'tool' ? toolDiffs(part) : []);
+      if (diffs.length) result.set(info.parentID, [...(result.get(info.parentID) ?? []), ...diffs]);
+    }
+    for (const [turn, state] of notifications.value) {
+      const users = usersByTurn.get(turn) ?? [];
+      const last = users.at(-1);
+      if (last && users.length === 1) {
+        result.set(last, parseTurnDiff(state.diff));
+      }
+    }
+    return result;
+  });
+
+  function enrich(info: MessageInfo): MessageInfo {
+    const diffs = diffsByUser.value.get(info.id);
+    return info.role === 'user' && info.sessionID === params.selectedSessionId.value && diffs?.length
+      ? { ...info, summary: { ...info.summary, diffs } } : info;
+  }
+  return { enrich, pruneRemovedTurns };
+}

--- a/app/composables/useSubagentWindows.ts
+++ b/app/composables/useSubagentWindows.ts
@@ -73,7 +73,8 @@ export function useSubagentWindows(options: UseSubagentWindowsOptions) {
       const displayName = resolveModelName?.(messageInfo.providerID, messageInfo.modelID);
       modelLabel = displayName || messageInfo.modelID;
       if (messageInfo.agent) {
-        agentLabel = messageInfo.agent.charAt(0).toUpperCase() + messageInfo.agent.slice(1);
+        agentLabel = messageInfo.mode === 'codex' ? messageInfo.agent
+          : messageInfo.agent.charAt(0).toUpperCase() + messageInfo.agent.slice(1);
       }
     }
     const agentPart = agentLabel ? `Agent ${agentLabel} ` : '';

--- a/app/i18n/types.ts
+++ b/app/i18n/types.ts
@@ -1256,6 +1256,7 @@ export interface LocaleMessages {
   threadBlock: {
     confirmFork: string;
     confirmRevert: string;
+    confirmCodexRevert: string;
     confirmUndoRevert: string;
     historyTitle: string;
     historyLabel: string;

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -1333,6 +1333,7 @@ const messages: LocaleMessages = {
   threadBlock: {
     confirmFork: 'Fork from this message?',
     confirmRevert: 'Revert to this message?',
+    confirmCodexRevert: 'Revert this message’s turn and all later turns? Supplemental messages in the same turn will also be removed.',
     confirmUndoRevert: 'Undo revert?',
     historyTitle: '{count} entries - click to view history',
     historyLabel: 'History',

--- a/app/locales/eo.ts
+++ b/app/locales/eo.ts
@@ -1332,6 +1332,7 @@ const messages: LocaleMessages = {
   threadBlock: {
     confirmFork: 'Forke el ĉi tiu mesaĝo?',
     confirmRevert: 'Restarigi al ĉi tiu mesaĝo?',
+    confirmCodexRevert: 'Ĉu malfari la vicon de ĉi tiu mesaĝo kaj ĉiujn postajn vicojn? Ankaŭ suplementaj mesaĝoj en la sama vico estos forigitaj.',
     confirmUndoRevert: 'Malfari restarigon?',
     historyTitle: '{count} eroj - alklaku por vidi historion',
     historyLabel: 'Historio',

--- a/app/locales/ja.ts
+++ b/app/locales/ja.ts
@@ -1335,6 +1335,7 @@ const messages: LocaleMessages = {
   threadBlock: {
     confirmFork: 'このメッセージからフォークしますか？',
     confirmRevert: 'このメッセージまで復元しますか？',
+    confirmCodexRevert: 'このメッセージを含むターンと、それ以降のすべてのターンを取り消しますか？同じターンの追加メッセージも取り消されます。',
     confirmUndoRevert: '復元を取り消しますか？',
     historyTitle: '{count}件のエントリー - クリックして履歴を表示',
     historyLabel: '履歴',

--- a/app/locales/zh-CN.ts
+++ b/app/locales/zh-CN.ts
@@ -1312,6 +1312,7 @@ const messages: LocaleMessages = {
   threadBlock: {
     confirmFork: '从此消息创建分支?',
     confirmRevert: '撤销到此消息?',
+    confirmCodexRevert: '撤销此消息所在回合及之后的所有回合？同一回合的补充消息也会一起撤销。',
     confirmUndoRevert: '撤消撤销操作?',
     historyTitle: '{count} 条历史记录 - 点击查看历史',
     historyLabel: '历史记录',

--- a/app/locales/zh-TW.ts
+++ b/app/locales/zh-TW.ts
@@ -1311,6 +1311,7 @@ const messages: LocaleMessages = {
   threadBlock: {
     confirmFork: '從此訊息建立分支?',
     confirmRevert: '復原到此訊息?',
+    confirmCodexRevert: '撤銷此訊息所在回合及之後的所有回合？同一回合的補充訊息也會一併撤銷。',
     confirmUndoRevert: '撤銷復原操作?',
     historyTitle: '{count} 條歷史紀錄 - 點選查看歷史',
     historyLabel: '歷史紀錄',

--- a/app/utils/codexAgentName.ts
+++ b/app/utils/codexAgentName.ts
@@ -1,0 +1,3 @@
+export function codexAgentName(path: string): string {
+  return path.split('/').filter(Boolean).at(-1) || path;
+}

--- a/app/utils/codexSubagentWindowEntries.ts
+++ b/app/utils/codexSubagentWindowEntries.ts
@@ -1,4 +1,5 @@
 import type { AssistantMessageInfo, TextPart, ToolPart } from '../types/sse';
+import { codexAgentName } from './codexAgentName';
 
 function record(value: unknown): Record<string, unknown> | undefined {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -14,6 +15,7 @@ export function codexSubagentWindowEntries(info: AssistantMessageInfo, part: Too
   const states = record(metadata.agentsStates);
   const prompt = typeof part.state.input.prompt === 'string' ? part.state.input.prompt : '';
   const model = typeof part.state.input.model === 'string' ? part.state.input.model : '';
+  const agent = typeof metadata.agentPath === 'string' ? codexAgentName(metadata.agentPath) : '';
   const entries: Array<{ info: AssistantMessageInfo; part: TextPart }> = [];
   for (const id of new Set(ids)) {
     if (typeof id !== 'string' || !id || id === info.sessionID) continue;
@@ -25,7 +27,7 @@ export function codexSubagentWindowEntries(info: AssistantMessageInfo, part: Too
     const completed = ['completed', 'interrupted', 'errored', 'shutdown', 'notFound'].includes(status);
     const messageId = `${part.messageID}:subagent:${id}`;
     entries.push({
-      info: { ...info, id: messageId, sessionID: id, modelID: model, agent: '', time: { created: info.time.created } },
+      info: { ...info, id: messageId, sessionID: id, modelID: model, agent, time: { created: info.time.created } },
       part: {
         id: `${part.id}:subagent:${id}`,
         messageID: messageId,

--- a/app/utils/storageKeys.ts
+++ b/app/utils/storageKeys.ts
@@ -197,6 +197,7 @@ export const StorageKeys = {
     codexPanelConnected: 'state.codexPanelConnected.v1',
     codexAuxiliaryHistory: 'state.codexAuxiliaryHistory.v1',
     codexTurnEfforts: 'state.codexTurnEfforts.v1',
+    codexMessageModels: 'state.codexMessageModels.v1',
     codexThreadActivity: 'state.codexThreadActivity.v1',
     forgePtyId: 'state.forgePtyId.v1',
     acpArchivedSessions: 'state.acpArchivedSessions.v1',

--- a/app/utils/threadSubagents.ts
+++ b/app/utils/threadSubagents.ts
@@ -1,4 +1,5 @@
 import type { MessagePart } from '../types/sse';
+import { codexAgentName } from './codexAgentName';
 import type { SessionState } from '../types/worker-state';
 import {
   isMagicContextWorkerName,
@@ -40,7 +41,9 @@ export function resolveThreadSubagentSessions(
       if (!childId || childId === sessionId) continue;
       const meta = metaById?.[childId];
       if (meta && meta.parentID !== sessionId && (state.metadata?.source !== 'codex' || meta.parentID)) continue;
-      const fallbackLabel = meta?.label || childId;
+      const agentPath = state.metadata?.source === 'codex' && typeof state.metadata.agentPath === 'string'
+        ? codexAgentName(state.metadata.agentPath) : '';
+      const fallbackLabel = meta?.label || agentPath || childId;
       if (isMagicContextWorkerName(fallbackLabel)) continue;
       if (!seen.has(childId)) seen.set(childId, resolveTaskWorkerLabel(part, fallbackLabel));
     }

--- a/scripts/qa/codex-auxiliary-storage.mjs
+++ b/scripts/qa/codex-auxiliary-storage.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { chromium } from 'playwright';
+
+const baseUrl = process.env.VIS_QA_URL || 'http://127.0.0.1:5173';
+const browser = await chromium.launch({ headless: true });
+try {
+  const context = await browser.newContext();
+  await context.route('**/__codex-storage-qa', route => route.fulfill({ contentType: 'text/html', body: '<html></html>' }));
+  const page = await context.newPage();
+  await page.goto(`${baseUrl}/__codex-storage-qa`);
+  const migrated = await page.evaluate(async () => {
+    const { storageSet } = await import('/utils/storageKeys.ts');
+    const storage = await import('/backends/codex/auxiliaryStorage.ts');
+    const effort = await import('/backends/codex/messageEffort.ts');
+    const { normalizeCodexTurnsToHistory } = await import('/backends/codex/normalize.ts');
+    const key = 'opencode.state.codexAuxiliaryHistory.v1.quota';
+    let low = 0, high = 6 * 1024 * 1024;
+    while (low < high) {
+      const length = Math.ceil((low + high) / 2);
+      try { localStorage.setItem(key, JSON.stringify({ text: 'x'.repeat(length) })); low = length; }
+      catch (error) { if (error.name !== 'QuotaExceededError') throw error; high = length - 1; }
+    }
+    const original = localStorage.getItem(key);
+    const rejected = !storageSet('quota-probe', '1');
+    const entries = normalizeCodexTurnsToHistory({ sessionId: 'thread', turns: [{ id: 'turn', status: 'completed', items: [
+      { type: 'userMessage', content: [{ type: 'text', text: 'Question' }] },
+      { type: 'agentMessage', id: 'answer', text: 'Done' },
+    ] }] });
+    effort.saveCodexTurnEffort('thread', 'turn', 'medium');
+    const lostBeforeMigration = effort.restoreCodexMessageEfforts('thread', entries).every(entry => !entry.info.variant);
+    await storage.initializeCodexAuxiliaryStorage();
+    const preserved = JSON.stringify(storage.readCodexAuxiliarySnapshot('quota')) === original;
+    const removed = localStorage.getItem(key) === null;
+    effort.saveCodexTurnEffort('thread', 'turn', 'medium');
+    sessionStorage.setItem('quota-size', String(original.length));
+    return { rejected, lostBeforeMigration, preserved, removed, variants: effort.restoreCodexMessageEfforts('thread', entries).map(entry => entry.info.variant) };
+  });
+  assert.deepEqual(migrated, { rejected: true, lostBeforeMigration: true, preserved: true, removed: true, variants: ['medium', 'medium'] });
+  await page.reload();
+  const restored = await page.evaluate(async () => {
+    const storage = await import('/backends/codex/auxiliaryStorage.ts');
+    await storage.initializeCodexAuxiliaryStorage();
+    const preserved = JSON.stringify(storage.readCodexAuxiliarySnapshot('quota')).length === Number(sessionStorage.getItem('quota-size'));
+    const savedEffort = JSON.parse(localStorage.getItem('opencode.state.codexTurnEfforts.v1.thread'))['turn:user:0'];
+    storage.writeCodexAuxiliarySnapshot('new', { text: 'new cached history' });
+    await storage.flushCodexAuxiliaryStorage();
+    return { preserved, savedEffort };
+  });
+  assert.deepEqual(restored, { preserved: true, savedEffort: 'medium' });
+  await page.reload();
+  const aborted = await page.evaluate(async () => {
+    const key = 'opencode.state.codexAuxiliaryHistory.v1.abort';
+    localStorage.setItem(key, '{"text":"keep on failure"}');
+    const storage = await import('/backends/codex/auxiliaryStorage.ts');
+    const put = IDBObjectStore.prototype.put;
+    IDBObjectStore.prototype.put = function () { throw new DOMException('Test quota failure', 'QuotaExceededError'); };
+    let rejected = false;
+    try { await storage.initializeCodexAuxiliaryStorage(); }
+    catch (error) { rejected = error.name === 'QuotaExceededError'; }
+    finally { IDBObjectStore.prototype.put = put; }
+    const retained = localStorage.getItem(key) === '{"text":"keep on failure"}';
+    await storage.initializeCodexAuxiliaryStorage();
+    const newHistory = storage.readCodexAuxiliarySnapshot('new');
+    const recovered = storage.readCodexAuxiliarySnapshot('abort');
+    storage.removeCodexAuxiliarySnapshot('new');
+    await storage.flushCodexAuxiliaryStorage();
+    return { rejected, retained, newHistory, recovered };
+  });
+  assert.deepEqual(aborted, { rejected: true, retained: true, newHistory: { text: 'new cached history' }, recovered: { text: 'keep on failure' } });
+  await page.reload();
+  assert.equal(await page.evaluate(async () => {
+    const storage = await import('/backends/codex/auxiliaryStorage.ts');
+    await storage.initializeCodexAuxiliaryStorage();
+    return storage.readCodexAuxiliarySnapshot('new');
+  }), null);
+  const second = await context.newPage();
+  await second.goto(`${baseUrl}/__codex-storage-qa`);
+  await second.evaluate(async () => {
+    const storage = await import('/backends/codex/auxiliaryStorage.ts');
+    await storage.initializeCodexAuxiliaryStorage();
+  });
+  await page.evaluate(async () => {
+    const storage = await import('/backends/codex/auxiliaryStorage.ts');
+    storage.writeCodexAuxiliarySnapshot('shared', { text: 'updated in another tab' });
+    await storage.flushCodexAuxiliaryStorage();
+  });
+  await second.waitForFunction(async () => {
+    const storage = await import('/backends/codex/auxiliaryStorage.ts');
+    return storage.readCodexAuxiliarySnapshot('shared')?.text === 'updated in another tab';
+  });
+  await page.evaluate(async () => {
+    const storage = await import('/backends/codex/auxiliaryStorage.ts');
+    storage.removeCodexAuxiliarySnapshot('shared');
+    await storage.flushCodexAuxiliaryStorage();
+  });
+  await second.waitForFunction(async () => {
+    const storage = await import('/backends/codex/auxiliaryStorage.ts');
+    return storage.readCodexAuxiliarySnapshot('shared') === null;
+  });
+  console.log('PASS: full quota reproduces completed-message effort loss; migration preserves history and restores durable metadata; aborted migration retains legacy data; writes and deletion survive reload and synchronize across tabs.');
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
修复 Codex 会话卡片在刷新、运行完成及撤销后的信息丢失和操作范围问题。

- 按消息持久化模型和提供商，避免刷新后丢失提供商名称或退化为 `codex` 占位名称。
- 历史用户消息也显示“撤销”，根据最新服务端历史撤销该消息所在回合及之后的回合。同回合补充消息一起撤销，确认提示明确说明范围。
- 从历史文件修改恢复各卡片自己的“差异”，并保留实时差异；撤销后的重新加载会清除已删除卡片并恢复保留卡片的差异。
- “分支”仍只显示在最新 Codex 用户消息上，沿用既有主题与 OpenCode 行为。

验证：234 项相关测试通过，vue-tsc、oxlint 和生产构建通过。浏览器使用真实组件配合模拟 app-server 协议，验证了提供商信息刷新、历史差异归属、撤销范围、撤销后即时显示及刷新一致性，并检查了 375/768/1280 像素宽度。未对真实用户会话执行破坏性撤销。

测试进程曾报告 ThreadBlock worker 退出超时；所有断言通过。构建保留已有的大分块提示。
